### PR TITLE
Plex media server no longer support the same XBMC commands.  Updated tes...

### DIFF
--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -36,8 +36,8 @@ class PLEXNotifier(XBMCNotifier):
             self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def test_notify(self, host, username, password):
-        return self._notifyXBMC("Testing Plex notifications from Sick Beard", "Test Notification", host, username, password, force=True)
-
+        return self._update_library() 
+        
     def update_library(self):
         if sickbeard.PLEX_UPDATE_LIBRARY:
             self._update_library()


### PR DESCRIPTION
...t_notify to run self._update_library().  The test will now complete properly.
