### PR TITLE
Auto create show folder if missing during post-processing

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -154,6 +154,7 @@ TVTORRENTS_HASH = None
 
 TORRENT_DIR = None
 
+ADD_SHOWS_WO_DIR = None
 CREATE_MISSING_SHOW_DIRS = None
 RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
@@ -377,7 +378,8 @@ def initialize(consoleLogging=True):
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
-                COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS
+                COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
+                ADD_SHOWS_WO_DIR
 
         if __INITIALIZED__:
             return False
@@ -499,6 +501,7 @@ def initialize(consoleLogging=True):
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
         CREATE_MISSING_SHOW_DIRS = check_setting_int(CFG, 'General', 'create_missing_show_dirs', 0)
+        ADD_SHOWS_WO_DIR = check_setting_int(CFG, 'General', 'add_shows_wo_dir', 0)
         
         EZRSS = bool(check_setting_int(CFG, 'General', 'use_torrent', 0))
         if not EZRSS:
@@ -981,6 +984,7 @@ def save_config():
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
     new_config['General']['create_missing_show_dirs'] = CREATE_MISSING_SHOW_DIRS
+    new_config['General']['add_shows_wo_dir'] = ADD_SHOWS_WO_DIR
     
     new_config['General']['extra_scripts'] = '|'.join(EXTRA_SCRIPTS)
     new_config['General']['git_path'] = GIT_PATH

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -154,6 +154,7 @@ TVTORRENTS_HASH = None
 
 TORRENT_DIR = None
 
+CREATE_MISSING_SHOW_DIRS = None
 RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
@@ -376,7 +377,7 @@ def initialize(consoleLogging=True):
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
-                COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS
+                COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS
 
         if __INITIALIZED__:
             return False
@@ -497,7 +498,8 @@ def initialize(consoleLogging=True):
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
-
+        CREATE_MISSING_SHOW_DIRS = check_setting_int(CFG, 'General', 'create_missing_show_dirs', 0)
+        
         EZRSS = bool(check_setting_int(CFG, 'General', 'use_torrent', 0))
         if not EZRSS:
             EZRSS = bool(check_setting_int(CFG, 'EZRSS', 'ezrss', 0))
@@ -978,6 +980,7 @@ def save_config():
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
+    new_config['General']['create_missing_show_dirs'] = CREATE_MISSING_SHOW_DIRS
     
     new_config['General']['extra_scripts'] = '|'.join(EXTRA_SCRIPTS)
     new_config['General']['git_path'] = GIT_PATH

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -646,6 +646,18 @@ class PostProcessor(object):
             except OSError, IOError:
                 raise exceptions.PostProcessingFailed("Unable to delete the existing files")
         
+        # if the show directory doesn't exist then make it if allowed
+        if not ek.ek(os.path.isdir, ep_obj.show.location) and sickbeard.CREATE_MISSING_SHOW_DIRS:
+            self._log(u"Show directory doesn't exist, creating it", logger.DEBUG)
+            try:
+                ek.ek(os.mkdir, ep_obj.show.location)
+                
+            except OSError, IOError:
+                raise exceptions.PostProcessingFailed("Unable to create the show directory: "+ep_obj.show.location)
+        
+            # get metadata for the show (but not episode because it hasn't been fully processed)
+            ep_obj.show.writeMetadata(True)
+            
         # find the destination folder
         try:
             dest_path = self._find_ep_destination_folder(ep_obj)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -98,7 +98,8 @@ class TVShow(object):
 
     def _setLocation(self, newLocation):
         logger.log(u"Setter sets location to " + newLocation, logger.DEBUG)
-        if ek.ek(os.path.isdir, newLocation):
+        # Don't validate dir if user wants to add shows without creating a dir
+        if sickbeard.ADD_SHOWS_WO_DIR or ek.ek(os.path.isdir, newLocation):
             self._location = newLocation
             self._isDirGood = True
         else:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -82,6 +82,10 @@ class TVShow(object):
         self.saveToDB()
 
     def _getLocation(self):
+        # no dir check needed if missing show dirs are created during post-processing
+        if sickbeard.CREATE_MISSING_SHOW_DIRS:
+            return self._location
+        
         if ek.ek(os.path.isdir, self._location):
             return self._location
         else:
@@ -150,7 +154,7 @@ class TVShow(object):
 
         return result
 
-    def writeMetadata(self):
+    def writeMetadata(self, show_only=False):
 
         if not ek.ek(os.path.isdir, self._location):
             logger.log(str(self.tvdbid) + u": Show dir doesn't exist, skipping NFO generation")
@@ -159,8 +163,9 @@ class TVShow(object):
         self.getImages()
 
         self.writeShowNFO()
