### PR TITLE
date/time formatting for air-by-date episodes

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1379,7 +1379,7 @@ class TVEpisode:
             naming_quality = sickbeard.NAMING_QUALITY
 
         if ((self.show.genre and "Talk Show" in self.show.genre) or self.show.air_by_date) and sickbeard.NAMING_DATES:
-            goodEpString = str(self.airdate)
+            goodEpString = self.airdate.strftime("%Y.%m.%d")
         else:
             goodEpString = config.naming_ep_type[naming_ep_type] % {'seasonnumber': self.season, 'episodenumber': self.episode}
 


### PR DESCRIPTION
This changes the date to be displayed in a way that can be just copy-pasted right into a search. It's also just more readable.
