### PR TITLE
Init script fix

### DIFF
--- a/init.fedora
+++ b/init.fedora
@@ -1,5 +1,5 @@
 ### BEGIN INIT INFO
-# Provides:          Sick Beard application instance
+# Provides:          sickbeard
 # Required-Start:    $all
 # Required-Stop:     $all
 # Default-Start:     2 3 4 5

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 ### BEGIN INIT INFO
-# Provides:          Sick Beard application instance
+# Provides:          sickbeard
 # Required-Start:    $all
 # Required-Stop:     $all
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
As you can see at http://wiki.debian.org/LSBInitScripts the Provides: line is space delimited, so "Sick Beard application instance" is actually "providing" four different scripts to the init system. When CouchPotato copied the init script and edited the provides line to "CouchPotatp application instance", "application" and "instance" were both "provided" by each init script which caused a conflict. This diff should fix the issue and make the Sick Beard init script more conform better to the spec.

Thank you for all your great work.
