### PR TITLE
Keeporiginalfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sickbeard.db*
 autoProcessTV/autoProcessTV.cfg
 *.bak
 .DS_Store/*
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Logs/*
 sickbeard.db*
 autoProcessTV/autoProcessTV.cfg
 *.bak
+.DS_Store/*


### PR DESCRIPTION
Main change is that I reworked the order of the code that does post processing of files.  This is so that when some one has "Keep Original Files" selected, it does not rename them.

Also added a couple things to the .gitignore for os x users.  
