### PR TITLE
Add search option for backlog search frequency

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -48,6 +48,17 @@
 
                         <div class="field-pair">
                             <label class="nocheck clearfix">
+                                <span class="component-title">Backlog Search Frequency</span>
+                                <input type="text" name="backlog_search_frequency" value="$sickbeard.BACKLOG_SEARCH_FREQUENCY" size="5" />
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Interval in days to run backlog searches (minimum $sickbeard.MIN_BACKLOG_SEARCH_FREQUENCY)</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label class="nocheck clearfix">
                                 <span class="component-title">Usenet Retention</span>
                                 <input type="text" name="usenet_retention" value="$sickbeard.USENET_RETENTION" size="5" />
                             </label>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -143,6 +143,7 @@ SEARCH_FREQUENCY = None
 BACKLOG_SEARCH_FREQUENCY = 21
 
 MIN_SEARCH_FREQUENCY = 10
+MIN_BACKLOG_SEARCH_FREQUENCY = 4
 
 DEFAULT_SEARCH_FREQUENCY = 60
 
@@ -365,7 +366,7 @@ def initialize(consoleLogging=True):
                 PLEX_SERVER_HOST, PLEX_HOST, PLEX_USERNAME, PLEX_PASSWORD, \
                 showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
                 NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
-                SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
+                SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, MIN_BACKLOG_SEARCH_FREQUENCY, \
                 QUALITY_DEFAULT, SEASON_FOLDERS_FORMAT, SEASON_FOLDERS_DEFAULT, STATUS_DEFAULT, \
                 GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
@@ -494,6 +495,10 @@ def initialize(consoleLogging=True):
         SEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'search_frequency', DEFAULT_SEARCH_FREQUENCY)
         if SEARCH_FREQUENCY < MIN_SEARCH_FREQUENCY:
             SEARCH_FREQUENCY = MIN_SEARCH_FREQUENCY
+
+        BACKLOG_SEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'backlog_search_frequency', BACKLOG_SEARCH_FREQUENCY)
+        if BACKLOG_SEARCH_FREQUENCY < MIN_BACKLOG_SEARCH_FREQUENCY:
+            BACKLOG_SEARCH_FREQUENCY = MIN_BACKLOG_SEARCH_FREQUENCY
 
         NZB_DIR = check_setting_str(CFG, 'Blackhole', 'nzb_dir', '')
         TORRENT_DIR = check_setting_str(CFG, 'Blackhole', 'torrent_dir', '')
@@ -957,6 +962,7 @@ def save_config():
     new_config['General']['nzb_method'] = NZB_METHOD
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
+    new_config['General']['backlog_search_frequency'] = int(BACKLOG_SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -122,6 +122,20 @@ def change_SEARCH_FREQUENCY(freq):
     sickbeard.currentSearchScheduler.cycleTime = datetime.timedelta(minutes=sickbeard.SEARCH_FREQUENCY)
     sickbeard.backlogSearchScheduler.cycleTime = datetime.timedelta(minutes=sickbeard.get_backlog_cycle_time())
 
+def change_BACKLOG_SEARCH_FREQUENCY(freq):
+
+    if freq == None:
+        return
+    else:
+        freq = int(freq)
+
+    if freq < sickbeard.MIN_BACKLOG_SEARCH_FREQUENCY:
+        freq = sickbeard.MIN_BACKLOG_SEARCH_FREQUENCY
+
+    sickbeard.BACKLOG_SEARCH_FREQUENCY = freq
+
+    sickbeard.backlogSearchScheduler.action.cycleTime = sickbeard.BACKLOG_SEARCH_FREQUENCY
+
 def change_VERSION_NOTIFY(version_notify):
    
     oldSetting = sickbeard.VERSION_NOTIFY

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -727,7 +727,7 @@ class ConfigSearch:
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
-                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None):
+                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, backlog_search_frequency=None):
 
         results = []
 
@@ -738,6 +738,7 @@ class ConfigSearch:
             results += ["Unable to create directory " + os.path.normpath(torrent_dir) + ", dir not changed."]
 
         config.change_SEARCH_FREQUENCY(search_frequency)
+        config.change_BACKLOG_SEARCH_FREQUENCY(backlog_search_frequency)
 
         if download_propers == "on":
             download_propers = 1


### PR DESCRIPTION
Under Search Options, there's now a field for setting the number of days between backlog searches. Default is still 21, minimum is 4.
