### PR TITLE
Added logging of IP and username when basic_auth fails

### DIFF
--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -48,6 +48,7 @@ def initWebServer(options = {}):
             args = [status, message, traceback, version]
 
             logger.log(u"Authentication error, check cherrypy log for more details", logger.WARNING)
+            logger.log(u" - URL = %s" % str(cherrypy.request.path_info), logger.WARNING)
             logger.log(u" - IP = %s" % str(cherrypy.request.remote.ip), logger.WARNING)
             auth_header = cherrypy.request.headers.get('authorization')
             if auth_header:

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -20,6 +20,9 @@
 import cherrypy.lib.auth_basic
 import os.path
 
+import binascii
+import base64
+
 from sickbeard import logger
 from sickbeard.webserve import WebInterface
 
@@ -42,8 +45,6 @@ def initWebServer(options = {}):
 
         #HTTP Errors
         def http_error_401_hander(status, message, traceback, version):
-            import binascii
-            import base64
             args = [status, message, traceback, version]
 
             logger.log(u"Authentication error, check cherrypy log for more details", logger.WARNING)


### PR DESCRIPTION
This adds information to the log about the IP address and username used when someone fails to login.

This clarifies the "Authentication error, check cherrypy log for more details" error that shows up when random people stumble upon your sickbeard install.
