### PR TITLE
Add TV show options to the general config view, with the following options.

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -299,7 +299,7 @@ def main():
         sickbeard.launchBrowser(startPort)
 
     # start an update if we're supposed to
-    if forceUpdate:
+    if forceUpdate or sickbeard.UPDATE_ON_START:
         sickbeard.showUpdateScheduler.action.run(force=True) #@UndefinedVariable
 
     # stay alive while my threads do the work

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -72,7 +72,7 @@
                     <fieldset class="component-group-list">
                         <div class="field-pair">
                             <input type="checkbox" name="update_on_start" id="update_on_start" #if $sickbeard.UPDATE_ON_START then "checked=\"checked\"" else ""#/>
-                            <label class="clearfix" for="launch_browser">
+                            <label class="clearfix" for="update_on_start">
                                 <span class="component-title">Update on Start</span>
                                 <span class="component-desc">Should Sick Beard update the show information when started?</span>
                             </label>

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -62,6 +62,36 @@
                     </fieldset>
                 </div><!-- /component-group1 //-->
 
+				<div id="core-component-group4" class="component-group clearfix">
+
+                    <div class="component-group-desc">
+                        <h3>TV Shows</h3>
+                        <p>Gives you the ability to modify the TV Show update behavoir of Sickbeard</p>
+                    </div>
+
+                    <fieldset class="component-group-list">
+                        <div class="field-pair">
+                            <input type="checkbox" name="update_on_start" id="update_on_start" #if $sickbeard.UPDATE_ON_START then "checked=\"checked\"" else ""#/>
+                            <label class="clearfix" for="launch_browser">
+                                <span class="component-title">Update on Start</span>
+                                <span class="component-desc">Should Sick Beard update the show information when started?</span>
+                            </label>
+                        </div>
+                        
+                        <div class="field-pair">
+                            <label class="nocheck clearfix">
+                                <span class="component-title">Update time</span>
+                                <input type="text" name="tv_show_update_time" value="$sickbeard.TV_SHOW_UPDATE_TIME" size="10" maxlength="2" />
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Time that Sick Beard should update TV Shows (between 0 and 23)</span>
+                            </label>
+                        </div>
+
+                        <input type="submit" class="config_submitter" value="Save Changes" />
+                    </fieldset>
+                </div><!-- /component-group4 //-->
 
                 <div id="core-component-group2" class="component-group clearfix">
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -276,6 +276,9 @@ EXTRA_SCRIPTS = []
 
 GIT_PATH = None
 
+UPDATE_ON_START = False
+TV_SHOW_UPDATE_TIME = 3
+
 IGNORE_WORDS = "german,french,core2hd,dutch,swedish"
 
 __INITIALIZED__ = False
@@ -396,7 +399,7 @@ def initialize(consoleLogging=True):
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
-                COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS
+                COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, UPDATE_ON_START, TV_SHOW_UPDATE_TIME
 
         if __INITIALIZED__:
             return False
@@ -441,6 +444,9 @@ def initialize(consoleLogging=True):
         API_KEY = check_setting_str(CFG, 'General', 'api_key', '')
         
         ENABLE_HTTPS = bool(check_setting_int(CFG, 'General', 'enable_https', 0))
+        
+        UPDATE_ON_START = bool(check_setting_int(CFG, 'General', 'update_on_start', 0))
+        TV_SHOW_UPDATE_TIME = check_setting_int(CFG, 'General', 'tv_show_update_time', 3)
         
         try:
             HTTPS_PORT = check_setting_str(CFG, 'General', 'https_port', '9091')
@@ -1015,6 +1021,9 @@ def save_config():
     new_config['General']['naming_dates'] = int(NAMING_DATES)
     new_config['General']['launch_browser'] = int(LAUNCH_BROWSER)
 
+    new_config['General']['update_on_start'] = int(UPDATE_ON_START)
+    new_config['General']['tv_show_update_time'] = int(TV_SHOW_UPDATE_TIME)
+
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()
@@ -1022,7 +1031,9 @@ def save_config():
     new_config['General']['metadata_ps3'] = metadata_provider_dict['Sony PS3'].get_config()
     new_config['General']['metadata_wdtv'] = metadata_provider_dict['WDTV'].get_config()
     new_config['General']['metadata_tivo'] = metadata_provider_dict['TIVO'].get_config()
-
+    
+    
+    
     new_config['General']['cache_dir'] = ACTUAL_CACHE_DIR if ACTUAL_CACHE_DIR else 'cache'
     new_config['General']['root_dirs'] = ROOT_DIRS if ROOT_DIRS else ''
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -33,7 +33,7 @@ class ShowUpdater():
     def run(self, force=False):
 
         # update at 3 AM
-        updateTime = datetime.time(hour=3)
+        updateTime = datetime.time(hour=sickbeard.TV_SHOW_UPDATE_TIME)
 
         logger.log(u"Checking update interval", logger.DEBUG)
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -719,8 +719,8 @@ class ConfigGeneral:
         
         sickbeard.UPDATE_ON_START = update_on_start
         
-        if(tv_show_update_time >= 0 and tv_show_update_time <= 23):
-            sickbeard.TV_SHOW_UPDATE_TIME = tv_show_update_time
+        if(int(tv_show_update_time) >= 0 and int(tv_show_update_time) <= 23):
+            sickbeard.TV_SHOW_UPDATE_TIME = int(tv_show_update_time)
         
         if not config.change_HTTPS_CERT(https_cert):
             results += ["Unable to create directory " + os.path.normpath(https_cert) + ", https cert dir not changed."]

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -661,7 +661,7 @@ class ConfigGeneral:
     @cherrypy.expose
     def saveGeneral(self, log_dir=None, web_port=None, web_log=None, web_ipv6=None,
                     launch_browser=None, web_username=None, use_api=None, api_key=None,
-                    web_password=None, version_notify=None, enable_https=None, https_port=None, https_cert=None, https_key=None):
+                    web_password=None, version_notify=None, enable_https=None, https_port=None, https_cert=None, https_key=None, update_on_start=None, tv_show_update_time=None):
 
         results = []
 
@@ -711,6 +711,16 @@ class ConfigGeneral:
         
         sickbeard.ENABLE_HTTPS = enable_https
         sickbeard.HTTPS_PORT = https_port
+        
+        if update_on_start == "on":
+            update_on_start = 1
+        else:
+            update_on_start = 0
+        
+        sickbeard.UPDATE_ON_START = update_on_start
+        
+        if(tv_show_update_time >= 0 and tv_show_update_time <= 23):
+            sickbeard.TV_SHOW_UPDATE_TIME = tv_show_update_time
         
         if not config.change_HTTPS_CERT(https_cert):
             results += ["Unable to create directory " + os.path.normpath(https_cert) + ", https cert dir not changed."]


### PR DESCRIPTION
TV show update on startup, this works together with the --force option at startup. Making it optional in the config makes it easier for novice users.

TV show update time, the current update time is hardcoded to 3 o clock. Making it optional gives users that don't have sickbeard running 24 hour the ability to update the TV show content automatically.
