### PR TITLE
Removed https from Newzbin to allow sickbeard to download successfully

### DIFF
--- a/sickbeard/providers/newzbin.py
+++ b/sickbeard/providers/newzbin.py
@@ -72,7 +72,7 @@ class NewzbinProvider(generic.NZBProvider):
 
         self.cache = NewzbinCache(self)
 
-        self.url = 'https://www.newzbin.com/'
+        self.url = 'http://www.newzbin.com/'
 
         self.NEWZBIN_NS = 'http://www.newzbin.com/DTD/2007/feeds/report/'
 


### PR DESCRIPTION
Removed https from Newzbin to allow sickbeard to download successfully and not hammer the newzbin servers with requests.
