### PR TITLE
more useful, proper time representation

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1379,7 +1379,7 @@ class TVEpisode:
             naming_quality = sickbeard.NAMING_QUALITY
 
         if ((self.show.genre and "Talk Show" in self.show.genre) or self.show.air_by_date) and sickbeard.NAMING_DATES:
-            goodEpString = str(self.airdate)
+            goodEpString = self.airdate.strftime("%Y.%m.%d")
         else:
             goodEpString = config.naming_ep_type[naming_ep_type] % {'seasonnumber': self.season, 'episodenumber': self.episode}
 


### PR DESCRIPTION
Currently, episode names of air-by-date shows contain dot-separated names with a dash-separated date. This commit changes the date to be dot-separated like the rest of the name and more useful, as it can be copied and searched for as-is rather than having to replace dashes with dots. In summary, it makes episodes names both prettier and more useful.
