### PR TITLE
.gitignore minor update: .pyc, emacs scratch file, group sickbeard-specific ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-*.pyc
+*.py[co]
+.DS_Store
+*~
+*.bak
 cache/*
 cache.db
 config.ini
 Logs/*
 sickbeard.db*
 autoProcessTV/autoProcessTV.cfg
-*.bak
-.DS_Store

--- a/initscript
+++ b/initscript
@@ -10,7 +10,33 @@
 # Description:       starts instance of Sick Beard using start-stop-daemon
 ### END INIT INFO
 
-############### EDIT ME ##################
+### DON'T EDIT ME
+## place your customizations to these variables in
+## the appropriate location for your distribution and
+## symlink this file to the appropriate location for
+## your distribution
+###
+
+###
+## debian/ubuntu usage example:
+##  one install:
+##   _symlink_ this script to /etc/init.d/sickbeard
+##   _copy_ initscript_config to /etc/defaults/sickbeard
+##
+##  multiple installs:
+##   copied config file name must match the name 
+##   you use for the symlink
+##   in /etc/init.d.
+##   e.g.:
+##   initscript symlinked to /etc/init.d/mygreatsickbeard1
+##   config _copied_ /etc/default/mygreatsickbeard1
+##   and
+##   initscript symlinked to /etc/init.d/mygreatsickbeard2
+##   config _copied_ to /etc/default/mygreatsickbeard2
+##
+## 
+###
+
 # path to app
 APP_PATH=PATH_TO_SICKBEARD_DIRECTORY
 
@@ -31,7 +57,13 @@ RUN_AS=SICKBEARD_USER
 
 PID_FILE=/var/run/sickbeard.pid
 
-############### END EDIT ME ##################
+# initscript name
+INITSCRIPT="$(basename "$0")"
+
+# debian, ubuntu place initscript customizations here
+if [ -r /etc/default/${INITSCRIPT} ]; then
+	. /etc/default/${INITSCRIPT}
+fi
 
 test -x $DAEMON || exit 0
 

--- a/initscript_config
+++ b/initscript_config
@@ -1,0 +1,19 @@
+# path to app
+APP_PATH=PATH_TO_SICKBEARD_DIRECTORY
+
+# path to python bin
+DAEMON=/usr/bin/python
+
+# startup args
+DAEMON_OPTS=" SickBeard.py -q"
+
+# script name
+NAME=sickbeard
+
+# app name
+DESC=SickBeard
+
+# user
+RUN_AS=SICKBEARD_USER
+
+PID_FILE=/var/run/sickbeard.pid


### PR DESCRIPTION
Figured it would make sense to group the sickbeard-specific ignored files at the bottom so that it's easy to find them all, should the file grow larger.  .gitignore supports comments so adding something like "#sickbeard-specific ignores below" would work too.

I added .pyc (as I end up with those as often as I end up with .pyo anyway), and *~ to ignore emacs auto-recover files, since there already are a few ignores for text editor and file browser litter.

Normally I wouldn't send a separate pull request for something so small but I didn't want it to get wrapped up in my next pull request (initscript enhancements) so I'm hoping this does the trick...
