### PR TITLE
Movedir

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -72,6 +72,14 @@
                         </div>
 
                         <div class="field-pair">
+                            <input type="checkbox" name="move_entire_dir" id="move_entire_dir" #if $sickbeard.MOVE_ENTIRE_DIR == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="move_entire_dir">
+                                <span class="component-title">Move directory</span>
+                                <span class="component-desc">Move the entire directory?</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <input type="checkbox" name="rename_episodes" id="rename_episodes" #if $sickbeard.RENAME_EPISODES == True then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="rename_episodes">
                                 <span class="component-title">Rename Episodes</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -155,6 +155,7 @@ RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
 MOVE_ASSOCIATED_FILES = False
+MOVE_ENTIRE_DIR = False
 TV_DOWNLOAD_DIR = None
 
 NZBS = False
@@ -364,7 +365,7 @@ def initialize(consoleLogging=True):
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
-                NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
+                NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, MOVE_ENTIRE_DIR, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS
 
         if __INITIALIZED__:
@@ -483,6 +484,7 @@ def initialize(consoleLogging=True):
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
+        MOVE_ENTIRE_DIR = check_setting_int(CFG, 'General', 'move_entire_dir', 0)
 
         EZRSS = bool(check_setting_int(CFG, 'General', 'use_torrent', 0))
         if not EZRSS:
@@ -955,6 +957,7 @@ def save_config():
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
+    new_config['General']['move_entire_dir'] = int(MOVE_ENTIRE_DIR)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
     

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -27,7 +27,7 @@ USER_AGENT = 'Sick Beard/alpha2-'+version.SICKBEARD_VERSION.replace(' ','-')+' (
 mediaExtensions = ['avi', 'mkv', 'mpg', 'mpeg', 'wmv',
                    'ogm', 'mp4', 'iso', 'img', 'divx',
                    'm2ts', 'm4v', 'ts', 'flv', 'f4v',
-                   'mov', 'rmvb', 'vob', 'dvr-ms', 'wtv',
+                   'mov', 'rmvb', 'vob', 'dvr-ms', 'wtv', 'sfv',
                    ]
 
 ### Other constants

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -406,6 +406,18 @@ def moveFile(srcFile, destFile):
         copyFile(srcFile, destFile)
         ek.ek(os.unlink, srcFile)
 
+def copyDir(srcDir, destDir):
+    try:
+       ek.ek(shutil.copytree, srcDir, destDir)
+    except OSError:
+       logger.log(u"Failed copying " + srcDir + " to " + destDir)
+
+def moveDir(srcDir, destDir):
+    try:
+       ek.ek(shutil.move, srcDir, destDir)
+    except OSError:
+       logger.log(u"Failed moving " + srcDir + " to " + destDir)
+
 def rename_file(old_path, new_name):
 
     old_path_list = ek.ek(os.path.split, old_path)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -699,9 +699,9 @@ class PostProcessor(object):
         try:
             if sickbeard.MOVE_ENTIRE_DIR:
                 if sickbeard.KEEP_PROCESSED_DIR:
-                   helpers.copyDir(os.path.dirname(self.file_path), os.path.join(dest_path, self.folder_name))
+                    helpers.copyDir(os.path.dirname(self.file_path), os.path.join(dest_path, self.folder_name))
                 else:
-                   helpers.moveDir(os.path.dirname(self.file_path), dest_path)
+                    helpers.moveDir(os.path.dirname(self.file_path), dest_path)
             else:
                 # move the episode and associated files to the show dir
                 if sickbeard.KEEP_PROCESSED_DIR:

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -107,7 +107,7 @@ def processDir (dirName, nzbName=None, recurse=False):
 
             if len(videoFiles) == 1 and not sickbeard.KEEP_PROCESSED_DIR and \
                 ek.ek(os.path.normpath, dirName) != ek.ek(os.path.normpath, sickbeard.TV_DOWNLOAD_DIR) and \
