### PR TITLE
returning False when file_path to process is actually a directory

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -594,6 +594,9 @@ class PostProcessor(object):
         
         self._log(u"Processing "+self.file_path+" ("+str(self.nzb_name)+")")
         
+        if os.path.isdir( self.file_path ):
+            self._log(u"File "+self.file_path+" seems to be a directory")
+            return False
         # reset per-file stuff
         self.in_history = False
         


### PR DESCRIPTION
I had a problem while manually postprocessing a directory with a bunch of episodes when the folders contianing the episodes were named like the episode itself:
    downloaddir/TV.Show.S02E08.avi/TV.Show.S02E08.avi
Sickbeard returned with a 500 http error while processing those, now it checks if the given filename is a directory
