### PR TITLE
Don't always reset web_ipv6 to False on shutdown

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -398,7 +398,7 @@ def initialize(consoleLogging=True):
             WEB_PORT = 8081
 
         WEB_HOST = check_setting_str(CFG, 'General', 'web_host', '0.0.0.0')
-        WEB_IPV6 = bool(check_setting_int(CFG, 'General', 'web_ipv6', 0))
+        WEB_IPV6 = check_setting_int(CFG, 'General', 'web_ipv6', 0)
         WEB_ROOT = check_setting_str(CFG, 'General', 'web_root', '').rstrip("/")
         WEB_LOG = bool(check_setting_int(CFG, 'General', 'web_log', 0))
         WEB_USERNAME = check_setting_str(CFG, 'General', 'web_username', '')


### PR DESCRIPTION
web_ipv6 was being reset to false every restart. This fixes that.
