### PR TITLE
Redirect to listening port on reboot after config change

### DIFF
--- a/data/interfaces/default/restart_bare.tmpl
+++ b/data/interfaces/default/restart_bare.tmpl
@@ -1,6 +1,10 @@
 <script type="text/javascript" charset="utf-8">
 <!--
 sbRoot = "$sbRoot";
+sbHttpPort = "$sbHttpPort";
+sbHttpsPort = "$sbHttpsPort";
+sbHttpsEnabled = "$sbHttpsEnabled";
+sbHost = "$sbHost";
 //-->
 </script>
 

--- a/data/js/restart.js
+++ b/data/js/restart.js
@@ -7,7 +7,7 @@ if (sbHttpsEnabled != "False" && sbHttpsEnabled != 0) {
     var sb_base_url = 'http://'+sbHost+':'+sbHttpPort+sbRoot;
 
 var base_url = window.location.protocol+'//'+window.location.host+sbRoot;
-var is_alive_url = '/home/is_alive';
+var is_alive_url = sbRoot+'/home/is_alive';
 var timeout_id;
 var current_pid = '';
 var num_restart_waits = 0;

--- a/data/js/restart.js
+++ b/data/js/restart.js
@@ -1,4 +1,13 @@
-var is_alive_url = sbRoot+'/home/is_alive';
+if (sbHttpsEnabled != "False" && sbHttpsEnabled != 0) {
+    if (sbHttpsPort != "False" && sbHttpsPort != "")
+        var sb_base_url = 'https://'+sbHost+':'+sbHttpsPort+sbRoot;
+    else
+        var sb_base_url = 'https://'+sbHost+':'+sbHttpPort+sbRoot;
+} else
+    var sb_base_url = 'http://'+sbHost+':'+sbHttpPort+sbRoot;
+
+var base_url = window.location.protocol+'//'+window.location.host+sbRoot;
+var is_alive_url = '/home/is_alive';
 var timeout_id;
 var current_pid = '';
 var num_restart_waits = 0;
@@ -8,26 +17,26 @@ function is_alive() {
     $.get(is_alive_url, function(data) {
                                         
         // if it's still initalizing then just wait and try again
-        if (data == 'nope') {
+        if (data.msg == 'nope') {
             $('#shut_down_loading').hide();
             $('#shut_down_success').show();
             $('#restart_message').show();
             setTimeout('is_alive()', 1000);
         } else {
             // if this is before we've even shut down then just try again later
-            if (current_pid == '' || data == current_pid) {
-                current_pid = data;
+            if (current_pid == '' || data.msg == current_pid) {
+                current_pid = data.msg;
                 setTimeout(is_alive, 1000);
 
-            // if we're ready to go then refresh the page which'll forward to /home
+            // if we're ready to go then redirect to new url
             } else {
                 $('#restart_loading').hide();
                 $('#restart_success').show();
                 $('#refresh_message').show();
-                location.reload();
+                window.location = sb_base_url+'/home';
             }
         }
-    });
+    }, 'jsonp');
 }
 
 $(document).ready(function() 
@@ -36,13 +45,18 @@ $(document).ready(function()
     is_alive();
     
     $('#shut_down_message').ajaxError(function(e, jqxhr, settings, exception) {
-        if (settings.url != is_alive_url)
-            return;
         num_restart_waits += 1;
 
         $('#shut_down_loading').hide();
         $('#shut_down_success').show();
         $('#restart_message').show();
+        is_alive_url = sb_base_url+'/home/is_alive';
+
+        // if https is newly enabled or the port changed just wait 5 seconds then redirect. This is because the ajax will fail if the cert is untrusted.
+        if (sbHttpsEnabled != "False" && sbHttpsEnabled != 0) {
+            if (base_url != sb_base_url)
+                setTimeout("window.location = sb_base_url+'/home'", 5000);
+        }
 
         // if it is taking forever just give up
         if (num_restart_waits > 90) {

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -26,7 +26,6 @@ import re
 import threading
 import datetime
 import random
-import json
 
 from Cheetah.Template import Template
 import cherrypy.lib

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -67,7 +67,7 @@ class PageTemplate (Template):
         self.sbHttpPort = sickbeard.WEB_PORT
         self.sbHttpsPort = sickbeard.HTTPS_PORT
         self.sbHttpsEnabled = sickbeard.ENABLE_HTTPS
-        self.sbHost = re.match("(.*)(?=:)", cherrypy.request.headers['Host'], re.X|re.M|re.S).group(0)
+        self.sbHost = re.match("[^:]+", cherrypy.request.headers['Host'], re.X|re.M|re.S).group(0)
         self.projectHomePage = "http://code.google.com/p/sickbeard/"
 
         logPageTitle = 'Logs &amp; Errors'


### PR DESCRIPTION
This will redirect to the proper url after a reboot if the
config changed the port or protocol (http/https) that the server is
listening to.
Previously it would just time out.

This changes the datatype to jsonp for the ajax request to is_alive to allow for cross domain requests, which it is when you change the protocol or port.

If going from http to https or https on a different port, the script will wait 5 seconds after the shutdown and then automatically redirect to the new url.  This is because if the SSL certificate is self-signed, or otherwise untrusted, the ajax request will break.
