### PR TITLE
testSABnzbd appends host with trailing slash if required

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1879,6 +1879,8 @@ class Home:
 
     @cherrypy.expose
     def testSABnzbd(self, host=None, username=None, password=None, apikey=None):
+        if not host.endswith("/"):
+            host = host + "/"
         connection, accesMsg = sab.getSabAccesMethod(host, username, password, apikey)
         if connection:
             authed, authMsg = sab.testAuthentication(host, username, password, apikey) #@UnusedVariable


### PR DESCRIPTION
I noticed a small bug when I was setting up sick beard for the first time. When I put the SABnzbd url into the configuration and then clicked TestSABnzbd, the test would fail because the URL didn't have a trailing slash. When the config is saved, a trailing slash gets appended to the URL if it doesn't have one. However, because  TestSABnzbd used the details from the URL fields before they were saved, it didn't append the URL with a trailing slash thus causing the test to fail. I've added a simple if statement to counteract this issue.
