### PR TITLE
Correct bug in python-twitter lib on non-posix OS'en.

### DIFF
--- a/lib/pythontwitter/__init__.py
+++ b/lib/pythontwitter/__init__.py
@@ -3108,7 +3108,7 @@ class _FileCache(object):
              os.getenv('USERNAME') or \
              os.getlogin() or \
              'nobody'
-    except (IOError, OSError), e:
+    except (AttributeError, IOError, OSError), e:
       return 'nobody'
 
   def _GetTmpCachePath(self):


### PR DESCRIPTION
AttributeError is thrown when os.getlogin() is called on an OS that doesn't support it (win*, symbian for example). This handles it and doesn't error out.
