### PR TITLE
Security: Separated settings from init.ubuntu to default.ubuntu and added logging

### DIFF
--- a/defaults.ubuntu
+++ b/defaults.ubuntu
@@ -7,11 +7,14 @@
 # leaving any required setting unconfigured will cause
 # the service to not start.
 
-# [optional] change to 1 to enable daemon
-ENABLE_DAEMON=0
+# [required] set path where sickbeard is installed:
+APP_PATH=/opt/sickbeard
 
 # [required] user or uid of account to run the program as:
 RUN_AS=
+
+# [optional] change to 1 to enable daemon
+ENABLE_DAEMON=0
 
 # [optional] change to 1 to enable updating from webinterface
 # this changes ownership of sickbeard's programfiles to user set @ RUN_AS
@@ -26,7 +29,7 @@ CONFIG=
 DATADIR=
 
 # [optional] port number to listen on:
-PORT=8081
+PORT=
 
 # [optional] full path for the pidfile
 # otherwise, the default location /var/run/sickbeard.pid is used:

--- a/defaults.ubuntu
+++ b/defaults.ubuntu
@@ -1,0 +1,33 @@
+# This file is sourced by /etc/init.d/sickbeard
+#
+# When sickbeard is started using the init script
+# is started under the account of $USER, as set below.
+#
+# Each setting is marked either "required" or "optional";
+# leaving any required setting unconfigured will cause
+# the service to not start.
+
+# [optional] change to 1 to enable daemon
+ENABLE_DAEMON=0
+
+# [required] user or uid of account to run the program as:
+RUN_AS=
+
+# [optional] change to 1 to enable updating from webinterface
+# this changes ownership of sickbeard's programfiles to user set @ RUN_AS
+WEB_UPDATE=0
+
+# [optional] full path to the configuration file of your choice;
+# otherwise, the default location (~/.sickbeard) is used:
+CONFIG=
+
+# [optional] full path to the folder to store data (databases/thumbs) in;
+# otherwise, the default location (~/.sickbeard) is used:
+DATADIR=
+
+# [optional] port number to listen on:
+PORT=8081
+
+# [optional] full path for the pidfile
+# otherwise, the default location /var/run/sickbeard.pid is used:
+PID_FILE=

--- a/defaults.ubuntu
+++ b/defaults.ubuntu
@@ -32,5 +32,5 @@ DATADIR=
 PORT=
 
 # [optional] full path for the pidfile
-# otherwise, the default location /var/run/sickbeard.pid is used:
+# otherwise, the default location /var/run/sickbeard/sickbeard.pid is used:
 PID_FILE=

--- a/defaults.ubuntu
+++ b/defaults.ubuntu
@@ -10,11 +10,11 @@
 # [required] set path where sickbeard is installed:
 APP_PATH=/opt/sickbeard
 
-# [required] user or uid of account to run the program as:
-RUN_AS=
-
 # [optional] change to 1 to enable daemon
 ENABLE_DAEMON=0
+
+# [required] user or uid of account to run the program as:
+RUN_AS=
 
 # [optional] change to 1 to enable updating from webinterface
 # this changes ownership of sickbeard's programfiles to user set @ RUN_AS

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -68,7 +68,7 @@ load_settings() {
             return 1; }
         [ -z "${RUN_AS%:*}" ] && exit 1
 
-        DAEMON_OPTS="SickBeard.py --quiet --daemon"
+        DAEMON_OPTS="SickBeard.py --quiet --daemon --nolaunch"
         [ -n "$CONFIG" ] && DAEMON_OPTS="$DAEMON_OPTS --config=$CONFIG"
         [ -z "$CONFIG" ] && DAEMON_OPTS="$DAEMON_OPTS --config=/home/$RUN_AS/.sickbeard/config.ini"
         [ -n "$DATADIR" ] && DAEMON_OPTS="$DAEMON_OPTS --datadir=$DATADIR"

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -24,7 +24,6 @@
 DAEMON=/usr/bin/python
 SETTINGS=/etc/default/sickbeard
 
-APP_PATH=/opt/sickbeard
 SETTINGS_LOADED=FALSE
 
 DESC=SickBeard
