### PR TITLE
daemon friendly options

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -195,6 +195,9 @@ def main():
 
     if not os.access(sickbeard.DATA_DIR, os.W_OK):
         raise SystemExit("datadir must be writeable '" + sickbeard.DATA_DIR + "'")
+    
+    if not os.access(sickbeard.CONFIG_FILE, os.W_OK):
+        raise SystemExit("config file must be writeable '" + sickbeard.CONFIG_FILE + "'")
         
     os.chdir(sickbeard.DATA_DIR)
     

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -197,7 +197,10 @@ def main():
         raise SystemExit("datadir must be writeable '" + sickbeard.DATA_DIR + "'")
     
     if not os.access(sickbeard.CONFIG_FILE, os.W_OK):
-        raise SystemExit("config file must be writeable '" + sickbeard.CONFIG_FILE + "'")
+        if os.path.isfile(sickbeard.CONFIG_FILE):
+            raise SystemExit("config file must be writeable '" + sickbeard.CONFIG_FILE + "'")
+        elif os.access(os.path.basename(sickbeard.CONFIG_FILE), os.W_OK):
+            raise SystemExit("config file must be writeable '" + sickbeard.CONFIG_FILE + "'") 
         
     os.chdir(sickbeard.DATA_DIR)
     

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -125,9 +125,9 @@ def main():
     threading.currentThread().name = "MAIN"
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "qfdp::", ['quiet', 'forceupdate', 'daemon', 'port=', 'tvbinz', 'pidfile=', 'config=', 'datadir='])
+        opts, args = getopt.getopt(sys.argv[1:], "qfdp::", ['quiet', 'forceupdate', 'daemon', 'port=', 'tvbinz', 'pidfile=', 'config=', 'datadir=', 'logdir='])
     except getopt.GetoptError:
-        print "Available options: --quiet, --forceupdate, --port, --daemon --pidfile --config --datadir"
+        print "Available options: --quiet, --forceupdate, --port, --daemon --pidfile --config --datadir --logdir"
         sys.exit()
 
     forceUpdate = False
@@ -164,6 +164,10 @@ def main():
         # datadir
         if (o in ('--datadir')):
             sickbeard.DATA_DIR = os.path.abspath(a)
+        
+        # logdir
+        if (o in ('--logdir')):
+            sickbeard.LOG_DIR = os.path.abspath(a)
 
         # write a pidfile if requested
         if o in ('--pidfile'):

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -73,7 +73,6 @@ def daemonize():
         raise RuntimeError("1st fork failed: %s [%d]" %
                    (e.strerror, e.errno))
 
-    os.chdir(sickbeard.DATA_DIR)
     os.setsid()
 
     # Make sure I can read my own files and shut out others
@@ -194,12 +193,17 @@ def main():
         except os.error, e:
             raise SystemExit("Unable to create datadir '" + sickbeard.DATA_DIR + "'")
 
+    if not os.access(sickbeard.DATA_DIR, os.W_OK):
+        raise SystemExit("datadir must be writeable '" + sickbeard.DATA_DIR + "'")
+        
+    os.chdir(sickbeard.DATA_DIR)
+    
     if consoleLogging:
         print "Starting up Sick Beard "+SICKBEARD_VERSION+" from " + sickbeard.CONFIG_FILE
 
     # load the config and publish it to the sickbeard package
     if not os.path.isfile(sickbeard.CONFIG_FILE):
-        logger.log(u"Unable to find config.ini, all settings will be default", logger.ERROR)
+        logger.log(u"Unable to find " + sickbeard.CONFIG_FILE + " , all settings will be default", logger.ERROR)
 
     sickbeard.CFG = ConfigObj(sickbeard.CONFIG_FILE)
 

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -14,7 +14,7 @@
 
 <div id="config">
 <div id="config-content">
-<h5>All non-absolute folder locations are relative to " <span class="path">$sickbeard.PROG_DIR</span> "</h5>
+<h5>All non-absolute folder locations are relative to " <span class="path">$sickbeard.DATA_DIR</span> "</h5>
 
 <form action="saveGeneral" method="post">
 

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -16,7 +16,7 @@
 
 <div id="config">
 <div id="config-content">
