### PR TITLE
fedora and ubuntu init script modifications

### DIFF
--- a/init.fedora
+++ b/init.fedora
@@ -23,7 +23,7 @@ lockfile=/var/lock/subsys/$prog
 ## the defaults
 username=${SB_USER-sickbeard}
 homedir=${SB_HOME-/opt/sickbeard}
-datadir=${SB_DATA-/home/sickbeard}
+datadir=${SB_DATA-~/.sickbeard}
 pidfile=${SB_PIDFILE-/var/run/sickbeard/sickbeard.pid}
 nice=${SB_NICE-}
 ##
@@ -35,6 +35,11 @@ options=" --daemon --pidfile=${pidfile} --datadir=${datadir}"
 if [ ! -d $pidpath ]; then
 	mkdir -p $pidpath
 	chown $username $pidpath
+fi
+
+if [ ! -d $datadir ]; then
+	mkdir -p $datadir
+	chown $username $datadir
 fi
 
 start() {

--- a/init.fedora
+++ b/init.fedora
@@ -23,12 +23,13 @@ lockfile=/var/lock/subsys/$prog
 ## the defaults
 username=${SB_USER-sickbeard}
 homedir=${SB_HOME-/opt/sickbeard}
+datadir=${SB_DATA-/home/sickbeard}
 pidfile=${SB_PIDFILE-/var/run/sickbeard/sickbeard.pid}
 nice=${SB_NICE-}
 ##
 
 pidpath=`dirname ${pidfile}`
-options=" --daemon --pidfile=${pidfile}"
+options=" --daemon --pidfile=${pidfile} --datadir=${datadir}"
 
 # create PID directory if not exist and ensure the SickBeard user can write to it
 if [ ! -d $pidpath ]; then

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -31,7 +31,7 @@ DESC=SickBeard
 RUN_AS=SICKBEARD_USER
 
 # data directory
-DATA_DIR=SICKBEARD_DATADIR
+DATA_DIR=~/.sickbeard
 
 # startup args
 DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
@@ -43,9 +43,15 @@ test -x $DAEMON || exit 0
 set -e
 
 if [ ! -d $PID_PATH ]; then
-        mkdir -p $PID_PATH
-        chown $RUN_AS $PID_PATH
+    mkdir -p $PID_PATH
+    chown $RUN_AS $PID_PATH
 fi
+
+if [ ! -d $DATA_DIR ]; then
+    mkdir -p $DATA_DIR
+    chown $RUN_AS $DATA_DIR
+fi
+
 
 case "$1" in
   start)

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -21,9 +21,6 @@ DAEMON=/usr/bin/python
 PID_FILE=/var/run/sickbeard/sickbeard.pid
 PID_PATH=`dirname $PID_FILE`
 
-# startup args
-DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE}"
-
 # script name
 NAME=sickbeard
 
@@ -32,6 +29,12 @@ DESC=SickBeard
 
 # user
 RUN_AS=SICKBEARD_USER
+
+# data directory
+DATA_DIR=SICKBEARD_DATADIR
+
+# startup args
+DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
 
 ############### END EDIT ME ##################
 
@@ -51,13 +54,12 @@ case "$1" in
         ;;
   stop)
         echo "Stopping $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE
+        start-stop-daemon --stop --pidfile $PID_FILE --retry 15
         ;;
 
   restart|force-reload)
         echo "Restarting $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE
-        sleep 15
+        start-stop-daemon --stop --pidfile $PID_FILE --retry 15
         start-stop-daemon -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;
   *)


### PR DESCRIPTION
Tweaking ubuntu and fedora init scripts to split out the data directory from the code directory.  Tweaked ubuntu init script to block until the daemon exits when stopping.
