### PR TITLE
Add sickbeard.db.dbFilename() method

### DIFF
--- a/data/interfaces/default/config.tmpl
+++ b/data/interfaces/default/config.tmpl
@@ -1,4 +1,5 @@
 #import sickbeard
+#from sickbeard import db
 #import os.path
 #set global $title="Configuration"
 
@@ -11,7 +12,7 @@
 <table class="infoTable" cellspacing="1" border="0" cellpadding="0">
     <tr><td class="infoTableHeader">SB Version: </td><td class="infoTableCell">alpha ($sickbeard.version.SICKBEARD_VERSION) <!-- &ndash; build.date //--></td></tr>
     <tr><td class="infoTableHeader">SB Config file: </td><td class="infoTableCell">$sickbeard.CONFIG_FILE</td></tr>
-    <tr><td class="infoTableHeader">SB Database file: </td><td class="infoTableCell">$os.path.join(sickbeard.DATA_DIR, 'sickbeard.db')</td></tr>
+    <tr><td class="infoTableHeader">SB Database file: </td><td class="infoTableCell">$db.dbFilename()</td></tr>
     <tr><td class="infoTableHeader">SB Cache Dir: </td><td class="infoTableCell">$sickbeard.CACHE_DIR</td></tr>
     <tr><td class="infoTableHeader">SB Arguments: </td><td class="infoTableCell">$sickbeard.MY_ARGS</td></tr>
     <tr><td class="infoTableHeader">SB Web Root: </td><td class="infoTableCell">$sickbeard.WEB_ROOT</td></tr>

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -130,13 +130,13 @@ class NewQualitySettings (NumericProviders):
     def execute(self):
 
         numTries = 0
-        while not ek.ek(os.path.isfile, ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db.v0')):
-            if not ek.ek(os.path.isfile, ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db')):
+        while not ek.ek(os.path.isfile, db.dbFilename(suffix='v0')):
+            if not ek.ek(os.path.isfile, db.dbFilename()):
                 break
 
             try:
                 logger.log(u"Attempting to back up your sickbeard.db file before migration...")
-                shutil.copy(ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db'), ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db.v0'))
+                shutil.copy(db.dbFilename(), db.dbFilename(suffix='v0'))
                 logger.log(u"Done backup, proceeding with migration.")
                 break
             except Exception, e:
@@ -211,7 +211,7 @@ class NewQualitySettings (NumericProviders):
 
         # if no updates were done then the backup is useless
         if didUpdate:
-            os.remove(ek.ek(os.path.join, sickbeard.PROG_DIR, 'sickbeard.db.v0'))
+            os.remove(db.dbFilename(suffix='v0'))
 
 
         ### Update show qualities

--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -26,17 +26,29 @@ import threading
 
 import sickbeard
 
+from sickbeard import encodingKludge as ek
 from sickbeard import logger
 from sickbeard.exceptions import ex
 
 db_lock = threading.Lock()
 
+def dbFilename(filename="sickbeard.db", suffix=None):
+    """
+    @param filename: The sqlite database filename to use. If not specified,
+                     will be made to be sickbeard.db
+    @param suffix: The suffix to append to the filename. A '.' will be added
+                   automatically, i.e. suffix='v0' will make dbfile.db.v0
+    @return: the correct location of the database file.
+    """
+    if suffix:
+        filename = "%s.%s" % (filename, suffix)
+    return ek.ek(os.path.join, sickbeard.DATA_DIR, filename)
+
 class DBConnection:
-    def __init__(self, dbFileName="sickbeard.db"):
+    def __init__(self, filename="sickbeard.db", suffix=None):
 
-        self.dbFileName = dbFileName
-
-        self.connection = sqlite3.connect(os.path.join(sickbeard.DATA_DIR, self.dbFileName), 20)
+        self.filename = filename
+        self.connection = sqlite3.connect(dbFilename(filename), 20)
         self.connection.row_factory = sqlite3.Row
 
     def action(self, query, args=None):
@@ -52,10 +64,10 @@ class DBConnection:
             while attempt < 5:
                 try:
                     if args == None:
-                        logger.log(self.dbFileName+": "+query, logger.DEBUG)
+                        logger.log(self.filename+": "+query, logger.DEBUG)
                         sqlResult = self.connection.execute(query)
                     else:
-                        logger.log(self.dbFileName+": "+query+" with args "+str(args), logger.DEBUG)
+                        logger.log(self.filename+": "+query+" with args "+str(args), logger.DEBUG)
                         sqlResult = self.connection.execute(query, args)
                     self.connection.commit()
                     # get out of the connection attempt loop since we were successful


### PR DESCRIPTION
This will ensure that the mistake that was in mainDB.py a few times
where PROG_DIR and DATA_DIR were exchanged will not happen, if everyone
uses the new function to find out the location of the db.

This also means that upgrades will work from scratch properly if you use --datadir :)