-<h5>All non-absolute folder locations are relative to " <span class="path">$sickbeard.PROG_DIR</span> "</h5>
+<h5>All non-absolute folder locations are relative to " <span class="path">$sickbeard.DATA_DIR</span> "</h5>
 
 <form action="savePostProcessing" method="post">
 

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -13,7 +13,7 @@
 
 <div id="config">
 <div id="config-content">
-<h5>All non-absolute folder locations are relative to " <span class="path">$sickbeard.PROG_DIR</span> "</h5>
+<h5>All non-absolute folder locations are relative to " <span class="path">$sickbeard.DATA_DIR</span> "</h5>
 <form action="saveSearch" method="post">
 
             <div id="config-components">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -364,7 +364,9 @@ def initialize(consoleLogging=True):
         CheckSection('Prowl')
         CheckSection('Twitter')
 
-        LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
+        if LOG_DIR is None:
+            LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
+        
         if not helpers.makeDir(LOG_DIR):
             logger.log(u"!!! No log folder, logging to screen only!", logger.ERROR)
 

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -131,13 +131,13 @@ class NewQualitySettings (NumericProviders):
     def execute(self):
 
         numTries = 0
-        while not ek.ek(os.path.isfile, ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db.v0')):
-            if not ek.ek(os.path.isfile, ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db')):
+        while not ek.ek(os.path.isfile, ek.ek(os.path.join, sickbeard.DATA_DIR, 'sickbeard.db.v0')):
+            if not ek.ek(os.path.isfile, ek.ek(os.path.join, sickbeard.DATA_DIR, 'sickbeard.db')):
                 break
 
             try:
                 logger.log(u"Attempting to back up your sickbeard.db file before migration...")
-                shutil.copy(ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db'), ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db.v0'))
+                shutil.copy(ek.ek(os.path.join, sickbeard.DATA_DIR, 'sickbeard.db'), ek.ek(os.path.join, sickbeard.DATA_DIR, 'sickbeard.db.v0'))
                 logger.log(u"Done backup, proceeding with migration.")
                 break
             except Exception, e:

--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -35,7 +35,7 @@ class DBConnection:
 
 		self.dbFileName = dbFileName
 
-		self.connection = sqlite3.connect(os.path.join(sickbeard.PROG_DIR, self.dbFileName), 20)
+		self.connection = sqlite3.connect(os.path.join(sickbeard.DATA_DIR, self.dbFileName), 20)
 		self.connection.row_factory = sqlite3.Row
 
  	def action(self, query, args=None):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -682,7 +682,7 @@ class ConfigGeneral:
             ui.flash.error('Error(s) Saving Configuration',
                         '<br />\n'.join(results))
         else:
-            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.PROG_DIR, 'config.ini') )
+            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.CONFIG_FILE) )
 
         redirect("/config/general/")
 
@@ -763,7 +763,7 @@ class ConfigSearch:
             ui.flash.error('Error(s) Saving Configuration',
                         '<br />\n'.join(results))
         else:
-            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.PROG_DIR, 'config.ini') )
+            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.CONFIG_FILE) )
 
         redirect("/config/search/")
 
@@ -870,7 +870,7 @@ class ConfigPostProcessing:
             ui.flash.error('Error(s) Saving Configuration',
                         '<br />\n'.join(results))
         else:
-            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.PROG_DIR, 'config.ini') )
+            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.CONFIG_FILE) )
 
         redirect("/config/postProcessing/")
 
@@ -1130,7 +1130,7 @@ class ConfigProviders:
             ui.flash.error('Error(s) Saving Configuration',
                         '<br />\n'.join(results))
         else:
-            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.PROG_DIR, 'config.ini') )
+            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.CONFIG_FILE) )
 
         redirect("/config/providers/")
 
@@ -1277,7 +1277,7 @@ class ConfigNotifications:
             ui.flash.error('Error(s) Saving Configuration',
                         '<br />\n'.join(results))
         else:
-            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.PROG_DIR, 'config.ini') )
+            ui.flash.message('Configuration Saved', ek.ek(os.path.join, sickbeard.CONFIG_FILE) )
 
         redirect("/config/notifications/")
 


### PR DESCRIPTION
This adds 3 options
1. --datadir
2. --config
3. --logdir

All of these would be very helpful to keep data out of PROG_DIR which is not pretty for packaging.  This would be beneficial as well on embedded systems such as openelc which has a read-only root filesystem.
