### PR TITLE
PS3 metadata provider

### DIFF
--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -1,7 +1,7 @@
-__all__ = ['generic', 'helpers', 'xbmc', 'mediabrowser']
+__all__ = ['generic', 'helpers', 'xbmc', 'mediabrowser', 'ps3']
 
 import sys
-import xbmc, mediabrowser
+import xbmc, mediabrowser, ps3
 
 def available_generators():
     return filter(lambda x: x not in ('generic', 'helpers'), __all__)

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -1,0 +1,82 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+import sickbeard
+
+import generic
+
+from sickbeard.common import *
+from sickbeard import logger, exceptions, helpers
+from sickbeard import encodingKludge as ek
+from lib.tvdb_api import tvdb_api, tvdb_exceptions
+
+class PS3Metadata(generic.GenericMetadata):
+    """
+    Metadata generation class for Sony PS3.
+    
+    The following file structure is used:
+    
+    show_root/cover.jpg                                      (poster)
+    show_root/fanart.jpg                                     (fanart)
+    show_root/Season 01/season.jpg                           (season thumb)
+    show_root/Season 01/show - 1x01 - episode.avi            (* example of existing ep
+                                                                of course)
+    show_root/Season 01/show - 1x01 - episode.avi.cover.jpg   (episode thumb)
+    """
+    
+    def __init__(self):
+        generic.GenericMetadata.__init__(self)
+
+        self.name = 'PS3'
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .cover.jpg extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = ep_obj.location + '.cover.jpg'
+        else:
+            return None
+        
+        return tbn_filename
+    
+    def get_season_thumb_path(self, show_obj, season):
+        """
+        Returns the full path to the file for a given season thumb.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_thumb_file_path = 'season-specials'
+        else:
+            season_thumb_file_path = 'season' + str(season).zfill(2)
+        
+        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'.jpg')
+    
+# present a standard "interface"
+metadata_class = PS3Metadata
+

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -24,26 +24,23 @@ import generic
 
 from sickbeard.common import *
 from sickbeard import logger, exceptions, helpers
-from sickbeard import encodingKludge as ek
 from lib.tvdb_api import tvdb_api, tvdb_exceptions
 
 class PS3Metadata(generic.GenericMetadata):
     """
     Metadata generation class for Sony PS3.
-    
+
     The following file structure is used:
     
     show_root/cover.jpg                                      (poster)
-    show_root/fanart.jpg                                     (fanart)
-    show_root/Season 01/season.jpg                           (season thumb)
-    show_root/Season 01/show - 1x01 - episode.avi            (* example of existing ep
-                                                                of course)
-    show_root/Season 01/show - 1x01 - episode.avi.cover.jpg   (episode thumb)
+    show_root/Season 01/show - 1x01 - episode.avi            (existing video)
+    show_root/Season 01/show - 1x01 - episode.avi.cover.jpg  (episode thumb)
     """
     
     def __init__(self):
         generic.GenericMetadata.__init__(self)
 
+	self.poster_name = 'cover.jpg'
         self.name = 'PS3'
 
     def get_episode_thumb_path(self, ep_obj):
@@ -59,23 +56,6 @@ class PS3Metadata(generic.GenericMetadata):
             return None
         
         return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
-        """
-        Returns the full path to the file for a given season thumb.
-        
-        show_obj: a TVShow instance for which to generate the path
-        season: a season number to be used for the path. Note that sesaon 0
-                means specials.
-        """
-
-        # Our specials thumbnail is, well, special
-        if season == 0:
-            season_thumb_file_path = 'season-specials'
-        else:
-            season_thumb_file_path = 'season' + str(season).zfill(2)
-        
-        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'.jpg')
     
 # present a standard "interface"
 metadata_class = PS3Metadata

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1792,7 +1792,7 @@ class WebInterface:
         if showObj == None:
             return "Unable to find show" #TODO: make it return a standard image
 
-        posterFilename = os.path.abspath(ek.ek(os.path.join, showObj.location, "folder.jpg"))
+        posterFilename = os.path.abspath(ek.ek(os.path.join, showObj.location, sickbeard.metadata_provider.poster_name))
         if ek.ek(os.path.isfile, posterFilename):
             try:
                 from PIL import Image


### PR DESCRIPTION
Hello Nic,

I added a provider for PS3 to allow the episode thumbnails to show up properly. It also generates season, fan art, and series thumbnails if the user requests them in the config... although the PS3 will ignore those. This metadata provider is working very well for me, and I expect it would be appreciated by anyone using the PS3 as their media server.

Currently, I'm not generating NFO files because the PS3 doesn't recognize them. Should I produce XBMC NFOs as a default if the user wants them?

One last thing... On the PS3, 'folder.jpg' is a special file name. The PS3 will use this file as the thumbnail for any video files in the same directory as 'folder.jpg'. Unfortunately, this will overrides any episode thumbnails that may also be present. The good news is that sorting a show into season folders avoids this issue.

I believe the best solution for this would be to have the name of the series thumbnail specified by the metadata provider instead of having it hardcoded to 'folder.jpg'... The web interface could load the images according to whatever name is specified in the metadata provider. I'd be happy to make this change if you're in agreement.

Sick Beard is amazing! Makes my life a lot simpler, so thanks!
