### PR TITLE
sabnzbd poller

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -184,6 +184,7 @@ SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = ''
+SAB_POLL = True
 
 NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
@@ -357,7 +358,7 @@ def initialize(consoleLogging=True):
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
-                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
+                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, SAB_POLL, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
@@ -536,6 +537,7 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
+        SAB_POLL = bool(check_setting_int(CFG, 'SABnzbd', 'sab_poll', 1))
 
         NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789')
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
@@ -1051,6 +1053,7 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
+    new_config['SABnzbd']['sab_poll'] = int(SAB_POLL)
 
     new_config['NZBget'] = {}
     new_config['NZBget']['nzbget_password'] = NZBGET_PASSWORD

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -203,3 +203,38 @@ def testAuthentication(host=None, username=None, password=None, apikey=None):
     
     return True,"Success"
     
+def getHistory():
+    # sample history url
+    # http://localhost:8080/sabnzbd/api?mode=history&limit=2&apikey=xxx&output=json
+    
+    params = {}
+    if sickbeard.SAB_USERNAME != None:
+        params['ma_username'] = sickbeard.SAB_USERNAME
+    if sickbeard.SAB_PASSWORD != None:
+        params['ma_password'] = sickbeard.SAB_PASSWORD
+    if sickbeard.SAB_APIKEY != None:
+        params['apikey'] = sickbeard.SAB_APIKEY
+
+    params['mode'] = 'history'
+    params['limit'] = 10
+    params['output'] = 'json'
+
+    url = sickbeard.SAB_HOST + "api?" + urllib.urlencode(params)
+    
+    logger.log(u"SABnzbd poll URL: " + url, logger.DEBUG)
+    success, f = _sabURLOpenSimple(url)
+    if not success:
+        logger.log(u"SABnzbd poll error: " + f, logger.WARNING)
+        return False
+
+    success, sabText = _checkSabResponse(f)
+    if not success:
+        return False  
+    else:
+        sabJson = {}
+        try:
+            sabJson = json.loads(sabText)
+        except ValueError, e:
+            pass
+        return sabJson
+

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -202,11 +202,11 @@ def testAuthentication(host=None, username=None, password=None, apikey=None):
         return False,sabText
     
     return True,"Success"
-    
+
 def getHistory():
     # sample history url
     # http://localhost:8080/sabnzbd/api?mode=history&limit=2&apikey=xxx&output=json
-    
+
     params = {}
     if sickbeard.SAB_USERNAME != None:
         params['ma_username'] = sickbeard.SAB_USERNAME
@@ -220,7 +220,7 @@ def getHistory():
     params['output'] = 'json'
 
     url = sickbeard.SAB_HOST + "api?" + urllib.urlencode(params)
-    
+
     logger.log(u"SABnzbd poll URL: " + url, logger.DEBUG)
     success, f = _sabURLOpenSimple(url)
     if not success:
@@ -229,7 +229,7 @@ def getHistory():
 
     success, sabText = _checkSabResponse(f)
     if not success:
-        return False  
+        return False
     else:
         sabJson = {}
         try:
@@ -237,4 +237,3 @@ def getHistory():
         except ValueError, e:
             pass
         return sabJson
-

--- a/sickbeard/sabPoller.py
+++ b/sickbeard/sabPoller.py
@@ -30,7 +30,7 @@ from sickbeard import sab
 class SabPoller():
 
     def run(self):
-        if not sickbeard.NZB_METHOD == "sabnzbd":
+        if not sickbeard.NZB_METHOD == "sabnzbd" or not sickbeard.SAB_POLL:
             return False
 
         history = sab.getHistory()

--- a/sickbeard/sabPoller.py
+++ b/sickbeard/sabPoller.py
@@ -1,0 +1,71 @@
+# Author: Dennis Lutter <lad1337@gmail.com>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import os.path
+import re
+
+import sickbeard
+
+from sickbeard import db
+from sickbeard import logger
+from sickbeard import encodingKludge as ek
+from sickbeard import processTV
+from sickbeard import sab
+
+class SabPoller():
+
+    def run(self):
+        if not sickbeard.NZB_METHOD == "sabnzbd":
+            return False
+
+        history = sab.getHistory()
+        if not history:
+            logger.log("no history from sab please look for previous log messages", logger.WARNING)
+            return False
+
+        mySlots = []
+        historySlots = history['history']['slots']
+        historySlots.reverse() # reverse slot order to have a old->new order... fifo
+        for slot in historySlots:
+            if slot['category'] == sickbeard.SAB_CATEGORY and slot['status'] == "Completed" and not checkSuccessfulPP(slot['storage']):
+                mySlots.append(slot)
+
+        if len(mySlots) == 0:
+            logger.log("Nothing new in the sab history this time", logger.DEBUG)
+            return False
+
+        for slot in mySlots:
+            curPath = slot['storage']
+            if not ek.ek(os.path.isdir, curPath):
+                logger.log(u"Post-processing attempted but " + curPath + " dir doesn't exist", logger.DEBUG)
+                continue
+
+            if not ek.ek(os.path.isabs, curPath):
+                logger.log(u"Post-processing attempted but dir " + curPath + " is relative (and probably not what you really want to process)", logger.DEBUG)
+                continue
+
+            processTV.processDir(curPath, nzbName=slot['nzb_name'])
+
+        return True
+
+def checkSuccessfulPP(path):
+    myDB = db.DBConnection()
+    sql_results = myDB.select("SELECT * FROM history WHERE resource LIKE ?", [path+'%'])
+    return bool(len(sql_results))
+
+

--- a/sickbeard/sabPoller.py
+++ b/sickbeard/sabPoller.py
@@ -17,7 +17,6 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
-import re
 
 import sickbeard
 
@@ -65,7 +64,5 @@ class SabPoller():
 
 def checkSuccessfulPP(path):
     myDB = db.DBConnection()
-    sql_results = myDB.select("SELECT * FROM history WHERE resource LIKE ?", [path+'%'])
+    sql_results = myDB.select("SELECT * FROM history WHERE resource LIKE ?", [path + '%'])
     return bool(len(sql_results))
-
-


### PR DESCRIPTION
it will poll sabs history every 30(hardcoded) seconds 10(hardcoded) items at a time. the sabToSickbeard script is not needed any more (but still working, both should NOT be used at a time could lead to a double pp)

it will filter out everything that has not the configured sab category
to stop post processing the same file over and over again it will compare the path of the "new" file with the post precessed files in the history
this means it will use the database every 30 seconds (bad for hdd spin downs)
with an advance option (in the config.ini only) it can be disabled (default is ON !)
