### PR TITLE
SB changes ignored eps to skipped during refresh

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1139,8 +1139,11 @@ class TVEpisode:
                 logger.log("Episode airs in the future, changing status from " + str(self.status) + " to " + str(UNAIRED), logger.DEBUG)
                 self.status = UNAIRED
             elif self.airdate == datetime.date.fromordinal(1):
-                logger.log("Episode has no air date, automatically marking it skipped", logger.DEBUG)
-                self.status = SKIPPED
+                if self.status != IGNORED:
+                    logger.log("Episode has no air date, automatically marking it skipped", logger.DEBUG)
+                    self.status = SKIPPED
+                else:
+                    logger.log("Episode has no air date, but it's already marked as ignored", logger.DEBUG)
             else:
                 if self.status == UNAIRED:
                     self.status = WANTED


### PR DESCRIPTION
When an ep has an airdate of 'never', which, with quite a few shows, happens a lot, and the episode is set to ignore, when the show gets refreshed (`loadFromTVDB` is called on the episode), the episode is changed to skipped with no regard to what the previous status was.
This was my way around the fact that episodes with airdates of never are being counted in the downloaded episodes bar, so I ignored them all. Obviously, this changed them back to skipped every refresh, which made my method pointless. I think I'll just merge one of the other methods, which seem cleaner and easier.
