### PR TITLE
Changed the newzbin provider url to use newzbin.com

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -34,7 +34,7 @@ RUN_AS=SICKBEARD_USER
 DATA_DIR=~/.sickbeard
 
 # startup args
-DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
+DAEMON_OPTS=" SickBeard.py -q --daemon --nolaunch --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
 
 ############### END EDIT ME ##################
 

--- a/sickbeard/providers/newzbin.py
+++ b/sickbeard/providers/newzbin.py
@@ -73,9 +73,9 @@ class NewzbinProvider(generic.NZBProvider):
 
         self.cache = NewzbinCache(self)
 
-        self.url = 'https://www.newzbin2.es/'
+        self.url = 'https://www.newzbin.com/'
 
-        self.NEWZBIN_NS = 'http://www.newzbin2.es/DTD/2007/feeds/report/'
+        self.NEWZBIN_NS = 'http://www.newzbin.com/DTD/2007/feeds/report/'
 
         self.NEWZBIN_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'
 
@@ -288,7 +288,7 @@ class NewzbinProvider(generic.NZBProvider):
                 raise exceptions.AuthException("The feed wouldn't load, probably because of invalid auth info")
             if sickbeard.USENET_RETENTION is not None:
                 try:
-                    dateString = cur_item.findtext('{http://www.newzbin2.es/DTD/2007/feeds/report/}postdate')
+                    dateString = cur_item.findtext('{http://www.newzbin.com/DTD/2007/feeds/report/}postdate')
                     # use the parse (imported as parseDate) function from the dateutil lib
                     # and we have to remove the timezone info from it because the retention_date will not have one
                     # and a comparison of them is not possible


### PR DESCRIPTION
I've changed the urls in the newzbin provider back to the newzbin.com url.
I expect newzbin will release an update on whether they plan on staying with the newzbin.com domain soon.

I've also included a commit that changes the launch parameters in the init.ubuntu script as per issue: https://code.google.com/p/sickbeard/issues/detail?id=1778
