### PR TITLE
Fix libnotify test button

### DIFF
--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -47,7 +47,7 @@ $(document).ready(function(){
 
     $('#testLibnotify').click(function(){
         $('#testLibnotify-result').html(loading);
-        $.get("$sbRoot/home/testLibnotify",
+        $.get(sbRoot+"/home/testLibnotify",
         function(message){ $('#testLibnotify-result').html(message); });
     });
   


### PR DESCRIPTION
The test libnotify button was finding sbRoot wrong in the JS file, this makes the test button work as expected.
