### PR TITLE
quality tags, tableClick fixes, coming episode adjustments

### DIFF
--- a/data/css/comingEpisodes.css
+++ b/data/css/comingEpisodes.css
@@ -18,10 +18,10 @@
 .tvshowTitle a {
     color: #FFFFFF;
     float: left; 
-    padding-top: 5px; 
+    padding-top: 3px; 
     padding-left: 8px; 
-    line-height: 17px;
-    font-size: 16px;
+    line-height: 1.2em;
+    font-size: 1.1em;
     text-shadow: -1px -1px 0 rgba(0,0,0,0.3);
 }
 

--- a/data/css/default.css
+++ b/data/css/default.css
@@ -1,4 +1,5 @@
 * { outline: 0; }
+*:focus { outline: none; }
 img { border: 0; vertical-align: middle;}
 
 body {
@@ -331,7 +332,7 @@ div#addShowPortal  button .buttontext { position: relative; display: block; padd
 
 #rootDirs, #rootDirsControls { width: 50%; min-width: 400px; }
 
-.hover { background-color: #cfcfcf !important; cursor: pointer; }
+td.tvShow:hover { background-color: #cfcfcf !important; cursor: pointer; }
 .navShow { display: inline; cursor: pointer; vertical-align: top; }
 
 /* for manage_massEdit */
@@ -351,3 +352,34 @@ a.whitelink { color: white; }
     font-size: 1em;
 }
 div.ui-pnotify { min-width: 340px; max-width: 550px; width: auto !important;}
+
+span.quality {
+    font: bold 1em/1.2em verdana, sans-serif;
+    background: none repeat scroll 0 0 #999999;
+    color: #FFFFFF;
+    display: inline-block;
+    padding: 2px 4px;
+    text-align: center;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+}
+span.Custom {
+    background: none repeat scroll 0 0 #444499; /* blue */
+}
+span.HD {
+    background: none repeat scroll 0 0 #449944; /* green */
+}
+span.SD {
+    background: none repeat scroll 0 0 #994444; /* red */
+}
+span.Any {
+    background: none repeat scroll 0 0 #444444; /* black */
+}
+
+span.false {
+    color: #993333; /* red */
+}
+span.true {
+    color: #669966; /* green */
+}

--- a/data/interfaces/default/comingEpisodes.tmpl
+++ b/data/interfaces/default/comingEpisodes.tmpl
@@ -119,7 +119,7 @@
 
 <br/>
     <table id="showListTable" class="sickbeardTable tablesorter" cellspacing="1" border="0" cellpadding="0">
-    <thead><tr><th class="nowrap">Next Ep</th><th>Next Ep Name</th><th>Airdate</th><th>Show</th><th>Network</th><th>Quality</th><th>tvDB</th><th>Force</th></tr></thead>
+    <thead><tr><th class="nowrap">Next Ep</th><th>Next Ep Name</th><th>Airdate</th><th>Show</th><th>Network</th><th>Quality</th><th>tvDB</th><th>Search</th></tr></thead>
     <tbody>
 
     #for $cur_result in $sql_results:
@@ -151,7 +151,7 @@
         </td>
         <td>$cur_result["name"]</td>
         <td align="center" class="nowrap">$datetime.date.fromordinal(int($cur_result["airdate"]))</td>
-        <td><a href="$sbRoot/home/displayShow?show=${cur_result["showid"]}">$cur_result["show_name"]</a>
+        <td class="tvShow"><a href="$sbRoot/home/displayShow?show=${cur_result["showid"]}">$cur_result["show_name"]</a>
             #if int($cur_result["paused"]):
             <span class="pause">[paused]</span>
             #end if
@@ -166,7 +166,7 @@ Custom
         </td>
         <td align="center"><a href="http://www.thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open(this.href, '_blank'); return false;" title="http://www.thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[info]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a></td>
         <td align="center">
-        <a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Force Update" id="forceUpdate-${cur_result["showid"]}" class="forceUpdate epSearch"><img alt="[update]" height="16" width="16" src="$sbRoot/images/forceUpdate32.png" id="forceUpdateImage-${cur_result["showid"]}" /></a>
+        <a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Manual Search" id="forceUpdate-${cur_result["showid"]}" class="forceUpdate epSearch"><img alt="[search]" height="16" width="16" src="$sbRoot/images/search32.png" id="forceUpdateImage-${cur_result["showid"]}" /></a>
         </td>
       </tr>
     <!-- end $cur_result["show_name"] //-->
@@ -179,7 +179,7 @@ Custom
 <script type="text/javascript" charset="utf-8">
 <!--
 \$(document).ready(function(){ 
-  \$('#sbRoot').ajaxEpSearch({'size': 20, 'loadingImage': 'loading16_333333.gif'});
+  \$('#sbRoot').ajaxEpSearch({'size': 16, 'loadingImage': 'loading16_333333.gif'});
   \$(".ep_summary").hide();
   \$(".ep_summaryTrigger").click(function() {
     \$(this).next(".ep_summary").slideToggle('normal', function() {
@@ -260,8 +260,8 @@ Custom
             #end if            
             </a></span>
             <span class="tvshowTitleIcons">
-                <a href="http://www.thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open(this.href, '_blank'); return false;" title="http://www.thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[info]" height="20" width="20" src="$sbRoot/images/search32.png" /></a>
-                <span><a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Force Update" id="forceUpdate-${cur_result["showid"]}" class="epSearch forceUpdate"><img alt="[update]" height="20" width="20" src="$sbRoot/images/forceUpdate32.png" id="forceUpdateImage-${cur_result["showid"]}" /></a></span>
+                <a href="http://www.thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open(this.href, '_blank'); return false;" title="http://www.thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[tvdb]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a>
+                <span><a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Manual Search" id="forceUpdate-${cur_result["showid"]}" class="epSearch forceUpdate"><img alt="[search]" height="16" width="16" src="$sbRoot/images/search32.png" id="forceUpdateImage-${cur_result["showid"]}" /></a></span>
             </span>
           </th>
         </tr>

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -132,7 +132,7 @@ Change selected episodes to
         <h2>#if int($epResult["season"]) == 0 then "Specials" else "Season "+str($epResult["season"])#</h2>
     </td>
   </tr>
-  <tr id="season-$epResult["season"]-cols"><th width="1%"><input type="checkbox" class="seasonCheck" id="$epResult["season"]" /></th><th>NFO</th><th>TBN</th><th>Episode</th><th>Name</th><th class="nowrap">Airdate</th><th>Filename</th><th>Status</th><th>Action</th></tr>
+  <tr id="season-$epResult["season"]-cols"><th width="1%"><input type="checkbox" class="seasonCheck" id="$epResult["season"]" /></th><th>NFO</th><th>TBN</th><th>Episode</th><th>Name</th><th class="nowrap">Airdate</th><th>Filename</th><th>Status</th><th>Search</th></tr>
         #set $curSeason = int($epResult["season"])
     #end if    
 

--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -198,12 +198,12 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 
   <tr>
     <td align="center">#if len($curEp) != 0 then $curEp[0].airdate else ""#</td>
-    <td><a href="$sbRoot/home/displayShow?show=$curShow.tvdbid">$curShow.name</a></td>
+    <td class="tvShow"><a href="$sbRoot/home/displayShow?show=$curShow.tvdbid">$curShow.name</a></td>
     <td>$curShow.network</td>
 #if $curShow.quality in $qualityPresets:
-    <td align="center">$qualityPresetStrings[$curShow.quality]</td>
+    <td align="center"><span class="quality $qualityPresetStrings[$curShow.quality]">$qualityPresetStrings[$curShow.quality]</span></td>
 #else:
-    <td align="center">Custom</td>
+    <td align="center"><span class="quality Custom">Custom</span></td>
 #end if
     <td align="center"><!--$dlStat--><div id="progressbar$curShow.tvdbid" style="position:relative;"></div>
         <script type="text/javascript">

--- a/data/interfaces/default/manage.tmpl
+++ b/data/interfaces/default/manage.tmpl
@@ -114,7 +114,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 
   <tr>
     <td align="center"><input type="checkbox" class="editCheck" id="edit-$curShow.tvdbid" /></td>
-    <td><a href="$sbRoot/home/displayShow?show=$curShow.tvdbid">$curShow.name</a></td>
+    <td class="tvShow"><a href="$sbRoot/home/displayShow?show=$curShow.tvdbid">$curShow.name</a></td>
 #if $curShow.quality in $qualityPresets:
     <td align="center">$qualityPresetStrings[$curShow.quality]</td>
 #else:

--- a/data/interfaces/default/manage.tmpl
+++ b/data/interfaces/default/manage.tmpl
@@ -116,9 +116,9 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
     <td align="center"><input type="checkbox" class="editCheck" id="edit-$curShow.tvdbid" /></td>
     <td class="tvShow"><a href="$sbRoot/home/displayShow?show=$curShow.tvdbid">$curShow.name</a></td>
 #if $curShow.quality in $qualityPresets:
-    <td align="center">$qualityPresetStrings[$curShow.quality]</td>
+    <td align="center"><span class="quality $qualityPresetStrings[$curShow.quality]">$qualityPresetStrings[$curShow.quality]</span></td>
 #else:
-    <td align="center">Custom</td>
+    <td align="center"><span class="quality Custom">Custom</span></td>
 #end if 
     <td align="center"><img src="$sbRoot/images/#if int($curShow.seasonfolders) == 1 then "yes16.png\" alt=\"Y\"" else "no16.png\" alt=\"N\""# width="16" height="16" /></td>
     <td align="center"><img src="$sbRoot/images/#if int($curShow.paused) == 1 then "yes16.png\" alt=\"Y\"" else "no16.png\" alt=\"N\""# width="16" height="16" /></td>

--- a/data/js/tableClick.js
+++ b/data/js/tableClick.js
@@ -1,13 +1,12 @@
 $(document).ready(function(){
 
-   $("table.sickbeardTable td").hover( 
-	       function() { $(this).find("a").parent().addClass("hover"); }, 
-	       function() { $(this).find("a").parent().removeClass("hover");
-   } );
-
-   $("table.sickbeardTable td").click( function() {
-        var href = $(this).find("a").attr("href");
-        if(href) { window.location = href; }
-   });
+    $("table.sickbeardTable td.tvShow").live('click', function(e) {
+        if( (!$.browser.msie && e.button == 0) || ($.browser.msie && e.button == 1) ) {
+            if(!e.shiftKey) {
+                var href = $(this).find("a").attr("href");
+                if(href) { window.location = href; }
+            }
+        }
+    });
 
 });


### PR DESCRIPTION
Added: css styling to make the show quality text on the home page look like a 'tag', plan to expand this cosmetic change to other sections later on.
Fixed: tableClick only affects left click now and will not kick off if shift is used. This should resolve those that want to shift click to open shows in new tabs.
Changed: Now the table td hover effect is purely css based rather than jquery adding/removing classes, should be more efficient and less prone to conflicts. Added class 'tvShow' for its identifier, also have tableClick use this class instead of a selector.
Changed: Made the verbiage on the coming episodes page mimic the displayShow page. Force -> Search. Also updated the non-list views to use the tvdb icon and search icon as well.

Preview:
http://zoggy.net/sb-ui-tweak1.png
http://zoggy.net/sb-ui-tweak2.png
http://zoggy.net/sb-ui-tweak3.png
