### PR TITLE
Using numbers for the date format used in logging.

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -86,7 +86,7 @@ class SBRotatingLogHandler(object):
     
         file_handler = logging.FileHandler(self.log_file)
         file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(message)s', '%b-%d %H:%M:%S'))
+        file_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(message)s', '%Y-%m-%d %H:%M:%S'))
         return file_handler
 
     def _log_file_name(self, i):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1809,7 +1809,7 @@ class ErrorLogs:
             data = f.readlines()
             f.close()
 
-        regex =  "^(\w{3})\-(\d\d)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"
+        regex =  "^\d+-(\d+)\-(\d+)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"
 
         finalData = []
 


### PR DESCRIPTION
I am using a Traditional Chinese Window 7 system. When I click on the "View Log" button on the web interface, it shows the following errors:
"UnicodeDecodeError: 'utf8' codec can't decode byte 0xa4 in position 0: invalid start byte ...."

After debugging, I found that the filehandler of logger.py use "%b-%d" as date format. In Asian country, "%b" shows like "一月", and it saves as local codepage while other messages are utf-8 string. Thus when webserver.py tried to read it back as utf-8, it just failed.

I also changed the date format of logger to default python style (only numbers), so that webserver.py could read it in a more universal way. Otherwise the "View Log" page will be blank since the regular expression can't match anything ("Jan-01" becomes "一月-01", then match failed).
