### PR TITLE
Post Processing Symlink Functionality

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -58,6 +58,18 @@
                                 <span class="component-desc">Keep original files after they've been processed?</span>
                             </label>
                         </div>
+                        
+                        <div class="field-pair">
+                            <input type="checkbox" name="symlink_processed_dir" id="symlink_processed_dir" #if $sickbeard.SYMLINK_PROCESSED_DIR == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="symlink_processed_dir">
+                                <span class="component-title">Symlink Original Files</span>
+                                <span class="component-desc">Symlink from the Original files after they've been processed?</span>
+                            </label>
+                            <label class="nocheck clearfix" for="symlink_processed_di">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc"><b>NOTE:</b> should not be enabled with <b>Keep Original Files</b></span>
+                            </label>
+                        </div>
 
                         <div class="field-pair">
                             <input type="checkbox" name="move_associated_files" id="move_associated_files" #if $sickbeard.MOVE_ASSOCIATED_FILES == True then "checked=\"checked\"" else ""# />

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -157,6 +157,7 @@ TORRENT_DIR = None
 RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
+SYMLINK_PROCESSED_DIR = False
 MOVE_ASSOCIATED_FILES = False
 TV_DOWNLOAD_DIR = None
 
@@ -370,7 +371,7 @@ def initialize(consoleLogging=True):
                 GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, \
-                KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
+                SYMLINK_PROCESSED_DIR, KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, \
                 NAMING_SHOW_NAME, NAMING_EP_TYPE, NAMING_MULTI_EP_TYPE, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
@@ -502,6 +503,7 @@ def initialize(consoleLogging=True):
         PROCESS_AUTOMATICALLY = check_setting_int(CFG, 'General', 'process_automatically', 0)
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
+        SYMLINK_PROCESSED_DIR = check_setting_int(CFG, 'General', 'symlink_processed_dir', 0)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
 
         EZRSS = bool(check_setting_int(CFG, 'General', 'use_torrent', 0))
@@ -986,6 +988,7 @@ def save_config():
     new_config['General']['root_dirs'] = ROOT_DIRS if ROOT_DIRS else ''
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
+    new_config['General']['symlink_processed_dir'] = int(SYMLINK_PROCESSED_DIR)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -391,6 +391,9 @@ def listMediaFiles(dir):
 
     return files
 
+def symlinkFile(srcFile, destFile):
+    ek.ek(os.symlink, srcFile, destFile)
+    
 def copyFile(srcFile, destFile):
     ek.ek(shutil.copyfile, srcFile, destFile)
     try:

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -207,6 +207,25 @@ class PostProcessor(object):
                 
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_move)
                 
+    def _symlink(self, file_path, new_path, new_base_name, associated_files=False):
+        """
+        file_path: The full path of the media file to symlink
+        new_path: Destination path where we want to symlink the file to 
+        new_base_name: The base filename (no extension) to use during the symlink. Use None to keep the same name.
+        associated_files: Boolean, whether we should symlink similarly-named files too
+        """
+
+        def _int_symlink (cur_file_path, new_file_path):
+
+            self._log(u"Symlink file from "+cur_file_path+" to "+new_file_path, logger.DEBUG)
+            try:
+                helpers.symlinkFile(cur_file_path, new_file_path)
+            except (IOError, OSError), e:
+                logger.log("Unable to symlink file "+cur_file_path+" to "+new_file_path+": "+ex(e), logger.ERROR)
+                raise e
+
+        self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_symlink)
+                
     def _copy(self, file_path, new_path, new_base_name, associated_files=False):
         """
         file_path: The full path of the media file to copy
@@ -687,6 +706,8 @@ class PostProcessor(object):
             # move the episode and associated files to the show dir
             if sickbeard.KEEP_PROCESSED_DIR:
                 self._copy(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+            elif sickbeard.SYMLINK_PROCESSED_DIR:
+                self._symlink(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
             else:
                 self._move(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
         except OSError, IOError:

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -105,7 +105,8 @@ def processDir (dirName, nzbName=None, recurse=False):
         # as long as the postprocessing was successful delete the old folder unless the config wants us not to
         if process_result:
 
-            if len(videoFiles) == 1 and not sickbeard.KEEP_PROCESSED_DIR and \
+            if len(videoFiles) == 1 and not sickbeard.KEEP_PROCESSED_DIR \
+                and not sickbeard.SYMLINK_PROCESSED_DIR and \
                 ek.ek(os.path.normpath, dirName) != ek.ek(os.path.normpath, sickbeard.TV_DOWNLOAD_DIR) and \
                 len(remainingFolders) == 0:
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -814,7 +814,7 @@ class ConfigPostProcessing:
                     naming_sep_type=None, naming_quality=None, naming_dates=None,
                     xbmc_data=None, mediabrowser_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
-                    move_associated_files=None, tv_download_dir=None):
+                    symlink_processed_dir=None, move_associated_files=None, tv_download_dir=None):
 
         results = []
 
@@ -865,6 +865,11 @@ class ConfigPostProcessing:
             keep_processed_dir = 1
         else:
             keep_processed_dir = 0
+            
+        if symlink_processed_dir == "on":
+            symlink_processed_dir = 1
+        else:
+            symlink_processed_dir = 0
 
         if move_associated_files == "on":
             move_associated_files = 1
@@ -873,6 +878,7 @@ class ConfigPostProcessing:
 
         sickbeard.PROCESS_AUTOMATICALLY = process_automatically
         sickbeard.KEEP_PROCESSED_DIR = keep_processed_dir
+        sickbeard.SYMLINK_PROCESSED_DIR = symlink_processed_dir
         sickbeard.RENAME_EPISODES = rename_episodes
         sickbeard.MOVE_ASSOCIATED_FILES = move_associated_files
 


### PR DESCRIPTION
This commit adds symlink as one of the options for Post Process.

With this functionality users torrenting can continue to seed after processing,
and without the draw back of keep two separate files on the filesystem 
(this was the only option with Keep Original Files).

Jeffrey-
