### PR TITLE
Notifo notifications

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -518,8 +518,9 @@ class PostProcessor(object):
         # make sure the quality is set right before we continue
         if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER:
             oldStatus, ep_quality = common.Quality.splitCompositeStatus(ep_obj.status)
-            self._log(u"The old status had a quality in it, using that: "+common.Quality.qualityStrings[ep_quality], logger.DEBUG)
-            return ep_quality
+            if ep_quality != common.Quality.UNKNOWN:
+                self._log(u"The old status had a quality in it, using that: "+common.Quality.qualityStrings[ep_quality], logger.DEBUG)
+                return ep_quality
 
         name_list = [self.nzb_name, self.folder_name, self.file_name]
     

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -32,7 +32,12 @@ class ShowUpdater():
 
             try:
 
-                curQueueItem = sickbeard.showQueueScheduler.action.updateShow(curShow, True)
+                if curShow.status != "Ended":
+                    curQueueItem = sickbeard.showQueueScheduler.action.updateShow(curShow, True)
+                else:
+                    #TODO: maybe I should still update specials?
+                    logger.log(u"Not updating episodes for show "+self.show.name+" because it's marked as ended.", logger.DEBUG)
+                    curQueueItem = sickbeard.showQueueScheduler.action.refreshShow(curShow, True)
 
                 piList.append(curQueueItem)
 

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -310,13 +310,6 @@ class QueueItemUpdate(ShowQueueItem):
         logger.log(u"Retrieving show info from TVDB", logger.DEBUG)
         self.show.loadFromTVDB(cache=not self.force)
 
-        # either update or refresh depending on the time
-        if self.show.status == "Ended" and not self.force:
-            #TODO: maybe I should still update specials?
-            logger.log(u"Not updating episodes for show "+self.show.name+" because it's marked as ended.", logger.DEBUG)
-            sickbeard.showQueueScheduler.action.refreshShow(self.show, True)
-            return
-
         # get episode list from DB
         logger.log(u"Loading all episodes from the database", logger.DEBUG)
         DBEpList = self.show.loadEpisodesFromDB()


### PR DESCRIPTION
This adds support for Notifo notifications. I made this because there is no Growl/Prowl client for Android phones, and I absolutely detest Twitter :). Notifo uses the push-notification infrastructure of iPhone/Android/BlackBerry/Win 7 devices (although the latter two are not yet available). 

BTW: I've been wrestling a bit with Git (which is new to me), so while there are no test commits or reverts in the history, there may be a couple of not-too-relevant messages. I hope this is acceptable as-is.

Jeroen
