### PR TITLE
Cleans up stale pid files in the init.ubuntu script

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -52,6 +52,13 @@ if [ ! -d $DATA_DIR ]; then
     chown $RUN_AS $DATA_DIR
 fi
 
+if [ -e $PID_FILE ]; then
+  PID=`cat $PID_FILE`
+  if ! kill -0 $PID > /dev/null 2>&1; then
+    echo "Removing stale $PID_FILE"
+    rm $PID_FILE
+  fi
+fi
 
 case "$1" in
   start)


### PR DESCRIPTION
start-stop-daemon's behavior is to check for the existence of a pid file, but doesn't ensure the pid listed inside is running.  Instead it checks that the pid file exists, and if the exec command exists in the process-list.  Since the python command isn't unique enough (/usr/bin/python), it thinks its still running.

This simply cleans up pid files which don't have a live pid in them, causing the rest of the behavior to work properly.