-                len(remainingFolders) == 0:
+                len(remainingFolders) == 0 and not sickbeard.MOVE_ENTIRE_DIR:
 
                 returnStr += logHelper(u"Deleting folder " + dirName, logger.DEBUG)
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -364,11 +364,14 @@ class TVShow(object):
 
     # make a TVEpisode object from a media file
     def makeEpFromFile(self, file):
-
         if not ek.ek(os.path.isfile, file):
             logger.log(str(self.tvdbid) + ": That isn't even a real file dude... " + file)
             return None
-
+        
+        # If working with movedir, pass the current folder
+        if sickbeard.MOVE_ENTIRE_DIR:
+            fileName = file
+            file = os.path.dirname(file)
         logger.log(str(self.tvdbid) + ": Creating episode object from " + file, logger.DEBUG)
 
         try:
@@ -448,8 +451,8 @@ class TVShow(object):
                 if newQuality != Quality.UNKNOWN:
                     curEp.status = Quality.compositeStatus(DOWNLOADED, newQuality)
 
-
-            elif sickbeard.helpers.isMediaFile(file) and curEp.status not in Quality.DOWNLOADED + [ARCHIVED, IGNORED]:
+            
+            elif (sickbeard.helpers.isMediaFile(file) or sickbeard.helpers.isMediaFile(fileName)) and curEp.status not in Quality.DOWNLOADED + [ARCHIVED, IGNORED]:
 
                 oldStatus, oldQuality = Quality.splitCompositeStatus(curEp.status)
                 newQuality = Quality.nameQuality(file)
@@ -714,7 +717,9 @@ class TVShow(object):
 
             # if the path doesn't exist or if it's not in our show dir
             if not ek.ek(os.path.isfile, curLoc) or not os.path.normpath(curLoc).startswith(os.path.normpath(self.location)):
-
+                if sickbeard.MOVE_ENTIRE_DIR:
+                    if ek.ek(os.path.isdir, curLoc):
+                        return
                 with curEp.lock:
                     # if it used to have a file associated with it and it doesn't anymore then set it to IGNORED
                     if curEp.location and curEp.status in Quality.DOWNLOADED:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -777,7 +777,7 @@ class ConfigPostProcessing:
                     naming_sep_type=None, naming_quality=None, naming_dates=None,
                     xbmc_data=None, mediabrowser_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
-                    move_associated_files=None, tv_download_dir=None):
+                    move_associated_files=None, move_entire_dir=None, tv_download_dir=None):
 
         results = []
 
@@ -834,10 +834,17 @@ class ConfigPostProcessing:
         else:
             move_associated_files = 0
 
+        if move_entire_dir == "on":
+            move_entire_dir = 1
+        else:
+            move_entire_dir = 0
+
+
         sickbeard.PROCESS_AUTOMATICALLY = process_automatically
         sickbeard.KEEP_PROCESSED_DIR = keep_processed_dir
         sickbeard.RENAME_EPISODES = rename_episodes
         sickbeard.MOVE_ASSOCIATED_FILES = move_associated_files
+        sickbeard.MOVE_ENTIRE_DIR = move_entire_dir
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)


### PR DESCRIPTION
Added a new post-processing option called "Move entire dir". If users check this option, it will move the     entire folder of a TV episode, instead of just the content, to the proper season folder.
## Example:

TV Downloads folder: /home/tv_complete/
TV Shows folder: /home/tv_shows/

Terra.Nova.S01E03.720p.HDTV.X264-DIMENSION gets moved by the usenet/torrent client to /home/tv_complete/

Instead of just looking for a media file in that folder, SickBeard will (with the Move Entire Dir option checked)
now move Terra.Nova.S01E03.720p.HDTV.X264-DIMENSION to /home/tv_shows/Season 01/Terra.Nova.S01E03.720p.HDTV.X264-DIMENSION

This is very useful for users who want to use SickBeard but still keep the original files of the episode. XBMC, along with many other media players allow playback from .rar files, so it is not necessary to extract them.
