### PR TITLE
Sab API url

### DIFF
--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -67,7 +67,7 @@ def sendNZB(nzb):
         params['mode'] = 'addfile'
         multiPartParams = {"nzbfile": (nzb.name+".nzb", nzb.extraInfo[0])}
 
-    url = sickbeard.SAB_HOST + "api?" + urllib.urlencode(params)
+    url = 'http://' + sickbeard.SAB_HOST + "/api?" + urllib.urlencode(params)
 
     logger.log(u"Sending NZB to SABnzbd")
 


### PR DESCRIPTION
The Sabnzbd API url is malformed. This causes snatched nzb to fail because they can't be send to SABnzbd. 
This diff poses some simple additions to fix the url. Maybe something more solid like a regex check would cover config errors like values with the http:// or the trailing slash in them 
