### PR TITLE
NZBMatrix search term update.

### DIFF
--- a/sickbeard/providers/nzbmatrix.py
+++ b/sickbeard/providers/nzbmatrix.py
@@ -49,7 +49,7 @@ class NZBMatrixProvider(generic.NZBProvider):
         sceneSearchStrings = set(sceneHelpers.makeSceneSeasonSearchString(show, season, "nzbmatrix"))
 
         # search for all show names and episode numbers like ("a","b","c") in a single search
-        return ['("' + '","'.join(sceneSearchStrings) + '")']
+        return [' '.join(sceneSearchStrings)]
 
     def _get_episode_search_strings(self, ep_obj):
 

--- a/sickbeard/sceneHelpers.py
+++ b/sickbeard/sceneHelpers.py
@@ -135,7 +135,7 @@ def makeSceneSeasonSearchString (show, segment, extraSearchType=None):
         # nzbmatrix is special, we build a search string just for them
         elif extraSearchType == "nzbmatrix":
             if numseasons == 1:
-                toReturn.append('+"'+curShow+'"')
+                toReturn.append('"'+curShow+'"')
             elif numseasons == 0:
                 toReturn.append('"'+curShow+' '+str(segment).replace('-',' ')+'"')
             else:
@@ -143,7 +143,10 @@ def makeSceneSeasonSearchString (show, segment, extraSearchType=None):
                 if show.is_air_by_date:
                     term_list = ['"'+x+'"' for x in term_list]
 
-                toReturn.append('+"'+curShow+'" +('+','.join(term_list)+')')
+                toReturn.append('"'+curShow+'"')
+    
+    if extraSearchType == "nzbmatrix":     
+       toReturn = ['+('+','.join(toReturn)+')', '+('+','.join(term_list)+')']
 
     return toReturn
 


### PR DESCRIPTION
Updated the NZBMatrix search term that is generated to work correctly using the multiple show name search format. 
## New
- Term: +(S03*,3x*) +("The Simpsons","Simpsons") 
- URL: http://rss.nzbmatrix.com/rss.php?term=%2B(S03*,3x*)+%2B(%22The+Simpsons%22,%22Simpsons%22)&subcat=6,41&english=1&page=download
- Result: Only Simpsons S03 results.
## Old
- Term: ("+"The Simpsons" +(S03*,3x*)","+"Simpsons" +(S03*,3x*)") 
- URL: http://rss.nzbmatrix.com/rss.php?term=(%22%2B%22The+Simpsons%22+%2B(S03*,3x*)%22,%22%2B%22Simpsons%22+%2B(S03*,3x*)%22)&subcat=6,41&english=1&page=download
- Result: No Simpsons results necessarily.  It appears as if the term was ignored/rejected and we are receiving the first ~50 results of everything on NZBMatrix.
