### PR TITLE
Update metadata of wdtv

### DIFF
--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -16,14 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
 import os
 import re
 
+import sickbeard
+
 import generic
 
-from sickbeard import logger, helpers
-
+from sickbeard.common import XML_NSMAP
+from sickbeard import logger, exceptions, helpers
 from sickbeard import encodingKludge as ek
+from lib.tvdb_api import tvdb_api, tvdb_exceptions
+from sickbeard.exceptions import ex
+
+import xml.etree.cElementTree as etree
 
 class WDTVMetadata(generic.GenericMetadata):
     """
@@ -32,8 +39,9 @@ class WDTVMetadata(generic.GenericMetadata):
     The following file structure is used:
     
     show_root/folder.jpg                                     (poster)
-    show_root/Season 01/folder.jpg                           (episode thumb)
-    show_root/Season 01/show - 1x01 - episode.jpg            (existing video)
+    show_root/Season 01/folder.jpg                           (season thumb)
+    show_root/Season 01/show - 1x01 - episode.metathumb      (episode thumb)
+    show_root/Season 01/show - 1x01 - episode.xml            (episode metadata)
     """
     
     def __init__(self,
@@ -52,20 +60,19 @@ class WDTVMetadata(generic.GenericMetadata):
                                          episode_thumbnails,
                                          season_thumbnails)
         
+        self._ep_nfo_extension = 'xml'
+
         self.name = 'WDTV'
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "<i>not supported</i>"
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
         self.eg_fanart = "<i>not supported</i>"
         self.eg_poster = "folder.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
         self.eg_season_thumbnails = "Season##\\folder.jpg"
     
     # all of the following are not supported, so do nothing
     def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_episode_metadata(self, ep_obj):
         pass
     
     def create_fanart(self, show_obj):
@@ -74,12 +81,12 @@ class WDTVMetadata(generic.GenericMetadata):
     def get_episode_thumb_path(self, ep_obj):
         """
         Returns the path where the episode thumbnail should be stored. Defaults to
-        the same path as the episode file but with a .cover.jpg extension.
+        the same path as the episode file but with a .metathumb extension.
         
         ep_obj: a TVEpisode instance for which to create the thumbnail
         """
         if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_filename = helpers.replaceExtension(ep_obj.location, 'jpg')
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
         else:
             return None
 
@@ -87,7 +94,7 @@ class WDTVMetadata(generic.GenericMetadata):
     
     def get_season_thumb_path(self, show_obj, season):
         """
-        Season thumbs for MediaBrowser go in Show Dir/Season X/folder.jpg
+        Season thumbs for WDTV go in Show Dir/Season X/folder.jpg
         
         If no season folder exists, None is returned
         """
@@ -120,6 +127,96 @@ class WDTVMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def _ep_data(self, ep_obj):
+        """
+        Creates an elementTree XML structure for a WDTV style episode.xml
+        and returns the resulting data object.
+        
+        ep_obj: a TVShow instance to create the NFO for
+        """
+        
+        eps_to_write = [ep_obj] + ep_obj.relatedEps
+        
+        tvdb_lang = ep_obj.show.lang
+    
+        try:
+            # There's gotta be a better way of doing this but we don't wanna
+            # change the language value elsewhere
+            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+            if tvdb_lang and not tvdb_lang == 'en':
+                ltvdb_api_parms['language'] = tvdb_lang
+
+            t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+            myShow = t[ep_obj.show.tvdbid]
+        except tvdb_exceptions.tvdb_shownotfound, e:
+            raise exceptions.ShowNotFoundException(e.message)
+        except tvdb_exceptions.tvdb_error, e:
+            logger.log("Unable to connect to TVDB while creating meta files - skipping - "+ex(e), logger.ERROR)
+            return False
+
+        rootNode = etree.Element("details")
+
+        # write an WDTV XML containing info for all matching episodes
+        for curEpToWrite in eps_to_write:
+        
+            try:
+                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+            except (tvdb_exceptions.tvdb_episodenotfound, tvdb_exceptions.tvdb_seasonnotfound):
+                logger.log("Unable to find episode " + str(curEpToWrite.season) + "x" + str(curEpToWrite.episode) + " on tvdb... has it been removed? Should I delete from db?")
+                return None
+            
+            if myEp["firstaired"] == None and ep_obj.season == 0:
+                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+            
+            if myEp["episodename"] == None or myEp["firstaired"] == None:
+                return None
+                
+            if len(eps_to_write) > 1:
+                episode = etree.SubElement(rootNode, "details")
+            else:
+                episode = rootNode
+            logger.log(str(curEpToWrite), logger.ERROR)
+            
+            #To do get right EpisodeID
+            episodeID = etree.SubElement(episode, "id")
+            episodeID.text = str(curEpToWrite.tvdbid)
+
+            seriesName = etree.SubElement(episode, "series_name")
+            if curEpToWrite.show_name != None:
+                seriesName.text = curEpToWrite.show_name
+
+            title = etree.SubElement(episode, "episode_name")
+            if curEpToWrite.name != None:
+                title.text = curEpToWrite.name
+
+            seasonNumber = etree.SubElement(episode, "season_number")
+            seasonNumber.text = str(curEpToWrite.season)
+                
+            episodeNum = etree.SubElement(episode, "episode_number")
+            episodeNum.text = str(curEpToWrite.episode)
+            
+            FirstAired = etree.SubElement(episode, "firstaired")
+            if curEpToWrite.airdate != datetime.date.fromordinal(1):
+                FirstAired.text = str(curEpToWrite.airdate)
+            else:
+                FirstAired.text = ''
+
+            Overview = etree.SubElement(episode, "overview")
+            if curEpToWrite.description != None:
+                Overview.text = curEpToWrite.description
+
+            director = etree.SubElement(episode, "director")
+            director_text = myEp['director']
+            if director_text != None:
+                director.text = director_text
+
+            # Make it purdy
+            helpers.indentXML(rootNode)
+            data = etree.ElementTree(rootNode)
+
+        return data
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -177,19 +177,22 @@ class WDTVMetadata(generic.GenericMetadata):
                 episode = etree.SubElement(rootNode, "details")
             else:
                 episode = rootNode
