### PR TITLE
Made show titles bolder on the main page

### DIFF
--- a/data/css/default.css
+++ b/data/css/default.css
@@ -332,6 +332,8 @@ div#addShowPortal  button .buttontext { position: relative; display: block; padd
 
 #rootDirs, #rootDirsControls { width: 50%; min-width: 400px; }
 
+td.tvShow { font-weight: bold; }
+
 td.tvShow:hover { background-color: #cfcfcf !important; cursor: pointer; }
 .navShow { display: inline; cursor: pointer; vertical-align: top; }
 


### PR DESCRIPTION
With the new quality badges, the front page is a little busy and the titles tend to get lost. I made them bolder so they stand out and take control of the row a bit better. I don't think it's the solution to stand time (I think the main page could use a re-org) but for now, I think it helps quite a bit.
