### PR TITLE
Libnotify exception fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.pyc
 cache/*
-cache.db
+cache.db*
 config.ini
 Logs/*
 sickbeard.db*

--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -67,6 +67,11 @@ class LibnotifyNotifier:
         except ImportError:
             logger.log(u"Unable to import pynotify. libnotify notifications won't work.")
             return False
+        try:
+            import gobject
+        except ImportError:
+            logger.log(u"Unable to import gobject. We can't catch a GError in display.")
+            return False
         if not pynotify.init('Sick Beard'):
             logger.log(u"Initialization of pynotify failed. libnotify notifications won't work.")
             return False
@@ -99,7 +104,9 @@ class LibnotifyNotifier:
         # will be printed but the call to show() will still return True.
         # pynotify doesn't seem too keen on error handling.
         n = self.pynotify.Notification(title, message, icon_uri)
-        return n.show()
-
+        try:
+            return n.show()
+        except gobject.GError:
+            return False
 
 notifier = LibnotifyNotifier

--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -58,6 +58,7 @@ def diagnose():
 class LibnotifyNotifier:
     def __init__(self):
         self.pynotify = None
+        self.gobject = None
 
     def init_pynotify(self):
         if self.pynotify is not None:
@@ -76,6 +77,7 @@ class LibnotifyNotifier:
             logger.log(u"Initialization of pynotify failed. libnotify notifications won't work.")
             return False
         self.pynotify = pynotify
+        self.gobject = gobject
         return True
 
     def notify_snatch(self, ep_name):
@@ -106,7 +108,7 @@ class LibnotifyNotifier:
         n = self.pynotify.Notification(title, message, icon_uri)
         try:
             return n.show()
-        except gobject.GError:
+        except self.gobject.GError:
             return False
 
 notifier = LibnotifyNotifier


### PR DESCRIPTION
- Catch GError exception 'display not found' when calling n.show() in libnotify.
- Modified .gitignore slightly as it was picking up cache.db-journal in commits

It's unclear to me why the comment in libnotify.py says that error handling doesn't work too well. 
This seems to work.

I took the libnotify fix from:
https://bugzilla.redhat.com/show_bug.cgi?id=667350
