### PR TITLE
Fix image thumbnail aspect ratio

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2455,9 +2455,10 @@ class WebInterface:
                     size = 136, 200
                 else:
                     return cherrypy.lib.static.serve_file(image_file_name, content_type="image/jpeg")
-                im.thumbnail(size, Image.ANTIALIAS)
+                im = im.resize(size, Image.ANTIALIAS)
                 buffer = StringIO()
-                im.save(buffer, 'JPEG')
+                im.save(buffer, 'JPEG', quality=85)
+                cherrypy.response.headers['Content-Type'] = 'image/jpeg'
                 return buffer.getvalue()
         else:
             return cherrypy.lib.static.serve_file(default_image_path, content_type="image/jpeg")


### PR DESCRIPTION
Resizing images using the thumbnail method preserves the aspect ratio, which is then discarded by the HTML/CSS, which forces them to a specific pixel size.  Images which aren't that pixel size (not all TVDB banners are exactly the proscribed pixel size) get blurred by the web browser.

Also added a content-type header for the resized image and slightly increased the JPEG quality.  Banners look way better as PNGs (JPEG blurs text), but I elected not to implement PNG as it significantly increases image size.
