### PR TITLE
Added priority selecter for SABnzbd

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -172,6 +172,49 @@
                                     <span class="component-desc">Category for downloads to go into (eg. TV)</span>
                                 </label>
                             </div>
+
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">SABnzbd New Priority</span>
+                                    <select name="sab_prioritynew" id="sab_prioritynew">
+                                    #set $sab_prioritynew_text = {'-100': "Default Priority", '-2': "Paused", '-1': "Low Priority", '0': "Normal Priority", '1':"High Priority", '2':"Force" }
+                                    #for $curAction in ('-100', '-2', '-1', '0', '1'):
+                                      #if $sickbeard.SAB_PRIORITYNEW == $curAction:
+                                        #set $sab_prioritynew = "selected=\"selected\""
+                                      #else
+                                        #set $sab_prioritynew = ""
+                                      #end if
+                                    <option value="$curAction" $sab_prioritynew>$sab_prioritynew_text[$curAction]</option>
+                                    #end for
+                                    </select>
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Priority of new episodes for SABnzbd</span>
+                                </label>
+                            </div>
+
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">SABnzbd Old Priority</span>
+                                    <select name="sab_priorityold" id="sab_priorityold">
+                                    #set $sab_priorityold_text = {'-100': "Default Priority", '-2': "Paused", '-1': "Low Priority", '0': "Normal Priority", '1':"High Priority", '2':"Force" }
+                                    #for $curAction in ('-100', '-2', '-1', '0', '1'):
+                                      #if $sickbeard.SAB_PRIORITYOLD == $curAction:
+                                        #set $sab_priorityold = "selected=\"selected\""
+                                      #else
+                                        #set $sab_priorityold = ""
+                                      #end if
+                                    <option value="$curAction" $sab_priorityold>$sab_priorityold_text[$curAction]</option>
+                                    #end for
+                                    </select>
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Priority of old episodes for SABnzbd</span>
+                                </label>
+                            </div>
+
                         </div>
 
                         <div id="nzbget_settings">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -180,6 +180,9 @@ SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = ''
+SAB_PRIORITYOLD = ''
+SAB_PRIORITYNEW = ''
+
 
 NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
@@ -341,7 +344,7 @@ def initialize(consoleLogging=True):
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
-                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
+                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, SAB_PRIORITYNEW, SAB_PRIORITYOLD, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
@@ -515,6 +518,8 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
+        SAB_PRIORITYNEW = check_setting_str(CFG, 'SABnzbd', 'sab_prioritynew', '1')
+        SAB_PRIORITYOLD = check_setting_str(CFG, 'SABnzbd', 'sab_priorityold', '0')
 
         NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789')
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
@@ -1003,6 +1008,8 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
+    new_config['SABnzbd']['sab_prioritynew'] = SAB_PRIORITYNEW
+    new_config['SABnzbd']['sab_priorityold'] = SAB_PRIORITYOLD
 
     new_config['NZBget'] = {}
     new_config['NZBget']['nzbget_password'] = NZBGET_PASSWORD

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -42,11 +42,14 @@ def sendNZB(nzb):
         params['apikey'] = sickbeard.SAB_APIKEY
     if sickbeard.SAB_CATEGORY != None:
         params['cat'] = sickbeard.SAB_CATEGORY
+    if sickbeard.SAB_PRIORITYOLD != None:
+        params['priority'] = sickbeard.SAB_PRIORITYOLD
+
 
     # if it aired recently make it high priority
     for curEp in nzb.episodes:
         if datetime.date.today() - curEp.airdate <= datetime.timedelta(days=7):
-            params['priority'] = 1
+            params['priority'] = sickbeard.SAB_PRIORITYNEW
 
     # if it's a normal result we just pass SAB the URL
     if nzb.resultType == "nzb":


### PR DESCRIPTION
This allows you to set the priority of old (>7 days) and new episodes sent to sabnzbd. It may be useful for people who have more then just sickbeard pushing into SAB or for people like myself who run 2 sickbeards and want one of them to be a lower priority.
