### PR TITLE
Alternative to ManuelAC's chmod

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -406,6 +406,16 @@ def rename_file(old_path, new_name):
 
     return new_path
 
+def chmodAsParent(chmodPath):
+    parentPath = os.path.dirname(chmodPath)
+    try:
+        shutil.copymode(parentPath, chmodPath)
+        logger.log(u"Inherited permissions from %s to %s" % (parentPath, chmodPath))
+    except WindowsError:
+        pass
+    except OSError:
+        logger.log(u"Couldn't inherit permissions from %s to %s" % (parentPath, chmodPath), logger.ERROR)
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod()

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -291,6 +291,7 @@ class GenericMetadata():
             if not ek.ek(os.path.isdir, nfo_file_dir):
                 logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
                 ek.ek(os.makedirs, nfo_file_dir)
+                helpers.chmodAsParent(nfo_file_dir)
     
             logger.log(u"Writing show nfo file to "+nfo_file_path)
             
@@ -298,6 +299,7 @@ class GenericMetadata():
     
             data.write(nfo_file, encoding="utf-8")
             nfo_file.close()
+            helpers.chmodAsParent(nfo_file_path)
         except IOError, e:
             logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+str(e).decode('utf-8'), logger.ERROR)
             return False
@@ -333,6 +335,7 @@ class GenericMetadata():
             if not ek.ek(os.path.isdir, nfo_file_dir):
                 logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
                 ek.ek(os.makedirs, nfo_file_dir)
+                helpers.chmodAsParent(nfo_file_dir)
             
             logger.log(u"Writing episode nfo file to "+nfo_file_path)
             
@@ -340,6 +343,7 @@ class GenericMetadata():
     
             data.write(nfo_file, encoding="utf-8")
             nfo_file.close()
+            helpers.chmodAsParent(nfo_file_path)
         except IOError, e:
             logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+str(e).decode('utf-8'), logger.ERROR)
             return False
@@ -491,10 +495,12 @@ class GenericMetadata():
             if not ek.ek(os.path.isdir, image_dir):
                 logger.log("Metadata dir didn't exist, creating it at "+image_dir, logger.DEBUG)
                 ek.ek(os.makedirs, image_dir)
+                helpers.chmodAsParent(image_dir)
 
             outFile = ek.ek(open, image_path, 'wb')
             outFile.write(image_data)
             outFile.close()
+            helpers.chmodAsParent(image_path)
         except IOError, e:
             logger.log(u"Unable to write image to "+image_path+" - are you sure the show folder is writable? "+str(e).decode('utf-8'), logger.ERROR)
             return False

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -196,6 +196,7 @@ class PostProcessor(object):
             self._log(u"Moving file from "+cur_file_path+" to "+new_file_path, logger.DEBUG)
             try:
                 helpers.moveFile(cur_file_path, new_file_path)
+                helpers.chmodAsParent(new_file_path)
             except (IOError, OSError), e:
                 self._log("Unable to move file "+cur_file_path+" to "+new_file_path+": "+str(e).decode('utf-8'), logger.ERROR)
                 raise e
@@ -219,6 +220,7 @@ class PostProcessor(object):
             self._log(u"Copying file from "+cur_file_path+" to "+new_file_path, logger.DEBUG)
             try:
                 helpers.copyFile(cur_file_path, new_file_path)
+                helpers.chmodAsParent(new_file_path)
             except (IOError, OSError), e:
                 logger.log("Unable to copy file "+cur_file_path+" to "+new_file_path+": "+str(e).decode('utf-8'), logger.ERROR)
                 raise e
@@ -663,6 +665,7 @@ class PostProcessor(object):
             self._log(u"Season folder didn't exist, creating it", logger.DEBUG)
             try:
                 ek.ek(os.mkdir, dest_path)
+                helpers.chmodAsParent(dest_path)
             except OSError, IOError:
                 raise exceptions.PostProcessingFailed("Unable to create the episode's destination folder: "+dest_path)
 

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -167,7 +167,9 @@ class GenericProvider:
     
     def _get_title_and_url(self, item):
         title = item.findtext('title')
-        url = item.findtext('link').replace('&amp;','&')
+        url = item.findtext('link')
+        if url:
+            url = url.replace('&amp;','&')
         
         return (title, url)
     

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1400,6 +1400,8 @@ class NewHomeAddShows:
             logger.log(u"Unable to create the folder "+show_dir+", can't add the show", logger.ERROR)
             ui.flash.error("Unable to add show", "Unable to create the folder "+show_dir+", can't add the show")
             redirect("/home")
+        else:
+            helpers.chmodAsParent(show_dir)
 
         # prepare the inputs for passing along
         if seasonFolders == "on":


### PR DESCRIPTION
An alternative for ManuelAC's chmod def... It has more predictable behavior for novice users since it chmods according to the parent directory and also has no error on windows machines

I didn't change postProcessor.py as you might combine the two so more advanced user can set there mask using ManuelAC's code ...
