### PR TITLE
ui.notifications: snatched msg should not only have a title

### DIFF
--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -85,7 +85,7 @@ def _downloadResult(result):
         return False
 
     if newResult:
-        ui.notifications.message('Episode <b>%s</b> snatched from <b>%s</b>' % (result.name, resProvider.name))
+        ui.notifications.message('Episode snatched','<b>%s</b> snatched from <b>%s</b>' % (result.name, resProvider.name))
 
     return newResult
 


### PR DESCRIPTION
ui.notifications: snatched msg should not only have a title, it has a simple title "Episode Snatched" and the main msg in the body now

example pic : http://cl.ly/0E1n290r1z3t2q1F3u1u
