### PR TITLE
debian initscript enhancements: multiple instances, configuration in /etc/default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-*.pyc
+*.py[co]
+.DS_Store
+*~
+*.bak
 cache/*
 cache.db
 config.ini
 Logs/*
 sickbeard.db*
 autoProcessTV/autoProcessTV.cfg
-*.bak
-.DS_Store

--- a/initscript
+++ b/initscript
@@ -10,7 +10,33 @@
 # Description:       starts instance of Sick Beard using start-stop-daemon
 ### END INIT INFO
 
-############### EDIT ME ##################
+### DON'T EDIT ME
+## place your customizations to these variables in
+## the appropriate location for your distribution and
+## symlink this file to the appropriate location for
+## your distribution
+###
+
+###
+## debian/ubuntu usage example:
+##  one install:
+##   _symlink_ this script to /etc/init.d/sickbeard
+##   _copy_ initscript_config to /etc/defaults/sickbeard
+##
+##  multiple installs:
+##   copied config file name must match the name 
+##   you use for the symlink
+##   in /etc/init.d.
+##   e.g.:
+##   initscript symlinked to /etc/init.d/mygreatsickbeard1
+##   config _copied_ /etc/default/mygreatsickbeard1
+##   and
+##   initscript symlinked to /etc/init.d/mygreatsickbeard2
+##   config _copied_ to /etc/default/mygreatsickbeard2
+##
+## 
+###
+
 # path to app
 APP_PATH=PATH_TO_SICKBEARD_DIRECTORY
 
@@ -31,7 +57,13 @@ RUN_AS=SICKBEARD_USER
 
 PID_FILE=/var/run/sickbeard.pid
 
-############### END EDIT ME ##################
+# initscript name
+INITSCRIPT="$(basename "$0")"
+
+# debian, ubuntu place initscript customizations here
+if [ -r /etc/default/${INITSCRIPT} ]; then
+	. /etc/default/${INITSCRIPT}
+fi
 
 test -x $DAEMON || exit 0
 

--- a/initscript_config
+++ b/initscript_config
@@ -1,0 +1,19 @@
+# path to app
+APP_PATH=PATH_TO_SICKBEARD_DIRECTORY
+
+# path to python bin
+DAEMON=/usr/bin/python
+
+# startup args
+DAEMON_OPTS=" SickBeard.py -q"
+
+# script name
+NAME=sickbeard
+
+# app name
+DESC=SickBeard
+
+# user
+RUN_AS=SICKBEARD_USER
+
+PID_FILE=/var/run/sickbeard.pid


### PR DESCRIPTION
As mentioned in the commit log; the initscript can be symlinked to /etc/init.d/anything, now, and the configuration will be picked up (based on the basename of the symlink) in /etc/default, if it exists.  This allows for multiple instances of sickbeard (each in their own separate directory, of course) to be started by initscripts.  

Additionally since the configuration edits would reside in a file not managed by git, the initscript itself can be updated by git or any other method safely in the future without losing or possibly incorrectly merging edits to the script.

For some reason the pull request feature won't remove my .gitignore commit from this request, I already sent a pull request about it separately to try and avoid this but oh well. :P
