### PR TITLE
Redirect to listening port on reboot after config change

### DIFF
--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -59,7 +59,7 @@ def processEpisode(dirName, nzbName=None):
     password = config.get("SickBeard", "password")
     try:
         ssl = int(config.get("SickBeard", "ssl"))
-    except ConfigParser.NoOptionError, ValueError:
+    except (ConfigParser.NoOptionError, ValueError):
         ssl = 0
     
     try:

--- a/data/interfaces/default/restart_bare.tmpl
+++ b/data/interfaces/default/restart_bare.tmpl
@@ -1,6 +1,10 @@
 <script type="text/javascript" charset="utf-8">
 <!--
 sbRoot = "$sbRoot";
+sbHttpPort = "$sbHttpPort";
+sbHttpsPort = "$sbHttpsPort";
+sbHttpsEnabled = "$sbHttpsEnabled";
+sbHost = "$sbHost";
 //-->
 </script>
 

--- a/data/js/restart.js
+++ b/data/js/restart.js
@@ -1,3 +1,12 @@
+if (sbHttpsEnabled != "False" && sbHttpsEnabled != 0) {
+    if (sbHttpsPort != "False" && sbHttpsPort != "")
+        var sb_base_url = 'https://'+sbHost+':'+sbHttpsPort+sbRoot;
+    else
+        var sb_base_url = 'https://'+sbHost+':'+sbHttpPort+sbRoot;
+} else
+    var sb_base_url = 'http://'+sbHost+':'+sbHttpPort+sbRoot;
+
+var base_url = window.location.protocol+'//'+window.location.host+sbRoot;
 var is_alive_url = sbRoot+'/home/is_alive';
 var timeout_id;
 var current_pid = '';
@@ -8,26 +17,26 @@ function is_alive() {
     $.get(is_alive_url, function(data) {
                                         
         // if it's still initalizing then just wait and try again
-        if (data == 'nope') {
+        if (data.msg == 'nope') {
             $('#shut_down_loading').hide();
             $('#shut_down_success').show();
             $('#restart_message').show();
             setTimeout('is_alive()', 1000);
         } else {
             // if this is before we've even shut down then just try again later
-            if (current_pid == '' || data == current_pid) {
-                current_pid = data;
+            if (current_pid == '' || data.msg == current_pid) {
+                current_pid = data.msg;
                 setTimeout(is_alive, 1000);
 
-            // if we're ready to go then refresh the page which'll forward to /home
+            // if we're ready to go then redirect to new url
             } else {
                 $('#restart_loading').hide();
                 $('#restart_success').show();
                 $('#refresh_message').show();
-                location.reload();
+                window.location = sb_base_url+'/home';
             }
         }
-    });
+    }, 'jsonp');
 }
 
 $(document).ready(function() 
@@ -36,13 +45,18 @@ $(document).ready(function()
     is_alive();
     
     $('#shut_down_message').ajaxError(function(e, jqxhr, settings, exception) {
-        if (settings.url != is_alive_url)
-            return;
         num_restart_waits += 1;
 
         $('#shut_down_loading').hide();
         $('#shut_down_success').show();
         $('#restart_message').show();
+        is_alive_url = sb_base_url+'/home/is_alive';
+
+        // if https is newly enabled or the port changed just wait 5 seconds then redirect. This is because the ajax will fail if the cert is untrusted.
+        if (sbHttpsEnabled != "False" && sbHttpsEnabled != 0) {
+            if (base_url != sb_base_url)
+                setTimeout("window.location = sb_base_url+'/home'", 5000);
+        }
 
         // if it is taking forever just give up
         if (num_restart_waits > 90) {

--- a/sickbeard/notifiers/notifo.py
+++ b/sickbeard/notifiers/notifo.py
@@ -42,7 +42,7 @@ class NotifoNotifier:
         data = urllib.urlencode({
             "title": title,
             "label": label,
-            "msg": msg
+            "msg": msg.encode(sickbeard.SYS_ENCODING)
         })
 
         try:

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -103,7 +103,7 @@ class XBMCNotifier:
     
             logger.log(u"Contacting XBMC via url: " + url, logger.DEBUG)
             handle = urllib2.urlopen(req)
-            response = handle.read()
+            response = handle.read().decode(sickbeard.SYS_ENCODING)
             logger.log(u"response: " + response, logger.DEBUG)
         except IOError, e:
             logger.log(u"Warning: Couldn't contact XBMC HTTP server at " + fixStupidEncodings(host) + ": " + ex(e))
@@ -191,7 +191,7 @@ class XBMCNotifier:
     
             for path in paths:
                 # Don't need it double-encoded, gawd this is dumb
-                unEncPath = urllib.unquote(path.text)
+                unEncPath = urllib.unquote(path.text).decode(sickbeard.SYS_ENCODING)
                 logger.log(u"XBMC Updating " + showName + " on " + host + " at " + unEncPath, logger.DEBUG)
                 updateCommand = {'command': 'ExecBuiltIn', 'parameter': 'XBMC.updatelibrary(video, %s)' % (unEncPath)}
                 request = self._sendToXBMC(updateCommand, host)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -63,6 +63,10 @@ class PageTemplate (Template):
         KWs['file'] = os.path.join(sickbeard.PROG_DIR, "data/interfaces/default/", KWs['file'])
         super(PageTemplate, self).__init__(*args, **KWs)
         self.sbRoot = sickbeard.WEB_ROOT
+        self.sbHttpPort = sickbeard.WEB_PORT
+        self.sbHttpsPort = sickbeard.HTTPS_PORT
+        self.sbHttpsEnabled = sickbeard.ENABLE_HTTPS
+        self.sbHost = re.match("[^:]+", cherrypy.request.headers['Host'], re.X|re.M|re.S).group(0)
         self.projectHomePage = "http://code.google.com/p/sickbeard/"
 
         logPageTitle = 'Logs &amp; Errors'
@@ -1902,13 +1906,18 @@ class ErrorLogs:
 class Home:
 
     @cherrypy.expose
-    def is_alive(self):
+    def is_alive(self, *args, **kwargs):
+        if 'callback' in kwargs and '_' in kwargs:
+            callback, _ = kwargs['callback'], kwargs['_']
+        else:
+            return "Error: Unsupported Request. Send jsonp request with 'callback' variable in the query stiring."
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
+        cherrypy.response.headers['Content-Type'] = 'text/javascript'
 
         if sickbeard.started:
-            return str(sickbeard.PID)
+            return callback+'('+json.dumps({"msg": str(sickbeard.PID)})+');'
         else:
-            return "nope"
+            return callback+'('+json.dumps({"msg": "nope"})+');'
 
     @cherrypy.expose
     def index(self):


### PR DESCRIPTION
This will redirect to the proper url after a reboot if the config changed the port or protocol (http/https) that the server is listening to.
Previously it would just time out.

This changes the datatype to jsonp for the ajax request to is_alive to allow for cross domain requests, which it is when you change the protocol or port.

If going from http to https or https on a different port, the script will wait 5 seconds after the shutdown and then automatically redirect to the new url. This is because if the SSL certificate is self-signed, or otherwise untrusted, the ajax request will fail silently.
