### PR TITLE
Extend 'stupid' regex to match s/e prefix

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -92,11 +92,11 @@ ep_regexes = [
                '''),
               
               ('stupid',
-               # tpz-abc102
+               # tpz-abc102 or tpz-abcs01e02
                '''
                (?P<release_group>.+?)-\w+?[\. ]?           # tpz-abc
-               (?P<season_num>\d{1,2})                     # 1
-               (?P<ep_num>\d{2})$                          # 02
+               s?(?P<season_num>\d{1,2})                   # 1 or s01
+               e?(?P<ep_num>\d{2})$                        # 02 or e02
                '''),
               
               ('verbose',


### PR DESCRIPTION
Add optional season (s) and episode (e) prefixes to the regex for the
'stupid' name parser. I have just encounted a batch of filenames named
pfa-tgtsXXeYY.avi - very close to the current 'stupid' regex.
