### PR TITLE
Missing import for using with statement

### DIFF
--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import with_statement
+
 import datetime
 import time
 


### PR DESCRIPTION
As per:

http://code.google.com/p/sickbeard/issues/detail?id=1065

Simple import statement missing that was breaking for python2.5 users
