### PR TITLE
Fix viewlog dropdown regression.

### DIFF
--- a/data/interfaces/default/viewlogs.tmpl
+++ b/data/interfaces/default/viewlogs.tmpl
@@ -14,7 +14,7 @@
 <!--
 \$(document).ready(function(){
     \$('#minLevel').change(function(){
-        url = 'viewlog?minLevel='+\$(this).val()
+        url = '$sbRoot/errorlogs/viewlog/?minLevel='+\$(this).val()
         window.location.href = url
     });
 });


### PR DESCRIPTION
The dropdown on /errorlogs/viewlog/ was no longer working after
b028d867973f6b31846938860de62d3b43c316d0, due to a trailing slash being added.

This makes the JS that changes the URL when you select a new dropdown value use
absolute paths.
