### PR TITLE
Sab Q limit

### DIFF
--- a/data/interfaces/default/config_episodedownloads.tmpl
+++ b/data/interfaces/default/config_episodedownloads.tmpl
@@ -193,6 +193,17 @@
                                     <span class="component-desc">Category for downloads to go into (eg. TV)</span>
                                 </label>
                             </div>
+                            <div class="field-pair">
+                                <input type="checkbox" name="sab_limit_q" id="sab_limit_q" #if $sickbeard.SAB_LIMIT_Q == True then "checked=\"checked\"" else ""# onclick="document.getElementById('sab_qlimit').disabled=document.getElementById('sab_limit_q').checked?false:true" />
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Limit queue size?</span>
+                                    <input type="text" name="sab_qlimit" id="sab_qlimit" value="$sickbeard.SAB_QLIMIT" size="20" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Only send downloads to SABnzbd+ when the queue is less than <i>x</i> MB</span>
+                                </label>
+                            </div>
                         </div>
                         
                         <div class="clearfix"></div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -170,6 +170,8 @@ SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = None
+SAB_QLIMIT = None
+SAB_LIMIT_Q = False
 
 USE_XBMC = False
 XBMC_NOTIFY_ONSNATCH = False
@@ -297,8 +299,8 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, \
-                NZB_METHOD, NZB_DIR, TVBINZ, TVBINZ_UID, TVBINZ_HASH, DOWNLOAD_PROPERS, \
-                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
+                NZB_METHOD,NZB_DIR, TVBINZ, TVBINZ_UID, TVBINZ_HASH, DOWNLOAD_PROPERS, \
+                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, SAB_QLIMIT, SAB_LIMIT_Q, \
                 XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, currentSearchScheduler, backlogSearchScheduler, \
                 showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
@@ -452,6 +454,8 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
+        SAB_QLIMIT = check_setting_str(CFG, 'SABnzbd', 'sab_qlimit', '10000')
+        SAB_LIMIT_Q = bool(check_setting_int(CFG, 'SABnzbd', 'sab_limit_q', 0))
 
         USE_XBMC = bool(check_setting_int(CFG, 'XBMC', 'use_xbmc', 0)) 
         XBMC_NOTIFY_ONSNATCH = bool(check_setting_int(CFG, 'XBMC', 'xbmc_notify_onsnatch', 0))
@@ -878,6 +882,8 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
+    new_config['SABnzbd']['sab_qlimit'] = SAB_QLIMIT
+    new_config['SABnzbd']['sab_limit_q'] = int(SAB_LIMIT_Q)
 
     new_config['XBMC'] = {}
     new_config['XBMC']['use_xbmc'] = int(USE_XBMC)    

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -674,6 +674,7 @@ class ConfigEpisodeDownloads:
     @cherrypy.expose
     def saveEpisodeDownloads(self, nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None,
+                       sab_limit_q=None, sab_qlimit=None,
                        torrent_dir=None, nzb_method=None, usenet_retention=None,
                        search_frequency=None, tv_download_dir=None,
                        keep_processed_dir=None, process_automatically=None, rename_episodes=None,
@@ -734,6 +735,14 @@ class ConfigEpisodeDownloads:
         sickbeard.SAB_PASSWORD = sab_password
         sickbeard.SAB_APIKEY = sab_apikey.strip()
         sickbeard.SAB_CATEGORY = sab_category
+        sickbeard.SAB_QLIMIT = sab_qlimit
+
+        if sab_limit_q == "on":
+            sab_limit_q = 1
+        else:
+            sab_limit_q = 0
+
+        sickbeard.SAB_LIMIT_Q = sab_limit_q
 
         if sab_host and not re.match('https?://.*', sab_host):
             sab_host = 'http://' + sab_host


### PR DESCRIPTION
Have written a mod that allows users to check the SABnzbd queue size before submitting an NZB. It fires an API call to SAB to check queue size in MB against a configured limit - if the queue is too big the NZB is not sent to SAB and the title remains in the 'wanted' state. This prevents the SAB queue from getting too large and causing things to grind to a halt.
