### PR TITLE
Set file ownership to parent dir owner after move/copy.

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -393,8 +393,13 @@ def listMediaFiles(dir):
 
 def copyFile(srcFile, destFile):
     ek.ek(shutil.copyfile, srcFile, destFile)
+    srcStat = os.stat(srcFile)
+    srcUID = srcStat[stat.ST_UID]
+    srcGID = srcStat[stat.ST_GID]
+
     try:
         ek.ek(shutil.copymode, srcFile, destFile)
+        ek.ek(os.chown, destFile, srcUID, srcGID)
     except OSError:
         pass
 
@@ -442,7 +447,6 @@ def chmodAsParent(childPath):
 
     try:
         ek.ek(os.chmod, childPath, childMode)
-        logger.log(u"Setting permissions for %s to %o as parent directory has %o" % (childPath, childMode, parentMode), logger.DEBUG)
     except OSError:
         logger.log(u"Failed to set permission for %s to %o" % (childPath, childMode), logger.ERROR)
 


### PR DESCRIPTION
I'm running Sickbeard on a Thecus NAS which is a tightly controlled environment and it is not easily possible to configure the sickbeard user (thus it's root).

Copied files are already chmod like their parents so I added a similar behaviour for owner and group.
