### PR TITLE
Changed newzbin error string

### DIFF
--- a/sickbeard/providers/newzbin.py
+++ b/sickbeard/providers/newzbin.py
@@ -284,7 +284,7 @@ class NewzbinProvider(generic.NZBProvider):
 
         for cur_item in items:
             title = cur_item.findtext('title')
-            if title == 'Feed Error':
+            if title == 'Feeds Error':
                 raise exceptions.AuthException("The feed wouldn't load, probably because of invalid auth info")
             if sickbeard.USENET_RETENTION is not None:
                 try:


### PR DESCRIPTION
The string returned from Newzbin is "Feeds Error" and not "Feed Error". This was causing an incorrect error message to be displayed in the logs: Error parsing date from Newzbin RSS feed: 'NoneType' object has no attribute 'read'
