### PR TITLE
Very small fix to handle occasional SSL errors that Prowl seems to generate from time-to-time

### DIFF
--- a/sickbeard/notifiers/prowl.py
+++ b/sickbeard/notifiers/prowl.py
@@ -64,10 +64,14 @@ class ProwlNotifier:
                 'description': message.encode('utf-8'),
                 'priority': prowl_priority }
 
-        http_handler.request("POST",
-                                "/publicapi/add",
-                                headers = {'Content-type': "application/x-www-form-urlencoded"},
-                                body = urlencode(data))
+        try:
+            http_handler.request("POST",
+                                    "/publicapi/add",
+                                    headers = {'Content-type': "application/x-www-form-urlencoded"},
+                                    body = urlencode(data))
+        except SSLError:
+            logger.log(u"Prowl notification failed.", logger.ERROR)
+            return False
         response = http_handler.getresponse()
         request_status = response.status
 


### PR DESCRIPTION
Occasionally after something downloads and Sick Beard tries to notify me, the Prowl API seems to generate some kind of an error related to SSL negotiation (which looks like a server-side issue).

All I've added is a try:except block to handle the errors produced when this happens, which should mean that SabNZBD+ is properly notified of the post-processing script completion, even if the notification failed.

Also, thanks a lot for Sick Beard. It's made a massive difference to how I watch TV.
