### PR TITLE
TVDB doesn't sanitize \r (CR) from user input in some fields. Let's strip

### DIFF
--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -537,11 +537,11 @@ class Tvdb:
         """
         src = self._loadUrl(url)
         try:
-            return ElementTree.fromstring(src)
+            return ElementTree.fromstring(src.rstrip('\r'))
         except SyntaxError:
             src = self._loadUrl(url, recache=True)
             try:
-                return ElementTree.fromstring(src)
+                return ElementTree.fromstring(src.rstrip('\r'))
             except SyntaxError, exceptionmsg:
                 errormsg = "There was an error with the XML retrieved from thetvdb.com:\n%s" % (
                     exceptionmsg


### PR DESCRIPTION
TVDB doesn't sanitize \r (CR) from user input in some fields. Let's strip it from the entire response, since it breaks xml parsing. Fix via will14m on irc.