-            logger.log(str(curEpToWrite), logger.ERROR)
             
             #To do get right EpisodeID
             episodeID = etree.SubElement(episode, "id")
             episodeID.text = str(curEpToWrite.tvdbid)
 
-            seriesName = etree.SubElement(episode, "series_name")
-            if curEpToWrite.show_name != None:
-                seriesName.text = curEpToWrite.show_name
+            title = etree.SubElement(episode, "title")
+            if myShow["seriesname"] != None or curEpToWrite.name != None : 
+                title.text = myShow["seriesname"] + " - S" + str(curEpToWrite.season).zfill(2) + "E" + str(curEpToWrite.episode).zfill(2) + " - " + curEpToWrite.name
 
-            title = etree.SubElement(episode, "episode_name")
+            seriesName = etree.SubElement(episode, "series_name")
+            if myShow["seriesname"] != None:
+                seriesName.text = myShow["seriesname"]
+
+            episodeName = etree.SubElement(episode, "episode_name")
             if curEpToWrite.name != None:
-                title.text = curEpToWrite.name
+                episodeName.text = curEpToWrite.name
 
             seasonNumber = etree.SubElement(episode, "season_number")
             seasonNumber.text = str(curEpToWrite.season)
@@ -197,20 +200,32 @@ class WDTVMetadata(generic.GenericMetadata):
             episodeNum = etree.SubElement(episode, "episode_number")
             episodeNum.text = str(curEpToWrite.episode)
             
-            FirstAired = etree.SubElement(episode, "firstaired")
+            firstAired = etree.SubElement(episode, "firstaired")
             if curEpToWrite.airdate != datetime.date.fromordinal(1):
-                FirstAired.text = str(curEpToWrite.airdate)
+                firstAired.text = str(curEpToWrite.airdate)
             else:
-                FirstAired.text = ''
+                firstAired.text = ''
 
-            Overview = etree.SubElement(episode, "overview")
-            if curEpToWrite.description != None:
-                Overview.text = curEpToWrite.description
+            genre = etree.SubElement(episode, "genre")
+            if myShow["genre"] != None:
+                genre.text = " / ".join([x for x in myShow["genre"].split('|') if x])
 
             director = etree.SubElement(episode, "director")
             director_text = myEp['director']
             if director_text != None:
                 director.text = director_text
+            else:
+                director.text = ''
+
+            actor = etree.SubElement(episode, "actor")
+            if myShow["actors"] != None:
+                actor.text = " / ".join([x for x in myShow["actors"].split('|') if x])
+            else:
+                actor.text = ''
+
+            overview = etree.SubElement(episode, "overview")
+            if curEpToWrite.description != None:
+                overview.text = curEpToWrite.description
 
             # Make it purdy
             helpers.indentXML(rootNode)
@@ -223,4 +238,3 @@ class WDTVMetadata(generic.GenericMetadata):
 
 # present a standard "interface"
 metadata_class = WDTVMetadata
-

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -184,7 +184,7 @@ class WDTVMetadata(generic.GenericMetadata):
 
             title = etree.SubElement(episode, "title")
             if myShow["seriesname"] != None or curEpToWrite.name != None : 
-                title.text = myShow["seriesname"] + " - S" + str(curEpToWrite.season).zfill(2) + "E" + str(curEpToWrite.episode).zfill(2) + " - " + curEpToWrite.name
+                title.text = ep_obj.prettyName()
 
             seriesName = etree.SubElement(episode, "series_name")
             if myShow["seriesname"] != None:
@@ -203,8 +203,6 @@ class WDTVMetadata(generic.GenericMetadata):
             firstAired = etree.SubElement(episode, "firstaired")
             if curEpToWrite.airdate != datetime.date.fromordinal(1):
                 firstAired.text = str(curEpToWrite.airdate)
-            else:
-                firstAired.text = ''
 
             genre = etree.SubElement(episode, "genre")
             if myShow["genre"] != None:
@@ -214,14 +212,10 @@ class WDTVMetadata(generic.GenericMetadata):
             director_text = myEp['director']
             if director_text != None:
                 director.text = director_text
-            else:
-                director.text = ''
 
             actor = etree.SubElement(episode, "actor")
             if myShow["actors"] != None:
                 actor.text = " / ".join([x for x in myShow["actors"].split('|') if x])
-            else:
-                actor.text = ''
 
             overview = etree.SubElement(episode, "overview")
             if curEpToWrite.description != None:


### PR DESCRIPTION
I have modified wdtv metadata creation make it useful (using last firmware) like issue 1761 http://code.google.com/p/sickbeard/issues/detail?id=1761

Missing some tag but a good starting point.

I'm not a python programmers and i don't know sickbeard sorce code so, for now, i dont know how add "title" and "series_name".
With this two all useful tags is done
