### PR TITLE
Backlog time format

### DIFF
--- a/data/interfaces/default/inc_bottom.tmpl
+++ b/data/interfaces/default/inc_bottom.tmpl
@@ -13,7 +13,7 @@
 <br />
 <b>Search</b>: <%=str(sickbeard.currentSearchScheduler.timeLeft()).split('.')[0]%> |
 <!--<b>Update</b>: <a%a=str(sickbeard.updateScheduler.timeLeft()).split('.')[0]%> | -->
-<b>Backlog</b>: $sickbeard.backlogSearchScheduler.nextRun().strftime("%c") <br />
+<b>Backlog</b>: $sickbeard.backlogSearchScheduler.nextRun().strftime("%a %b %d") <br />
 </div>
 </body>
 </html>

--- a/data/interfaces/default/inc_bottom.tmpl
+++ b/data/interfaces/default/inc_bottom.tmpl
@@ -13,7 +13,7 @@
 <br />
 <b>Search</b>: <%=str(sickbeard.currentSearchScheduler.timeLeft()).split('.')[0]%> |
 <!--<b>Update</b>: <a%a=str(sickbeard.updateScheduler.timeLeft()).split('.')[0]%> | -->
-<b>Backlog</b>: $sickbeard.backlogSearchScheduler.nextRun().strftime("%A") <br />
+<b>Backlog</b>: $sickbeard.backlogSearchScheduler.nextRun().strftime("%c") <br />
 </div>
 </body>
 </html>


### PR DESCRIPTION
Default backlog search frequency is greater than a week, so having %A as the date format doesn't make sense.  The 'Thursday' of the next backlog search could be any Thursday in the next few weeks.  Better to use more detail.
