### PR TITLE
temporally set the locale to en_US so the date string we get from newzbin

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -23,6 +23,7 @@ import stat
 import urllib, urllib2
 import re, socket
 import shutil
+import locale
 
 import sickbeard
 
@@ -495,6 +496,31 @@ def sanitizeSceneName (name, ezrss=False):
         name = name[:-1]
 
     return name
+
+def set_locale_to_us():
+    """This will set the local var to en_US. does it gracefully
+    """
+    # if the default is not "en_US" and if the manual set locale is not "en_US"
+    # try to set it
+    if locale.getdefaultlocale() != ('en_US', 'ISO8859-1') and locale.getlocale(locale.LC_ALL) != ('en_US', 'ISO8859-1'):
+        try:
+            locale.setlocale(locale.LC_ALL, 'en_US')
+        except Exception, e:
+            logger.log("Can't set local to en_US this might lead to errors during time parsing: " + str(e), logger.ERROR)
+
+def set_locale_to_default():
+    """This will set the local var to the default / environment setting. does it gracefully
+    """
+    # if getdefaultlocale and getlocale is not the same we are not on the default
+    # getlocale gives back (None, None) if it was never set manually
+    # so on the initial call this will set the default even if we never changed it in the first place
+    if locale.getdefaultlocale() != locale.getlocale(locale.LC_ALL):
+        try:
+            locale.setlocale(locale.LC_ALL,'')
+        except Exception, e:
+            logger.log("Can't set local (back) to the default. this might lead to further errors!!: " + str(e), logger.ERROR)
+
+
 
 
 if __name__ == '__main__':

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -506,7 +506,7 @@ def set_locale_to_us():
         try:
             locale.setlocale(locale.LC_ALL, 'en_US')
         except Exception, e:
-            logger.log("Can't set local to en_US this might lead to errors during time parsing: " + str(e), logger.ERROR)
+            logger.log("Can't set local to en_US this might lead to errors during time parsing: " + ex(e), logger.ERROR)
 
 def set_locale_to_default():
     """This will set the local var to the default / environment setting. does it gracefully
@@ -518,7 +518,7 @@ def set_locale_to_default():
         try:
             locale.setlocale(locale.LC_ALL,'')
         except Exception, e:
-            logger.log("Can't set local (back) to the default. this might lead to further errors!!: " + str(e), logger.ERROR)
+            logger.log("Can't set local (back) to the default. this might lead to further errors!!: " + ex(e), logger.ERROR)
 
 
 

--- a/sickbeard/providers/newzbin.py
+++ b/sickbeard/providers/newzbin.py
@@ -33,6 +33,7 @@ from sickbeard import classes, logger, helpers, exceptions, show_name_helpers
 from sickbeard import tvcache
 from sickbeard.common import Quality
 from sickbeard.exceptions import ex
+from sickbeard.helpers import set_locale_to_us, set_locale_to_default
 
 class NewzbinDownloader(urllib.FancyURLopener):
 
@@ -280,10 +281,11 @@ class NewzbinProvider(generic.NZBProvider):
         except Exception, e:
             logger.log("Error trying to load Newzbin RSS feed: "+ex(e), logger.ERROR)
             return []
-
+        set_locale_to_us() # set the locale to "en_US" so we can parse the date string we get from newzbin
         for cur_item in items:
             title = cur_item.findtext('title')
             if title == 'Feed Error':
+                set_locale_to_default() # before we raise the exception set the locale back to default
                 raise exceptions.AuthException("The feed wouldn't load, probably because of invalid auth info")
             if sickbeard.USENET_RETENTION is not None:
                 try:
@@ -296,7 +298,7 @@ class NewzbinProvider(generic.NZBProvider):
                     continue
 
             item_list.append(cur_item)
-
+        set_locale_to_default() # set locale back to default
         return item_list
 
 


### PR DESCRIPTION
temporally set the locale to en_US so the date string we get from newzbin can be parsed.
implemented as helper functions.

tested on mac osx with python 2.7 and a default locale "de_DE"
k thx by