@@ -55,6 +54,10 @@ check_retval() {
 load_settings() {
     if [ $SETTINGS_LOADED != "TRUE" ]; then
         . $SETTINGS
+
+        [ -n "$APP_PATH" ] || {
+            log_warning_msg "$DESC: path to $DESC not set, aborting. See $SETTINGS";
+            return 1; }
 
         [ $ENABLE_DAEMON != 1 ] && {
             log_warning_msg "$DESC: daemon not enabled, aborting. See $SETTINGS";

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -20,12 +20,11 @@
 # Description:       starts instance of SickBeard using start-stop-daemon
 ### END INIT INFO
 
-set -e
-
 # main variables
 DAEMON=/usr/bin/python
 SETTINGS=/etc/default/sickbeard
 
+APP_PATH=/opt/sickbeard
 SETTINGS_LOADED=FALSE
 
 DESC=SickBeard
@@ -56,10 +55,6 @@ check_retval() {
 load_settings() {
     if [ $SETTINGS_LOADED != "TRUE" ]; then
         . $SETTINGS
-        
-        [ -n "$APP_PATH" ] || {
-            log_warning_msg "$DESC: path to $DESC not set, aborting. See $SETTINGS";
-            return 1; }
 
         [ $ENABLE_DAEMON != 1 ] && {
             log_warning_msg "$DESC: daemon not enabled, aborting. See $SETTINGS";
@@ -87,42 +82,60 @@ load_settings() {
 
 load_settings || exit 0
 
+is_running () {
+    # returns 1 when running, else 0.
+    PID=$(pgrep -f "$DAEMON_OPTS")
+    RET=$?
+    [ $RET -gt 1 ] && exit 1 || return $RET
+}
+
 handle_pid () {
-PID_PATH=`dirname $PID_FILE`
-[ -d $PID_PATH ] || mkdir -p $PID_PATH && chown -R $RUN_AS $PID_PATH > /dev/null || {
-    log_warning_msg "$DESC: Could not create $PID_FILE, aborting.";
-    return 1;}
+    PID_PATH=`dirname $PID_FILE`
+    [ -d $PID_PATH ] || mkdir -p $PID_PATH && chown -R $RUN_AS $PID_PATH > /dev/null || {
+        log_warning_msg "$DESC: Could not create $PID_FILE, aborting.";
+        return 1;}
 }
 
 enable_updates () {
-chown -R $RUN_AS $APP_PATH > /dev/null || {
-    log_warning_msg "$DESC: $APP_PATH not writable for web-updates, See $SETTINGS";
-    return 0; }
+    chown -R $RUN_AS $APP_PATH > /dev/null || {
+        log_warning_msg "$DESC: $APP_PATH not writable for web-updates, See $SETTINGS";
+        return 0; }
+}
+
+start_sickbeard () {
+    if ! is_running; then
+        log_daemon_msg "Starting $DESC"
+        [ "$WEB_UPDATE" = 1 ] && enable_updates
+        handle_pid
+        start-stop-daemon -o -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+        check_retval
+    else
+        log_success_msg "$DESC: already running (pid $PID)"
+    fi
+}
+
+stop_sickbeard () {
+    if is_running; then
+        log_daemon_msg "Stopping $DESC"
+        start-stop-daemon -o --stop --pidfile $PID_FILE --retry 15
+        check_retval
+    else
+        log_success_msg "$DESC: not running"
+    fi
 }
 
 case "$1" in
-  start)
-    echo "Starting $DESC"
-    [ "$WEB_UPDATE" = 1 ] && enable_updates
-    handle_pid
-    start-stop-daemon -o -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
-    check_retval
-    ;;
-  stop)
-        echo "Stopping $DESC"
-        start-stop-daemon -o --stop --pidfile $PID_FILE --retry 15
-        check_retval
+    start)
+        start_sickbeard
         ;;
-
-  restart|force-reload)
-        echo "Stopping $DESC"
-        start-stop-daemon -o --stop --pidfile $PID_FILE --retry 15
-        check_retval
-        [ "$WEB_UPDATE" = 1 ] && enable_updates
-        start-stop-daemon -o -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
-        check_retval
+    stop)
+        stop_sickbeard
         ;;
-  *)
+    restart|force-reload)
+        stop_sickbeard
+        start_sickbeard
+        ;;
+    *)
         N=/etc/init.d/$NAME
         echo "Usage: $N {start|stop|restart|force-reload}" >&2
         exit 1

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -105,20 +105,22 @@ case "$1" in
     echo "Starting $DESC"
     [ "$WEB_UPDATE" = 1 ] && enable_updates
     handle_pid
