### PR TITLE
Use RegExp for sanitizing & Backlog searching with NZBMatrix documentary categories

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -98,10 +98,8 @@ def sanitizeFileName (name):
     >>> sanitizeFileName('a"b')
     'ab'
     '''
-    for x in "\\/*":
-        name = name.replace(x, "-")
-    for x in ":\"<>|?":
-        name = name.replace(x, "")
+    name = re.sub(r"[\\/*]", "-", name)
+    name = re.sub(r'[:"<>|?]', "", name)
     return name
 
 

--- a/sickbeard/providers/nzbmatrix.py
+++ b/sickbeard/providers/nzbmatrix.py
@@ -69,7 +69,7 @@ class NZBMatrixProvider(generic.NZBProvider):
                   "page": "download",
                   "username": sickbeard.NZBMATRIX_USERNAME,
                   "apikey": sickbeard.NZBMATRIX_APIKEY,
-                  "subcat": "6,41",
+                  "subcat": "6,41,9,53",
                   "english": 1,
                   "ssl": 1}
 
@@ -153,7 +153,7 @@ class NZBMatrixCache(tvcache.TVCache):
                    'english': 1,
                    'ssl': 1,
                    'scenename': 1,
-                   'subcat': '6,41,9,53'}
+                   'subcat': '6,41'}
 
         url += urllib.urlencode(urlArgs)
 

--- a/sickbeard/providers/nzbmatrix.py
+++ b/sickbeard/providers/nzbmatrix.py
@@ -153,7 +153,7 @@ class NZBMatrixCache(tvcache.TVCache):
                    'english': 1,
                    'ssl': 1,
                    'scenename': 1,
-                   'subcat': '6,41'}
+                   'subcat': '6,41,9,53'}
 
         url += urllib.urlencode(urlArgs)
 


### PR DESCRIPTION
Regular expressions are efficient in replacing characters.

I understand why the periodically RSS request only uses TV SD and TV HD categories (because of the 50 shows limit)..so, left that unchanged... 
I don't see why backlog searches could not search documentary categories.....?
