### PR TITLE
Added twitter_prefix config option to web config-notifications page

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -254,6 +254,16 @@
 
                         <div class="field-pair">
                             <label class="clearfix">
+                                <span class="component-title">Twitter Prefix</span>
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-desc">Enter the prefix with which you want to start the tweet.<br/></span>
+                                <input type="text" name="twitter_prefix" id="twitter_prefix" value="$sickbeard.TWITTER_PREFIX" size="35" maxlength="30"/><br />
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label class="clearfix">
                                 <span class="component-title">Step One</span>
                             </label>
                             <label class="nocheck clearfix">

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -939,7 +939,7 @@ class ConfigNotifications:
     def saveNotifications(self, use_xbmc=None, xbmc_notify_onsnatch=None, xbmc_notify_ondownload=None,
                           xbmc_update_library=None, xbmc_update_full=None, xbmc_host=None, xbmc_username=None, xbmc_password=None,
                           use_growl=None, growl_notify_onsnatch=None, growl_notify_ondownload=None, growl_host=None, growl_password=None, 
-						  use_twitter=None, twitter_notify_onsnatch=None, twitter_notify_ondownload=None):
+						  use_twitter=None, twitter_notify_onsnatch=None, twitter_notify_ondownload=None, twitter_prefix=None):
 
         results = []
 
@@ -1014,6 +1014,7 @@ class ConfigNotifications:
         sickbeard.USE_TWITTER = use_twitter
         sickbeard.TWITTER_NOTIFY_ONSNATCH = twitter_notify_onsnatch
         sickbeard.TWITTER_NOTIFY_ONDOWNLOAD = twitter_notify_ondownload
+        sickbeard.TWITTER_PREFIX = twitter_prefix
 
         sickbeard.save_config()
 


### PR DESCRIPTION
Hi,
I've added the twitter_prefix config option to the web config-notifications page.  Only a small addition to make the option available via the website rather than just the config file.
