### PR TITLE
processTV crashes when parsing filenames that contain roman numerals

### DIFF
--- a/lib/tvnamer/roman.py
+++ b/lib/tvnamer/roman.py
@@ -44,7 +44,7 @@ def int_to_roman(input):
    MCMXCIX
    """
    if type(input) != type(1):
-      raise TypeError, "expected integer, got %s" % type(input)
+      raise TypeError, "expected integer, got {0} for input {1}".format(type(input), input)
    if not 0 < input < 4000:
       raise ValueError, "Argument must be between 1 and 3999"   
    ints = (1000, 900,  500, 400, 100,  90, 50,  40, 10,  9,   5,  4,   1)
@@ -86,7 +86,7 @@ def roman_to_int(input):
    ValueError: input is not a valid roman numeral: IL
    """
    if type(input) != type(""):
-      raise TypeError, "expected string, got %s" % type(input)
+      raise TypeError, "expected string, got {0} for input {1}".format(type(input), input)
    input = input.upper()
    nums = ['M', 'D', 'C', 'L', 'X', 'V', 'I']
    ints = [1000, 500, 100, 50,  10,  5,   1]

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -268,19 +268,22 @@ def processFile(fileName, downloadDir=None, nzbName=None):
         season = None
         episodes = []
         
+        result = None
+        
         try:
             returnStr += logHelper("Attempting to parse name "+curName, logger.DEBUG)
             myParser = FileParser(curName)
             result = myParser.parse()
 
-            season = result.seasonnumber if result.seasonnumber != None else 1
-            episodes = result.episodenumbers
-            
-            returnStr += logHelper("Ended up with season {0} and episodes {1}".format(season, episodes), logger.DEBUG)
-            
-        except tvnamer_exceptions.InvalidFilename:
-            returnStr += logHelper("Unable to parse the filename "+curName+" into a valid episode", logger.DEBUG)
+        except Exception, err:
+            returnStr += logHelper("Unable to parse the filename "+curName+" into a valid episode, error message: {0}".format(err), logger.DEBUG)
             continue
+            
+        season = result.seasonnumber if result.seasonnumber != None else 1
+        episodes = result.episodenumbers
+            
+        returnStr += logHelper("Ended up with season {0} and episodes {1}".format(season, episodes), logger.DEBUG)
+        
 
         if not result.seriesname:
             returnStr += logHelper("Filename "+curName+" has no series name, unable to use this name for processing", logger.DEBUG)


### PR DESCRIPTION
Looks like you added the miniseriesnaming stuff, thanks!  I noticed that processTV is crashing when processing the filenames 'The.Pillars.of.the.Earth.Pt.I.PROPER.720p.HDTV.X264-DIMENSION.mkv', 'The.Pillars.of.the.Earth.Pt.VII.and.Pt.VIII.720p.HDTV.X264-DIMENSION.mkv' and 'The.Pillars.of.the.Earth.Pt.VII.&.Pt.VIII.720p.HDTV.X264-DIMENSION.mkv'.  Looks like it's choking on a TypeError raised by roman.py.  Apparently 'VII' isn't of type string???  In any case, I added some logging to roman.py and modified processTV.py to gracefully handle any exceptions thrown from tvnamers parser.

I'm not sure if parsing roman numerals is a reality at this point (at least not without some changes on the tvnamer side).  Here is the error message that is generated after my changes:
Unable to parse the filename /data/sabnzbd_downloads/complete/TV/The.Pillars.of.the.Earth.Pt.VII.and.Pt.VIII.720p.HDTV.X264-DIMENSION.1/The.Pillars.of.the.Earth.Pt.VII.and.Pt.VIII.720p.HDTV.X264-DIMENSION.mkv into a valid episode, error message: expected string, got for input VII
