### PR TITLE
newzbin_ignoresource pull request

### DIFF
--- a/data/interfaces/default/config_providers.tmpl
+++ b/data/interfaces/default/config_providers.tmpl
@@ -162,6 +162,11 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <span class="component-title">Newzbin Password</span>
                                 <input class="component-desc" type="password" name="newzbin_password" value="$sickbeard.NEWZBIN_PASSWORD" size="40" />
                             </label>
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title">Ignore Newzbbin Source</span>
+                                <input class="component-desc" type="checkbox" name="newzbin_ignoresource" #if $sickbeard.NEWZBIN_IGNORESOURCE then "checked=\"checked\"" else ""# />
+                            </label>
                         </div>
 </div>
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -173,6 +173,7 @@ NZBMATRIX_APIKEY = None
 NEWZBIN = False
 NEWZBIN_USERNAME = None
 NEWZBIN_PASSWORD = None
+NEWZBIN_IGNORESOURCE = False
 
 SAB_USERNAME = None
 SAB_PASSWORD = None
@@ -361,7 +362,7 @@ def initialize(consoleLogging=True):
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
-                NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
+                NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, NEWZBIN_IGNORESOURCE, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, IGNORE_WORDS
 
         if __INITIALIZED__:
@@ -503,6 +504,7 @@ def initialize(consoleLogging=True):
         NEWZBIN = bool(check_setting_int(CFG, 'Newzbin', 'newzbin', 0))
         NEWZBIN_USERNAME = check_setting_str(CFG, 'Newzbin', 'newzbin_username', '')
         NEWZBIN_PASSWORD = check_setting_str(CFG, 'Newzbin', 'newzbin_password', '')
+        NEWZBIN_IGNORESOURCE = bool(check_setting_int(CFG, 'Newzbin', 'newzbin_ignoresource', 0))
 
         WOMBLE = bool(check_setting_int(CFG, 'Womble', 'womble', 1))
 
@@ -985,6 +987,7 @@ def save_config():
     new_config['Newzbin']['newzbin'] = int(NEWZBIN)
     new_config['Newzbin']['newzbin_username'] = NEWZBIN_USERNAME
     new_config['Newzbin']['newzbin_password'] = NEWZBIN_PASSWORD
+    new_config['Newzbin']['newzbin_ignoresource'] = NEWZBIN_IGNORESOURCE
 
     new_config['Womble'] = {}
     new_config['Womble']['womble'] = int(WOMBLE)

--- a/sickbeard/providers/newzbin.py
+++ b/sickbeard/providers/newzbin.py
@@ -311,7 +311,6 @@ class NewzbinProvider(generic.NZBProvider):
                 'u_comment_posts_only': 0,
                 'u_show_passworded': 0,
                 'u_v3_retention': 0,
-                'ps_rb_source': 3008,
                 'ps_rb_video_format': 3082257,
                 'ps_rb_language': 4096,
                 'sort': 'date',
@@ -325,6 +324,9 @@ class NewzbinProvider(generic.NZBProvider):
             params['q'] = search + " AND "
         else:
             params['q'] = ''
+
+        if not sickbeard.NEWZBIN_IGNORESOURCE:
+                params['ps_rb_source']=3008
 
         params['q'] += 'Attr:Lang~Eng AND NOT Attr:VideoF=DVD'
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1022,7 +1022,7 @@ class ConfigProviders:
                       nzbmatrix_username=None, nzbmatrix_apikey=None,
                       nzbs_r_us_uid=None, nzbs_r_us_hash=None, newznab_string=None,
                       tvtorrents_digest=None, tvtorrents_hash=None, 
-                      newzbin_username=None, newzbin_password=None,
+                      newzbin_username=None, newzbin_password=None, newzbin_ignoresource=False,
                       provider_order=None):
 
         results = []
@@ -1104,6 +1104,7 @@ class ConfigProviders:
 
         sickbeard.NEWZBIN_USERNAME = newzbin_username
         sickbeard.NEWZBIN_PASSWORD = newzbin_password
+        sickbeard.NEWZBIN_IGNORESOURCE = bool(newzbin_ignoresource)
 
         sickbeard.PROVIDER_ORDER = provider_list
 


### PR DESCRIPTION
Add support for ignoring newzbins quality setting in searches, since
it is often missing or incorrect for more obscure shows - the same as  the patch in issue #1515 where i failed to follow instructions :)
