### PR TITLE
NZB Method: NZBget (based on XMLRPC)

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -85,8 +85,8 @@
                                 <span class="component-title jumbo">NZB Method:</span>
                                 <span class="component-desc">
                                     <select name="nzb_method" id="nzb_method">
-                                    #set $nzb_method_text = {'blackhole': "Black hole", 'sabnzbd': "SABnzbd"}
-                                    #for $curAction in ('sabnzbd', 'blackhole'):
+                                    #set $nzb_method_text = {'blackhole': "Black hole", 'sabnzbd': "SABnzbd", 'nzbget': "NZBget"}
+                                    #for $curAction in ('sabnzbd', 'blackhole', 'nzbget'):
                                       #if $sickbeard.NZB_METHOD == $curAction:
                                         #set $nzb_method = "selected=\"selected\""
                                       #else
@@ -165,6 +165,45 @@
                                 <label class="nocheck clearfix">
                                     <span class="component-title">SABnzbd Category</span>
                                     <input type="text" name="sab_category" value="$sickbeard.SAB_CATEGORY" size="20" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Category for downloads to go into (eg. TV)</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div id="nzbget_settings">
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">NZBget HOST:PORT</span>
+                                    <input type="text" name="nzbget_host" value="$sickbeard.NZBGET_HOST" size="45" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Hostname and portnumber of the NZBget RPC (not NZBgetweb!)</span>
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">(eg. localhost:6789)</span>
+                                </label>
+                            </div>
+                            
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">NZBget Password</span>
+                                    <input type="password" name="nzbget_password" value="$sickbeard.NZBGET_PASSWORD" size="20" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Password found in nzbget.conf (by default tegbzn6789)</span>
+                                </label>
+                            </div>
+
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">NZBget Category</span>
+                                    <input type="text" name="nzbget_category" value="$sickbeard.NZBGET_CATEGORY" size="20" />
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>

