### PR TITLE
Untitled

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -207,6 +207,7 @@ PLEX_PASSWORD = None
 USE_GROWL = False
 GROWL_NOTIFY_ONSNATCH = False
 GROWL_NOTIFY_ONDOWNLOAD = False
+GROWL_STICKY = False
 GROWL_HOST = None
 GROWL_PASSWORD = None
 
@@ -349,8 +350,8 @@ def initialize(consoleLogging=True):
                 NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
                 SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
                 QUALITY_DEFAULT, SEASON_FOLDERS_FORMAT, SEASON_FOLDERS_DEFAULT, STATUS_DEFAULT, \
-                GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
-                USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
+                TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
+                USE_GROWL, GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, GROWL_STICKY, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, \
                 KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 TVBINZ_AUTH, showQueueScheduler, searchQueueScheduler, ROOT_DIRS, \
@@ -537,6 +538,7 @@ def initialize(consoleLogging=True):
         USE_GROWL = bool(check_setting_int(CFG, 'Growl', 'use_growl', 0))
         GROWL_NOTIFY_ONSNATCH = bool(check_setting_int(CFG, 'Growl', 'growl_notify_onsnatch', 0))
         GROWL_NOTIFY_ONDOWNLOAD = bool(check_setting_int(CFG, 'Growl', 'growl_notify_ondownload', 0))
+        GROWL_STICKY = bool(check_setting_int(CFG, 'Growl', 'growl_sticky', 0))
         GROWL_HOST = check_setting_str(CFG, 'Growl', 'growl_host', '')
         GROWL_PASSWORD = check_setting_str(CFG, 'Growl', 'growl_password', '')
 
@@ -1026,6 +1028,7 @@ def save_config():
     new_config['Growl']['use_growl'] = int(USE_GROWL)
     new_config['Growl']['growl_notify_onsnatch'] = int(GROWL_NOTIFY_ONSNATCH)
     new_config['Growl']['growl_notify_ondownload'] = int(GROWL_NOTIFY_ONDOWNLOAD) 
+    new_config['Growl']['growl_sticky'] = int(GROWL_STICKY) 
     new_config['Growl']['growl_host'] = GROWL_HOST
     new_config['Growl']['growl_password'] = GROWL_PASSWORD
     

--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -28,15 +28,18 @@ from lib.growl import gntp
 class GrowlNotifier:
 
     def test_notify(self, host, password):
-        return self._sendGrowl("Test Growl", "Testing Growl settings from Sick Beard", "Test", host, password, force=True)
+        sticky = sickbeard.GROWL_STICKY
+        return self._sendGrowl("Test Growl", "Testing Growl settings from Sick Beard", "Test", host, password, force=True,sticky=sticky)
 
     def notify_snatch(self, ep_name):
+        sticky = sickbeard.GROWL_STICKY
         if sickbeard.GROWL_NOTIFY_ONSNATCH:
-            self._sendGrowl(common.notifyStrings[common.NOTIFY_SNATCH], ep_name)
+            self._sendGrowl(common.notifyStrings[common.NOTIFY_SNATCH], ep_name, sticky=sticky)
 
     def notify_download(self, ep_name):
+        sticky = sickbeard.GROWL_STICKY
         if sickbeard.GROWL_NOTIFY_ONDOWNLOAD:
-            self._sendGrowl(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_name)
+            self._sendGrowl(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_name,sticky=sticky)
 
     def _send_growl(self, options,message=None):
     
@@ -62,6 +65,7 @@ class GrowlNotifier:
             notice.set_password(options['password'])
     
         #Optional
+        # determined by config option GROWL_STICKY
         if options['sticky']:
             notice.add_header('Notification-Sticky',options['sticky'])
         if options['priority']:
@@ -90,7 +94,7 @@ class GrowlNotifier:
 
         return response
 
-    def _sendGrowl(self, title="Sick Beard Notification", message=None, name=None, host=None, password=None, force=False):
+    def _sendGrowl(self, title="Sick Beard Notification", message=None, name=None, host=None, password=None, force=False, sticky=None):
     
         if not sickbeard.USE_GROWL and not force:
             return False
@@ -117,7 +121,7 @@ class GrowlNotifier:
         opts['title'] = title
         opts['app'] = 'SickBeard'
     
-        opts['sticky'] = None
+        opts['sticky'] = sticky
         opts['priority'] = None
         opts['debug'] = False
     
@@ -132,11 +136,11 @@ class GrowlNotifier:
         for pc in growlHosts:
             opts['host'] = pc[0]
             opts['port'] = pc[1]
-            logger.log(u"Sending growl to "+opts['host']+":"+str(opts['port'])+": "+message)
+            logger.log(u"Sending growl (sticky: "+str(opts['sticky'])+ ") to "+opts['host']+":"+str(opts['port'])+": "+message)
             try:
                 return self._send_growl(opts, message)
             except socket.error, e:
-                logger.log(u"Unable to send growl to "+opts['host']+":"+str(opts['port'])+": "+str(e).decode('utf-8'))
+                logger.log(u"Unable to send growl (sticky: "+str(opts['sticky'])+ ") to "+opts['host']+":"+str(opts['port'])+": "+str(e).decode('utf-8'))
                 return False
 
-notifier = GrowlNotifier
+notifier = GrowlNotifier 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1817,11 +1817,12 @@ class Home:
 
     @cherrypy.expose
     def testGrowl(self, host=None, password=None):
+        sticky = sickbeard.GROWL_STICKY
         result = notifiers.growl_notifier.test_notify(host, password)
-        if password==None or password=='':
-            pw_append = ''
+        if password==None or password=='': 
+            pw_append = " with sticky: "+str(sticky) 
         else:
-            pw_append = " with password: " + password
+            pw_append = " with sticky: "+str(sticky)+" and with password: " + password 
 
         if result:
             return "Test growl sent successfully to "+urllib.unquote_plus(host)+pw_append


### PR DESCRIPTION
Add GROWL_STICKY/growl_sticky config.ini option. This enables a user to set growl messages to be sticky (1) or not (0/default) when sent by sickbeard. Feel free to contact "derwin" in #sickbeard with questions. :)
