### PR TITLE
libnotify exception fix

### DIFF
--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -67,6 +67,13 @@ class LibnotifyNotifier:
         except ImportError:
             logger.log(u"Unable to import pynotify. libnotify notifications won't work.")
             return False
+
+	try:
+            import gobject
+        except ImportError:
+            logger.log(u"Unable to import gobject. We can't catch an GError in display.")
+            return False
+
         if not pynotify.init('Sick Beard'):
             logger.log(u"Initialization of pynotify failed. libnotify notifications won't work.")
             return False
@@ -98,14 +105,7 @@ class LibnotifyNotifier:
         # If the session bus can't be acquired here a bunch of warning messages
         # will be printed but the call to show() will still return True.
         # pynotify doesn't seem too keen on error handling.
-        n = self.pynotify.Notification(title, message, icon_uri)
-
-        try:
-            import gobject
-        except ImportError:
-            logger.log(u"Unable to import gobject. We might not be able to catch an GError in display.")
-            pass
-        
+      
         try:
             return n.show()
         except gobject.GError:

--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -99,7 +99,16 @@ class LibnotifyNotifier:
         # will be printed but the call to show() will still return True.
         # pynotify doesn't seem too keen on error handling.
         n = self.pynotify.Notification(title, message, icon_uri)
-        return n.show()
 
+        try:
+            import gobject
+        except ImportError:
+            logger.log(u"Unable to import gobject. We might not be able to catch an GError in display.")
+            pass
+        
+        try:
+            return n.show()
+        except gobject.GError:
+            return False
 
 notifier = LibnotifyNotifier


### PR DESCRIPTION
Catch GError exception 'display not found' when calling n.show() in libnotify.

It's unclear why the comment says that error handling doesn't work too well. This seems to work alright. 

I took the fix from:
https://bugzilla.redhat.com/show_bug.cgi?id=667350
