### PR TITLE
added support for hard-linking files instead of copying them on posix systems

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -398,12 +398,24 @@ def copyFile(srcFile, destFile):
         pass
 
 
+def linkOrCopyFile(srcFile, destFile):
+    if os.name == 'posix':
+        try:
+            ek.ek(os.link, srcFile, destFile)
+        except OSError:
+            # source and destination may be on different partitions, so hard-link is impossible
+            copyFile(srcFile, destFile)
+    else:
+        # link certainly not supported
+        copyFile(srcFile, destFile)
+
+
 def moveFile(srcFile, destFile):
     try:
         ek.ek(os.rename, srcFile, destFile)
         fixSetGroupID(destFile)
     except OSError:
-        copyFile(srcFile, destFile)
+        linkOrCopyFile(srcFile, destFile)
         ek.ek(os.unlink, srcFile)
 
 

--- a/sickbeard/image_cache.py
+++ b/sickbeard/image_cache.py
@@ -142,7 +142,7 @@ class ImageCache:
             ek.ek(os.makedirs, self._cache_dir())
 
         logger.log(u"Copying from "+image_path+" to "+dest_path)
-        helpers.copyFile(image_path, dest_path)
+        helpers.linkOrCopyFile(image_path, dest_path)
         
         return True
 

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -248,7 +248,7 @@ class PostProcessor(object):
 
             self._log(u"Copying file from " + cur_file_path + " to " + new_file_path, logger.DEBUG)
             try:
-                helpers.copyFile(cur_file_path, new_file_path)
+                helpers.linkOrCopyFile(cur_file_path, new_file_path)
                 helpers.chmodAsParent(new_file_path)
             except (IOError, OSError), e:
                 logger.log(u"Unable to copy file " + cur_file_path + " to " + new_file_path + ": " + ex(e), logger.ERROR)


### PR DESCRIPTION
Hi,

On POSIX systems (Linux/OS X), files can be hard-linked instead of copied, if they reside on the same filesystem.  This means there will be two file entries pointing to the same data block.
There are two major advantages to using hard-linking when possible: first, the operation is much faster (especially for big files), because only a new file entry is created, no data copy takes place; second, a lot less disk space will be used because both files share the same data.  This should help when handling many TV shows with HD episodes :).

I've added a method linkOrCopyFile to helpers.py, which attempts to create a hard-link instead of a file copy; if the operation fails (e.g. the source and destination are on different file systems), an exception is raised and it falls back on the regular copyFile.  I've also replaced all calls to copyFile with linkOrCopyFile in postProcessor.py, image_cache.py and helpers.py. 
I've tested it a bit, and it works as expected both when linking is possible and when not; however I only have a Linux machine to test it.

Cheers,
-pwr
