### PR TITLE
Added nolaunch parameter to init scripts as per issue #1778

### DIFF
--- a/init.fedora
+++ b/init.fedora
@@ -29,7 +29,7 @@ nice=${SB_NICE-}
 ##
 
 pidpath=`dirname ${pidfile}`
-options=" --daemon --pidfile=${pidfile} --datadir=${datadir}"
+options=" --daemon --nolaunch --pidfile=${pidfile} --datadir=${datadir}"
 
 # create PID directory if not exist and ensure the SickBeard user can write to it
 if [ ! -d $pidpath ]; then

--- a/init.freebsd
+++ b/init.freebsd
@@ -44,7 +44,7 @@ status_cmd="${name}_status"
 stop_cmd="${name}_stop"
 
 command="/usr/sbin/daemon"
-command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py ${sickbeard_flags} --quiet"
+command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py ${sickbeard_flags} --quiet --nolaunch"
 
 # Check for wget and refuse to start without it.
 if [ ! -x "${WGET}" ]; then

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -34,7 +34,7 @@ RUN_AS=SICKBEARD_USER
 DATA_DIR=~/.sickbeard
 
 # startup args
-DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
+DAEMON_OPTS=" SickBeard.py -q --daemon --nolaunch --pidfile=${PID_FILE} --datadir=${DATA_DIR}"
 
 ############### END EDIT ME ##################
 


### PR DESCRIPTION
I've added the nolaunch parameter to the init scripts, I don't see why there would be a need for a web browser to be launched from any init script. The solaris script hasn't been modified as I don't have any experience with solaris.
