### PR TITLE
Gentoo Fixes for Sickbeard

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -20,7 +20,10 @@ from __future__ import with_statement
 
 import cherrypy
 import webbrowser
-import sqlite3
+try:
+    import sqlite3
+except:
+    from pysqlite2 import dbapi2 as sqlite3
 import datetime
 import socket
 import os, sys, subprocess, re

--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -20,7 +20,10 @@ from __future__ import with_statement
 
 import os.path
 import re
-import sqlite3
+try:
+    import sqlite3
+except:
+    from pysqlite2 import dbapi2 as sqlite3
 import time
 import threading
 

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -18,7 +18,10 @@
 
 import time
 import datetime
-import sqlite3
+try:
+    import sqlite3
+except:
+    from pysqlite2 import dbapi2 as sqlite3
 
 import sickbeard
 


### PR DESCRIPTION
Hi,
I changed the way sqlite3 is imported, making it fail over to pysqlite if it can't find it. This resolves issues in Gentoo Linux installs where you are unable to emerge sqlite3 for python from the standard ports.

Shouldn't affect any other systems that currently with with sqlite3
