### PR TITLE
when adding a show first load episodes from thetvdb then load files from dir

### DIFF
--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -274,12 +274,6 @@ class QueueItemAdd(ShowQueueItem):
         sickbeard.showList.append(self.show)
 
         try:
-            self.show.loadEpisodesFromDir()
-        except Exception, e:
-            logger.log(u"Error searching dir for episodes: " + ex(e), logger.ERROR)
-            logger.log(traceback.format_exc(), logger.DEBUG)
-
-        try:
             self.show.loadEpisodesFromTVDB()
             self.show.setTVRID()
 
@@ -288,6 +282,12 @@ class QueueItemAdd(ShowQueueItem):
             
         except Exception, e:
             logger.log(u"Error with TVDB, not creating episode list: " + ex(e), logger.ERROR)
+            logger.log(traceback.format_exc(), logger.DEBUG)
+
+        try:
+            self.show.loadEpisodesFromDir()
+        except Exception, e:
+            logger.log(u"Error searching dir for episodes: " + ex(e), logger.ERROR)
             logger.log(traceback.format_exc(), logger.DEBUG)
 
         try:


### PR DESCRIPTION
as mentioned i dont see why the files should be parsed before we have info of them in our db
the only thing i can think of are the infos pulled from the nfo's but the tvdb lookup is done anyway