-        self.writeEpisodeNFOs()
-
+        
+        if not show_only:
+            self.writeEpisodeNFOs()
 
     def writeEpisodeNFOs (self):
 
@@ -1142,7 +1147,8 @@ class TVEpisode(object):
         #early conversion to int so that episode doesn't get marked dirty
         self.tvdbid = int(myEp["id"])
         
-        if not ek.ek(os.path.isdir, self.show._location):
+        #don't update show status if show dir is missing, unless missing show dirs are created during post-processing
+        if not ek.ek(os.path.isdir, self.show._location) and not sickbeard.CREATE_MISSING_SHOW_DIRS:
             logger.log(u"The show dir is missing, not bothering to change the episode statuses since it'd probably be invalid")
             return
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -693,8 +693,8 @@ class TVShow(object):
 
     def refreshDir(self):
 
-        # make sure the show dir is where we think it is
-        if not ek.ek(os.path.isdir, self._location):
+        # make sure the show dir is where we think it is unless dirs are created on the fly
+        if not ek.ek(os.path.isdir, self._location) and not sickbeard.CREATE_MISSING_SHOW_DIRS:
             return False
 
         # load from dir

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1773,12 +1773,17 @@ class CMD_ShowAddNew(ApiCall):
 
         # moved the logic check to the end in an attempt to eliminate empty directory being created from previous errors
         showPath = ek.ek(os.path.join, self.location, helpers.sanitizeFileName(tvdbName))
-        dir_exists = helpers.makeDir(showPath)
-        if not dir_exists:
-            logger.log(u"API :: Unable to create the folder " + showPath + ", can't add the show", logger.ERROR)
-            return _responds(RESULT_FAILURE, {"path": showPath}, "Unable to create the folder " + showPath + ", can't add the show")
+        
+        # don't create show dir if config says not to
+        if sickbeard.ADD_SHOWS_WO_DIR:
+            logger.log(u"Skipping initial creation of "+showPath+" due to config.ini setting")
         else:
-            helpers.chmodAsParent(showPath)
+            dir_exists = helpers.makeDir(showPath)
+            if not dir_exists:
+                logger.log(u"API :: Unable to create the folder " + showPath + ", can't add the show", logger.ERROR)
+                return _responds(RESULT_FAILURE, {"path": showPath}, "Unable to create the folder " + showPath + ", can't add the show")
+            else:
+                helpers.chmodAsParent(showPath)
 
         sickbeard.showQueueScheduler.action.addShow(int(self.tvdbid), showPath, newStatus, newQuality, int(self.season_folder), self.lang) #@UndefinedVariable
         return _responds(RESULT_SUCCESS, {"name": tvdbName}, tvdbName + " has been queued to be added")

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1649,14 +1649,17 @@ class NewHomeAddShows:
             ui.notifications.error("Unable to add show", "Folder "+show_dir+" exists already")
             redirect('/home')
         
-        # create the dir and make sure it worked
-        dir_exists = helpers.makeDir(show_dir)
-        if not dir_exists:
-            logger.log(u"Unable to create the folder "+show_dir+", can't add the show", logger.ERROR)
-            ui.notifications.error("Unable to add show", "Unable to create the folder "+show_dir+", can't add the show")
-            redirect("/home")
+        # don't create show dir if config says not to
+        if sickbeard.ADD_SHOWS_WO_DIR:
+            logger.log(u"Skipping initial creation of "+show_dir+" due to config.ini setting")
         else:
-            helpers.chmodAsParent(show_dir)
+            dir_exists = helpers.makeDir(show_dir)
+            if not dir_exists:
+                logger.log(u"Unable to create the folder "+show_dir+", can't add the show", logger.ERROR)
+                ui.notifications.error("Unable to add show", "Unable to create the folder "+show_dir+", can't add the show")
+                redirect("/home")
+            else:
+                helpers.chmodAsParent(show_dir)
 
         # prepare the inputs for passing along
         if seasonFolders == "on":


### PR DESCRIPTION
This allows users to configure Sick-Beard to automatically create show folders if they are missing during post-processing. There is also an option to have Sick-Beard skip the creation of the show folder when a new show is added. Finally, during Sick-Beard's file scan routine, if a show directory is missing, and auto-create is true, then Sick-Beard will behave as if the directory is there, but episodes and/or season directories are missing (ie, behave as if the episode files have been deleted, and update the database to reflect that).   

This is to address Issue 136: http://code.google.com/p/sickbeard/issues/detail?id=136 

This is especially helpful for users who use WDTV, Asus O!Play, or other media players that do not hide empty folders in their UI. 

This is my first time using git-hub, so please let me know if I did something wrong (or could have done something better).
