### PR TITLE
added SSL support for nzbmatrix

### DIFF
--- a/sickbeard/providers/nzbmatrix.py
+++ b/sickbeard/providers/nzbmatrix.py
@@ -40,7 +40,7 @@ class NZBMatrixProvider(generic.NZBProvider):
 
         self.cache = NZBMatrixCache(self)
 
-        self.url = 'http://www.nzbmatrix.com/'
+        self.url = 'https://nzbmatrix.com/'
 
     def isEnabled(self):
         return sickbeard.NZBMATRIX


### PR DESCRIPTION
I changed http://www.nzbmatrix.com to https://nzbmatrix.com to support SSL.

I'm new to this so I hope I did this right.

Thanks,
Lyle

p.s. sickbeard is great.