--- a/data/js/configSearch.js
+++ b/data/js/configSearch.js
@@ -7,9 +7,15 @@ $(document).ready(function(){
         if (selectedProvider == "blackhole") {
             $('#blackhole_settings').show();
             $('#sabnzbd_settings').hide();
+            $('#nzbget_settings').hide();
+        } else if (selectedProvider == "nzbget") {
+            $('#blackhole_settings').hide();
+            $('#sabnzbd_settings').hide();
+            $('#nzbget_settings').show();
         } else {
             $('#blackhole_settings').hide();
             $('#sabnzbd_settings').show();
+            $('#nzbget_settings').hide();
         }
 
     }

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -181,6 +181,10 @@ SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = None
 
+NZBGET_PASSWORD = None
+NZBGET_CATEGORY = None
+NZBGET_HOST = None
+
 USE_XBMC = False
 XBMC_NOTIFY_ONSNATCH = False
 XBMC_NOTIFY_ONDOWNLOAD = False
@@ -321,6 +325,7 @@ def initialize(consoleLogging=True):
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, TVBINZ, TVBINZ_UID, TVBINZ_HASH, DOWNLOAD_PROPERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
+                NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, \
                 XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, currentSearchScheduler, backlogSearchScheduler, \
                 showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
@@ -353,6 +358,7 @@ def initialize(consoleLogging=True):
         CheckSection('Newzbin')
         CheckSection('TVBinz')
         CheckSection('SABnzbd')
+        CheckSection('NZBget')
         CheckSection('XBMC')
         CheckSection('Growl')
         CheckSection('Prowl')
@@ -430,7 +436,7 @@ def initialize(consoleLogging=True):
         USE_TORRENTS = bool(check_setting_int(CFG, 'General', 'use_torrents', 0))
 
         NZB_METHOD = check_setting_str(CFG, 'General', 'nzb_method', 'blackhole')
-        if NZB_METHOD not in ('blackhole', 'sabnzbd'):
+        if NZB_METHOD not in ('blackhole', 'sabnzbd', 'nzbget'):
             NZB_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
@@ -486,6 +492,10 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
+
+        NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789')
+        NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
+        NZBGET_HOST = check_setting_str(CFG, 'NZBget', 'nzbget_host', '')
 
         USE_XBMC = bool(check_setting_int(CFG, 'XBMC', 'use_xbmc', 0)) 
         XBMC_NOTIFY_ONSNATCH = bool(check_setting_int(CFG, 'XBMC', 'xbmc_notify_onsnatch', 0))
@@ -940,6 +950,11 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
+
+    new_config['NZBget'] = {}
+    new_config['NZBget']['nzbget_password'] = NZBGET_PASSWORD
+    new_config['NZBget']['nzbget_category'] = NZBGET_CATEGORY
+    new_config['NZBget']['nzbget_host'] = NZBGET_HOST
 
     new_config['XBMC'] = {}
     new_config['XBMC']['use_xbmc'] = int(USE_XBMC)    

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -1,0 +1,89 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+import httplib
+import datetime
+
+import sickbeard
+
+from base64 import standard_b64encode
+import xmlrpclib
+
+from sickbeard.providers.generic import GenericProvider
+
+from sickbeard.common import *
+from sickbeard import logger, classes
+
+def sendNZB(nzb):
+
+    addToTop = False
+    nzbgetXMLrpc = "http://nzbget:%(password)s@%(host)s/xmlrpc"
+
+    if sickbeard.NZBGET_HOST == None:
+        logger.log(u"No NZBget host found in configuration. Please configure it.", logger.ERROR)
+        return False
+
+    url = nzbgetXMLrpc % {"host": sickbeard.NZBGET_HOST, "password": sickbeard.NZBGET_PASSWORD}
+
+    nzbGetRPC = xmlrpclib.ServerProxy(url)
+    try:
+        if nzbGetRPC.writelog("INFO", "Sickbeard connected to drop of %s any moment now." % (nzb.name + ".nzb")):
+            logger.log(u"Successful connected to NZBget", logger.DEBUG)
+        else:
+            logger.log(u"Successful connected to NZBget, but unable to send a message" % (nzb.name + ".nzb"), logger.ERROR)
+
+    except httplib.socket.error:
+        logger.log(u"Please check your NZBget host and port (if it is running). NZBget is not responding to this combination", logger.ERROR)
+        return False
+
+    except xmlrpclib.ProtocolError, e:
+        if (e.errmsg == "Unauthorized"):
+            logger.log(u"NZBget password is incorrect.", logger.ERROR)
+        else:
+            logger.log(u"Protocol Error: " + e.errmsg, logger.ERROR)
+        return False
+
+    # if it aired recently make it high priority
+    for curEp in nzb.episodes:
+        if datetime.date.today() - curEp.airdate <= datetime.timedelta(days=7):
+            addToTop = True
+
+    # if it's a normal result need to download the NZB content
+    if nzb.resultType == "nzb":
+        genProvider = GenericProvider("")
+        data = genProvider.getURL(nzb.url)
+        if (data == None):
+            return False
+
+    # if we get a raw data result thats even better
+    elif nzb.resultType == "nzbdata":
+        data = nzb.extraInfo[0]
+
+    nzbcontent64 = standard_b64encode(data)
+
+    logger.log(u"Sending NZB to NZBget")
+    logger.log(u"URL: " + url, logger.DEBUG)
+
+    if nzbGetRPC.append(nzb.name + ".nzb", sickbeard.NZBGET_CATEGORY, addToTop, nzbcontent64):
+        logger.log(u"NZB sent to NZBget successfully", logger.DEBUG)
+        return True
+    else:
+        logger.log(u"NZBget could not add %s to the queue" % (nzb.name + ".nzb"), logger.ERROR)
+        return False

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -26,6 +26,7 @@ from common import *
 
 from sickbeard import logger, db, sceneHelpers, exceptions, helpers
 from sickbeard import sab
+from sickbeard import nzbget
 from sickbeard import history
 from sickbeard import notifiers
 from sickbeard import nzbSplitter
@@ -75,6 +76,8 @@ def snatchEpisode(result, endStatus=SNATCHED):
             dlResult = _downloadResult(result)
         elif sickbeard.NZB_METHOD == "sabnzbd":
             dlResult = sab.sendNZB(result)
+        elif sickbeard.NZB_METHOD == "nzbget":
+            dlResult = nzbget.sendNZB(result)
         else:
             logger.log(u"Unknown NZB action specified in config: " + sickbeard.NZB_METHOD, logger.ERROR)
             dlResult = False

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -698,8 +698,8 @@ class ConfigSearch:
 
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
-                       sab_apikey=None, sab_category=None, sab_host=None, torrent_dir=None, nzb_method=None, usenet_retention=None,
-                       search_frequency=None, download_propers=None):
+                       sab_apikey=None, sab_category=None, sab_host=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
+                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None):
 
         results = []
 
@@ -749,6 +749,11 @@ class ConfigSearch:
             sab_host = sab_host + '/'
 
         sickbeard.SAB_HOST = sab_host
+
+        sickbeard.NZBGET_PASSWORD = nzbget_password
+        sickbeard.NZBGET_CATEGORY = nzbget_category
+        sickbeard.NZBGET_HOST = nzbget_host
+
 
         sickbeard.save_config()
 


### PR DESCRIPTION
NZBget is a very light-weighted binary newsgrabber for nzb files (written in C++, and still maintained). It can sustain high constant download speeds on low cpu powered devices. (especially when you compare it to SABnzbd)  
This makes it popular on mediaplayers and NAS devices (mostly pre-installed).

This commit will add NZBget support (remote or on the localhost) so NZBget users (like me) won't have to wait before the nzb is picked up from the blackhole... And prioritize recently aired episodes just like in sab.py

The XML-RPC code is thanks to http://nzbget.sourceforge.net/RPC_API_reference
