### PR TITLE
Reactor and expanded the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,33 @@
-*.pyc
+#  SB User Related   #
+######################
 cache/*
 cache.db*
 config.ini
 Logs/*
 sickbeard.db*
 autoProcessTV/autoProcessTV.cfg
+
+#  Compiled source   #
+######################
+*.py[co]
+
+#  IDE specific      #
+######################
 *.bak
+*.tmp
+*.wpr
+*.project
+*.cproject
+*.tmproj
+*.tmproject
+
+# OS generated files #
+######################
+.Spotlight-V100
+.Trashes
 .DS_Store
+desktop.ini
+ehthumbs.db
+Thumbs.db
+.directory
+*~


### PR DESCRIPTION
Should eliminate problems for those running sickbeard on an external drive or those that want to use an IDE (eclipse/wing/textmate) with sickbeard without having to be mindful of un-versioned files.
