### PR TITLE
Cherrypick upcoming episodes from paused shows

### DIFF
--- a/data/css/comingEpisodes.css
+++ b/data/css/comingEpisodes.css
@@ -134,6 +134,11 @@ span.pause {
     font-size: 12px;
 }
 
+span.cherrypick {
+    color: #336600;
+    font-size: 12px;
+}
+
 .ep_summaryTrigger {
     float: left;
     padding-top: 5px;

--- a/data/interfaces/default/comingEpisodes.tmpl
+++ b/data/interfaces/default/comingEpisodes.tmpl
@@ -121,7 +121,7 @@
 
     #for $cur_result in $sql_results:
 
-        #if int($cur_result["paused"]) and not $sickbeard.COMING_EPS_DISPLAY_PAUSED:
+        #if int($cur_result["paused"]) and not $sickbeard.COMING_EPS_DISPLAY_PAUSED and int($cur_result["cherry_pick_status"]) != $sickbeard.common.WANTED:
             #continue
         #end if
 
@@ -150,7 +150,11 @@
         <td align="center" class="nowrap">$datetime.date.fromordinal(int($cur_result["airdate"]))</td>
         <td><a href="$sbRoot/home/displayShow?show=${cur_result["showid"]}">$cur_result["show_name"]</a>
             #if int($cur_result["paused"]):
-            <span class="pause">[paused]</span>
+                #if int($cur_result["cherry_pick_status"]) == $sickbeard.common.WANTED:
+                    <span class="cherrypick">[cherry picked]</span>
+                #else
+                    <span class="pause">[paused]</span>
+                #end if
             #end if
         </td>
         <td align="center">$cur_result["network"]</td>

--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -181,6 +181,7 @@ table.tablesorter thead tr .headerSortDown { background-image: url("$sbRoot/imag
                         <li><a href="$sbRoot/manage/backlogOverview"><img src="$sbRoot/images/menu/backlog16.png" alt="" width="16" height="16" />Backlog Overview</a></li>
                         <li><a href="$sbRoot/manage/manageSearches"><img src="$sbRoot/images/menu/managesearches16.png" alt="" width="16" height="16" />Manage Searches</a></li>
                         <li><a href="$sbRoot/manage/episodeStatuses"><img src="$sbRoot/images/menu/backlog16.png" alt="" width="16" height="16" />Episode Status Management</a></li>
+                        <li><a href="$sbRoot/manage/cherryPickPaused"><img src="$sbRoot/images/menu/backlog16.png" alt="" width="16" height="16" />Cherry Pick Paused Episodes</a></li>
                 </ul>
             </li>
             <li id="NAVconfig"><a href="$sbRoot/config">Config</a>

--- a/data/interfaces/default/manage_cherryPickPaused.tmpl
+++ b/data/interfaces/default/manage_cherryPickPaused.tmpl
@@ -12,16 +12,14 @@
 
 <script type="text/javascript" src="$sbRoot/js/manageCherryPickPaused.js"></script>
 
-<form action="$sbRoot/manage/changeEpisodeStatuses" method="POST">
+<form action="$sbRoot/manage/changeCherryPickPaused" method="POST">
 
 <h2>Paused Shows containing unaired episodes</h2>
 
 <br/ >
 
-<input type="hidden" id="row_class" value="good">
-
 Set checked shows/episodes to <select name="newStatus">
-#set $statusList = [$common.SKIPPED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]
+#set $statusList = [$common.UNAIRED, $common.WANTED]
 #for $curStatus in $statusList:
 <option value="$curStatus">$common.statusStrings[$curStatus]</option>
 #end for
@@ -35,7 +33,7 @@ Set checked shows/episodes to <select name="newStatus">
 #for $cur_tvdb_id in $sorted_show_ids:
  <tr id="$cur_tvdb_id">
   <th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all" checked></th>
-  <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="get_more_eps" id="$cur_tvdb_id" value="Expand"></th>
+  <th colspan="3" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="get_more_eps" id="$cur_tvdb_id" value="Expand"></th>
  </tr>
 #end for
 </table>

--- a/data/interfaces/default/manage_cherryPickPaused.tmpl
+++ b/data/interfaces/default/manage_cherryPickPaused.tmpl
@@ -1,0 +1,45 @@
+#import sickbeard
+#import datetime
+#from sickbeard import common
+#set global $title="Episode Overview"
+
+#set global $sbPath=".."
+
+#set global $topmenu="manage"#
+#import os.path
+#include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
+
+
+<script type="text/javascript" src="$sbRoot/js/manageCherryPickPaused.js"></script>
+
+<form action="$sbRoot/manage/changeEpisodeStatuses" method="POST">
+
+<h2>Paused Shows containing unaired episodes</h2>
+
+<br/ >
+
+<input type="hidden" id="row_class" value="good">
+
+Set checked shows/episodes to <select name="newStatus">
+#set $statusList = [$common.SKIPPED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]
+#for $curStatus in $statusList:
+<option value="$curStatus">$common.statusStrings[$curStatus]</option>
+#end for
+</select>
+<input type="submit" value="Go">
+<br />
+<br />
+<br />
+
+<table class="sickbeardTable" cellspacing="1" border="0" cellpadding="0">
+#for $cur_tvdb_id in $sorted_show_ids:
+ <tr id="$cur_tvdb_id">
+  <th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all" checked></th>
+  <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="get_more_eps" id="$cur_tvdb_id" value="Expand"></th>
+ </tr>
+#end for
+</table>
+</form>
+
+
+#include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_bottom.tmpl")

--- a/data/interfaces/default/manage_cherryPickPaused.tmpl
+++ b/data/interfaces/default/manage_cherryPickPaused.tmpl
@@ -19,7 +19,7 @@
 <br/ >
 
 Set checked shows/episodes to <select name="newStatus">
-#set $statusList = [$common.UNAIRED, $common.WANTED]
+#set $statusList = [$common.WANTED, $common.UNAIRED]
 #for $curStatus in $statusList:
 <option value="$curStatus">$common.statusStrings[$curStatus]</option>
 #end for
@@ -32,7 +32,7 @@ Set checked shows/episodes to <select name="newStatus">
 <table class="sickbeardTable" cellspacing="1" border="0" cellpadding="0">
 #for $cur_tvdb_id in $sorted_show_ids:
  <tr id="$cur_tvdb_id">
-  <th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all" checked></th>
+  <th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all"></th>
   <th colspan="3" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="get_more_eps" id="$cur_tvdb_id" value="Expand"></th>
  </tr>
 #end for

--- a/data/js/manageCherryPickPaused.js
+++ b/data/js/manageCherryPickPaused.js
@@ -1,18 +1,26 @@
 $(document).ready(function() { 
 
-    function make_row(tvdb_id, season, episode, name, checked) {
+    function make_row(tvdb_id, season, episode, name, checked, cherry_status) {
         if (checked)
             var checked = ' checked';
         else
             var checked = '';
         
-        var row_class = $('#row_class').val();
         
         var row = '';
-        row += ' <tr class="'+row_class+'">';
+        if ( cherry_status == 3 ) {
+            row += ' <tr class="wanted">';
+        } else {
+            row += ' <tr class="unaired">';
+        }
         row += '  <td><input type="checkbox" class="'+tvdb_id+'-epcheck" name="'+tvdb_id+'-'+season+'x'+episode+'"'+checked+'></td>';
         row += '  <td>'+season+'x'+episode+'</td>';
-        row += '  <td style="width: 100%">'+name+'</td>';
+        row += '  <td style="width: 90%">'+name+'</td>';
+        if ( cherry_status == 3 ) {
+            row += '  <td>Wanted</td>';
+        } else {
+            row += '  <td>Unaired</td>';
+        }
         row += ' </tr>'
         
         return row;
@@ -35,8 +43,8 @@ $(document).ready(function() {
                   function (data) {
                       $.each(data, function(season,eps){
                           $.each(eps, function(episode, name) {
-                              //alert(season+'x'+episode+': '+name);
-                              last_row.after(make_row(cur_tvdb_id, season, episode, name, checked));
+                                  //alert(season+'x'+episode+': '+name);
+                                  last_row.after(make_row(cur_tvdb_id, season, episode, name.name, checked, name.cherry_pick_status));
                           });
                       });
                   });

--- a/data/js/manageCherryPickPaused.js
+++ b/data/js/manageCherryPickPaused.js
@@ -1,0 +1,46 @@
+$(document).ready(function() { 
+
+    function make_row(tvdb_id, season, episode, name, checked) {
+        if (checked)
+            var checked = ' checked';
+        else
+            var checked = '';
+        
+        var row_class = $('#row_class').val();
+        
+        var row = '';
+        row += ' <tr class="'+row_class+'">';
+        row += '  <td><input type="checkbox" class="'+tvdb_id+'-epcheck" name="'+tvdb_id+'-'+season+'x'+episode+'"'+checked+'></td>';
+        row += '  <td>'+season+'x'+episode+'</td>';
+        row += '  <td style="width: 100%">'+name+'</td>';
+        row += ' </tr>'
+        
+        return row;
+    }
+
+    $('.allCheck').click(function(){
+        var tvdb_id = $(this).attr('id').split('-')[1];
+        $('.'+tvdb_id+'-epcheck').attr('checked', $(this).attr('checked'));
+    });
+
+    $('.get_more_eps').click(function(){
+        var cur_tvdb_id = $(this).attr('id');
+        var checked = $('#allCheck-'+cur_tvdb_id).attr('checked');
+        var last_row = $('tr#'+cur_tvdb_id);
+        
+        $.getJSON(sbRoot+'/manage/showCherryPickPaused',
+                  {
+                   tvdb_id: cur_tvdb_id
+                  },
+                  function (data) {
+                      $.each(data, function(season,eps){
+                          $.each(eps, function(episode, name) {
+                              //alert(season+'x'+episode+': '+name);
+                              last_row.after(make_row(cur_tvdb_id, season, episode, name, checked));
+                          });
+                      });
+                  });
+        $(this).hide();
+    });
+
+});

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -398,3 +398,11 @@ class FixAirByDateSetting(SetNzbTorrentSettings):
                 self.connection.action("UPDATE tv_shows SET air_by_date = ? WHERE tvdb_id = ?", [1, cur_show["tvdb_id"]])
         
         self.incDBVersion()
+
+class AddCherryPickStatus (FixAirByDateSetting):
+    def test(self):
+        return self.hasColumn("tv_episodes", "cherry_pick_status")
+
+    def execute(self):
+        self.addColumn("tv_episodes", "cherry_pick_status", "NUMERIC")
+

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -23,7 +23,7 @@ import traceback
 
 import sickbeard
 
-from common import SNATCHED, Quality, SEASON_RESULT, MULTI_EP_RESULT
+from common import SNATCHED, Quality, SEASON_RESULT, MULTI_EP_RESULT, WANTED
 
 from sickbeard import logger, db, show_name_helpers, exceptions, helpers
 from sickbeard import sab
@@ -168,7 +168,10 @@ def searchForNeededEpisodes():
 
             if curEp.show.paused:
                 logger.log(u"Show "+curEp.show.name+" is paused, ignoring all RSS items for "+curEp.prettyName(True), logger.DEBUG)
-                continue
+                if curEp.cherry_pick_status == WANTED:
+                    logger.log(u"Wait, change of plans, thanks to cherry picking, ignore that ", logger.DEBUG)
+                else:
+                    continue
 
             # find the best result for the current episode
             bestResult = None

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1152,6 +1152,7 @@ class TVEpisode(object):
                 # and it hasn't aired yet set the status to UNAIRED
                 logger.log(u"Episode airs in the future, changing status from " + str(self.status) + " to " + str(UNAIRED), logger.DEBUG)
                 self.status = UNAIRED
+                self.cherry_pick_status = UNAIRED
             # if there's no airdate then set it to skipped (and respect ignored)
             elif self.airdate == datetime.date.fromordinal(1):
                 if self.status == IGNORED:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -853,7 +853,10 @@ class TVShow(object):
             return False
 
         epStatus = int(sqlResults[0]["status"])
-        epCherryPickStatus = int(sqlResults[0]["cherry_pick_status"])
+        if "cherry_pick_status" in sqlresults[0]: 
+            epCherryPickStatus = int(sqlResults[0]["cherry_pick_status"])
+        else:
+            epCherryPickStatus = UNAIRED
 
         logger.log(u"current episode status: "+str(epStatus), logger.DEBUG)
         logger.log(u"current episode cherry_pick_status: "+str(epCherryPickStatus), logger.DEBUG)
@@ -1047,7 +1050,10 @@ class TVEpisode(object):
             self.airdate = datetime.date.fromordinal(int(sqlResults[0]["airdate"]))
             #logger.log(u"1 Status changes from " + str(self.status) + " to " + str(sqlResults[0]["status"]), logger.DEBUG)
             self.status = int(sqlResults[0]["status"])
-            self.cherry_pick_status = int(sqlResults[0]["cherry_pick_status"])
+            if "cherry_pick_status" in sqlResults[0]:
+                self.cherry_pick_status = int(sqlResults[0]["cherry_pick_status"])
+            else:
+                self.cherry_pick_status = UNAIRED
 
             # don't overwrite my location
             if sqlResults[0]["location"] != "" and sqlResults[0]["location"] != None:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -933,6 +933,7 @@ class TVEpisode(object):
         self._hastbn = False
         self._status = UNKNOWN
         self._tvdbid = 0
+        self._cherry_pick_status = UNKNOWN
 
         # setting any of the above sets the dirty flag
         self.dirty = True
@@ -958,6 +959,7 @@ class TVEpisode(object):
     status = property(lambda self: self._status, dirty_setter("_status"))
     tvdbid = property(lambda self: self._tvdbid, dirty_setter("_tvdbid"))
     location = property(lambda self: self._location, dirty_setter("_location"))
+    cherry_pick_status = property(lambda self: self._cherry_pick_status, dirty_setter("_cherry_pick_status"))
 
     def checkForMetaFiles(self):
 
@@ -1322,6 +1324,7 @@ class TVEpisode(object):
                         "hasnfo": self.hasnfo,
                         "hastbn": self.hastbn,
                         "status": self.status,
+                        "cherry_pick_status": self.cherry_pick_status,
                         "location": self.location}
         controlValueDict = {"showid": self.show.tvdbid,
                             "season": self.season,

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -322,7 +322,10 @@ class Manage:
 
             cur_season = int(cur_result["season"])
             cur_episode = int(cur_result["episode"])
-            cur_cherry_pick_status = int(cur_result["cherry_pick_status"])
+            if "cherry_pick_status" in cur_result:
+                cur_cherry_pick_status = int(cur_result["cherry_pick_status"])
+            else:
+                cur_cherry_pick_status = common.UNAIRED
             
             if cur_season not in result:
                 result[cur_season] = {}

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -290,7 +290,7 @@ class Manage:
         t.submenu = ManageMenu
 
         myDB = db.DBConnection()
-        cherry_results = myDB.select("select show_name,season,episode,name,tv_episodes.status,tv_shows.tvdb_id as tvdb_id from tv_shows,tv_episodes where tv_episodes.showid = tv_shows.tvdb_id and paused = 1 and tv_episodes.status = 1")
+        cherry_results = myDB.select("select show_name,season,episode,name,tv_episodes.status,tv_shows.tvdb_id as tvdb_id from tv_shows,tv_episodes where tv_episodes.showid = tv_shows.tvdb_id and paused = 1 and tv_episodes.status = 1 ORDER BY show_name")
 
         ep_counts = {}
         show_names = {}
@@ -315,8 +315,8 @@ class Manage:
     def showCherryPickPaused(self, tvdb_id):
         myDB = db.DBConnection()
 
-        cur_cherry_results = myDB.select("select show_name,season,episode,name,tv_episodes.status,cherry_pick_status,tv_shows.tvdb_id as tvdb_id from tv_shows,tv_episodes where showid = ? and tv_episodes.showid = tv_shows.tvdb_id and paused = 1 and tv_episodes.status = 1", [int(tvdb_id)])
-        
+        cur_cherry_results = myDB.select("select show_name,season,episode,name,tv_episodes.status,cherry_pick_status,tv_shows.tvdb_id as tvdb_id from tv_shows,tv_episodes where showid = ? and tv_episodes.showid = tv_shows.tvdb_id and paused = 1 and tv_episodes.status = 1 ORDER BY episode ASC", [int(tvdb_id)])
+
         result = {}
         for cur_result in cur_cherry_results:
 


### PR DESCRIPTION
Quite sure this isn't ready for merging, just hoping to get some comments for now.

Reasoning: I have a few nightly talk style shows added to SB but paused.  If I see one coming up that I like the guests on, I have to remember to watch for it on a nzb site and manually download.  Easy to forget.  Wanted a way to mark upcoming specific episodes as being wanted in SB so that when they come up, it knows to grab them.

Bugs: 
- Episode ordering on the manage cherry pick page is weird, but I don't know why, I'm using order by in my search
- Can't un-cherry pick a show once it moves from unaired to skipped, the night (before?) it airs.

Aside from those, I believe it's all working.

cheers.
