### PR TITLE
Bugfix for Linux where c speedups for simplejson don't work

### DIFF
--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -78,6 +78,8 @@ class TraktNotifier:
     def _notifyTrakt(self, method, api, username, password, data = {}):
         logger.log("trakt_notifier: Call method " + method, logger.DEBUG)
 
+        json._toggle_speedups(False)
+
         if not api:
             api = self._api()
         if not username:


### PR DESCRIPTION
On linux, the encode json data function didn't work due to some bug in the c code. I've disabled the speedups, which shouldn't make any difference in performance (little data is encoded)