-    start-stop-daemon -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+    start-stop-daemon -o -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+    check_retval
     ;;
   stop)
         echo "Stopping $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+        start-stop-daemon -o --stop --pidfile $PID_FILE --retry 15
         check_retval
         ;;
 
   restart|force-reload)
-        echo "Restarting $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+        echo "Stopping $DESC"
+        start-stop-daemon -o --stop --pidfile $PID_FILE --retry 15
         check_retval
         [ "$WEB_UPDATE" = 1 ] && enable_updates
-        start-stop-daemon -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+        start-stop-daemon -o -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+        check_retval
         ;;
   *)
         N=/etc/init.d/$NAME

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -26,7 +26,6 @@ set -e
 DAEMON=/usr/bin/python
 SETTINGS=/etc/default/sickbeard
 
-APP_PATH=/opt/sickbeard
 SETTINGS_LOADED=FALSE
 
 DESC=SickBeard
@@ -57,6 +56,10 @@ check_retval() {
 load_settings() {
     if [ $SETTINGS_LOADED != "TRUE" ]; then
         . $SETTINGS
+        
+        [ -n "$APP_PATH" ] || {
+            log_warning_msg "$DESC: path to $DESC not set, aborting. See $SETTINGS";
+            return 1; }
 
         [ $ENABLE_DAEMON != 1 ] && {
             log_warning_msg "$DESC: daemon not enabled, aborting. See $SETTINGS";

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -1,71 +1,120 @@
 #! /bin/sh
 
+# Copyright (C) 2011- by Mar2zz <LaSi.Mar2zz@gmail.com>
+# released under GPL, version 2 or later
+
+
+################################################
+#                                              #
+#  TO CONFIGURE EDIT /etc/default/sickbeard
+#                                              #
+################################################
+
 ### BEGIN INIT INFO
-# Provides:          Sick Beard application instance
+# Provides:          SickBeard application instance
 # Required-Start:    $all
 # Required-Stop:     $all
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: starts instance of Sick Beard
-# Description:       starts instance of Sick Beard using start-stop-daemon
+# Short-Description: starts instance of SickBeard
+# Description:       starts instance of SickBeard using start-stop-daemon
 ### END INIT INFO
-
-############### EDIT ME ##################
-# path to app
-APP_PATH=PATH_TO_SICKBEARD_DIRECTORY
-
-# path to python bin
-DAEMON=/usr/bin/python
-
-# Path to store PID file
-PID_FILE=/var/run/sickbeard/sickbeard.pid
-PID_PATH=`dirname $PID_FILE`
-
-# script name
-NAME=sickbeard
-
-# app name
-DESC=SickBeard
-
-# user
-RUN_AS=SICKBEARD_USER
-
-# data directory
-DATA_DIR=~/.sickbeard
-
-# startup args
-DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
-
-############### END EDIT ME ##################
-
-test -x $DAEMON || exit 0
 
 set -e
 
-if [ ! -d $PID_PATH ]; then
-    mkdir -p $PID_PATH
-    chown $RUN_AS $PID_PATH
-fi
+# main variables
+DAEMON=/usr/bin/python
+SETTINGS=/etc/default/sickbeard
 
-if [ ! -d $DATA_DIR ]; then
-    mkdir -p $DATA_DIR
-    chown $RUN_AS $DATA_DIR
-fi
+APP_PATH=/opt/sickbeard
+SETTINGS_LOADED=FALSE
 
+DESC=SickBeard
+
+# only accept values from /etc/default/sickbeard
+unset RUN_AS CONFIG DATADIR PORT PID_FILE
+
+. /lib/lsb/init-functions
+
+[ -x $DAEMON ] || {
+    log_warning_msg "$DESC: Can't execute daemon, aborting. See $DAEMON";
+    return 1; }
+
+[ -r $SETTINGS ] || {
+    log_warning_msg "$DESC: Can't read settings, aborting. See $SETTINGS";
+    return 1; }
+
+check_retval() {
+    if [ $? -eq 0 ]; then
+        log_end_msg 0
+        return 0
+    else
+        log_end_msg 1
+        exit 1
+    fi
+}
+
+load_settings() {
+    if [ $SETTINGS_LOADED != "TRUE" ]; then
+        . $SETTINGS
+
+        [ $ENABLE_DAEMON != 1 ] && {
+            log_warning_msg "$DESC: daemon not enabled, aborting. See $SETTINGS";
+            return 1; }
+
+        [ -z "$RUN_AS" ] && {
+            log_warning_msg "$DESC: daemon username not set, aborting. See $SETTINGS";
+            return 1; }
+        [ -z "${RUN_AS%:*}" ] && exit 1
+
+        DAEMON_OPTS="SickBeard.py --quiet --daemon"
+        [ -n "$CONFIG" ] && DAEMON_OPTS="$DAEMON_OPTS --config=$CONFIG"
+        [ -z "$CONFIG" ] && DAEMON_OPTS="$DAEMON_OPTS --config=/home/$RUN_AS/.sickbeard/config.ini"
+        [ -n "$DATADIR" ] && DAEMON_OPTS="$DAEMON_OPTS --datadir=$DATADIR"
+        [ -z "$DATADIR" ] && DAEMON_OPTS="$DAEMON_OPTS --datadir=/home/$RUN_AS/.sickbeard"
+        [ -n "$PORT" ] && DAEMON_OPTS="$DAEMON_OPTS --port=$PORT"
+        if ! [ -n "$PID_FILE" ]; then
+            PID_FILE=/var/run/sickbeard/sickbeard.pid
+        fi
+        DAEMON_OPTS="$DAEMON_OPTS --pidfile=$PID_FILE"
+        SETTINGS_LOADED=TRUE
+    fi
+    return 0
+}
+
+load_settings || exit 0
+
+handle_pid () {
+PID_PATH=`dirname $PID_FILE`
+[ -d $PID_PATH ] || mkdir -p $PID_PATH && chown -R $RUN_AS $PID_PATH > /dev/null || {
+    log_warning_msg "$DESC: Could not create $PID_FILE, aborting.";
+    return 1;}
+}
+
+enable_updates () {
+chown -R $RUN_AS $APP_PATH > /dev/null || {
+    log_warning_msg "$DESC: $APP_PATH not writable for web-updates, See $SETTINGS";
+    return 0; }
+}
 
 case "$1" in
   start)
-        echo "Starting $DESC"
-        start-stop-daemon -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
-        ;;
+    echo "Starting $DESC"
+    [ "$WEB_UPDATE" = 1 ] && enable_updates
+    handle_pid
+    start-stop-daemon -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
+    ;;
   stop)
         echo "Stopping $DESC"
         start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+        check_retval
         ;;
 
   restart|force-reload)
         echo "Restarting $DESC"
         start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+        check_retval
+        [ "$WEB_UPDATE" = 1 ] && enable_updates
         start-stop-daemon -d $APP_PATH -c $RUN_AS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;
   *)


### PR DESCRIPTION
These two files are for daemon use. Settings can be edited in default.ubuntu, which needs to be in /etc/default/sickbeard. init.ubuntu will read this settings file and will log if the daemon isn't set correct. This way an install can be done inside /opt or other folders owned by root, so root is owner (secure) and all data and config will be in a folder of choice, or by default in ~/.sickbeard. updating through web_interface is made optional, can be set in /etc/default/sickbeard, so there is only one user (set by root) that can update sickbeard (also secure).

This is also easy for running multiple sickbeard-instances with one sickbeard source, or different branches. (use 2 init.d's-scripts and 2 settings-scripts)
