### PR TITLE
Revert e62e19095

### DIFF
--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -131,8 +131,6 @@ def searchForNeededEpisodes():
 			logger.log(traceback.format_exc(), logger.DEBUG)
 			continue
 
-		curFoundResults = filter(lambda x: sceneHelpers.filterBadReleases(x.name) and isGoodResult(x, episode.show), curFoundResults)
-
 		didSearch = True
 		
 		# pick a single result for each episode, respecting existing results


### PR DESCRIPTION
This causes all RSS feed results to error with "Unable to parse the filename <episode name> into a valid episode".

It looks like the curFoundResults.name value being passed is not the proper input for filterBadRelease.
