### PR TITLE
Allow fullscreen mode for iOS when added as a webApp

### DIFF
--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -8,6 +8,7 @@
 <head>
     <title>Sick Beard - alpha $sickbeard.version.SICKBEARD_VERSION - $title</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <link rel="shortcut icon" href="$sbRoot/images/favicon.ico" />
     <link rel="apple-touch-icon" href="$sbRoot/images/sickbeard_touch_icon.png" />
     <link rel="stylesheet" type="text/css" href="$sbRoot/css/default.css" />


### PR DESCRIPTION
Just added one line in the header to allow Sickbeard to be launch as a fullScreen webapp on IOS devices
