### PR TITLE
Trakt collection deletion

### DIFF
--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -75,3 +75,5 @@ def notify_snatch(ep_name):
         n.notify_snatch(ep_name)
     notifo_notifier.notify_snatch(ep_name)
 
+def notify_delete(ep_obj):
+    trakt_notifier.notify_delete(ep_obj)

--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -42,10 +42,19 @@ class TraktNotifier:
 
     def notify_download(self, ep_name):
         pass
+    
+    def notify_delete(self, ep_obj):
+        logger.log(u"Starting Trakt removal", logger.DEBUG)
+                    
+        if ep_obj != None:
+            logger.log(u"Removing " + ep_obj.show.name + " " + str(ep_obj.season) + "x" + str(ep_obj.episode) + " from Trakt collection", logger.DEBUG)
+            self.update_library(ep_obj, True)
+        else:
+            logger.log(u"No episode could be found to be removed from your Trakt collection", logger.WARNING)
 
-    def update_library(self, ep_obj):
+    def update_library(self, ep_obj, delete=False):
         if sickbeard.USE_TRAKT:
-            method = "show/episode/library/"
+            method = "show/episode/unlibrary/" if delete else "show/episode/library/"
             method += "%API%"
             
             data = {

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -39,6 +39,7 @@ from sickbeard import tvrage
 from sickbeard import config
 from sickbeard import image_cache
 from sickbeard import postProcessor
+from sickbeard import notifiers
 
 from sickbeard import encodingKludge as ek
 
@@ -720,6 +721,7 @@ class TVShow(object):
                     if curEp.location and curEp.status in Quality.DOWNLOADED:
                         logger.log(str(self.tvdbid) + ": Location for " + str(season) + "x" + str(episode) + " doesn't exist, removing it and changing our status to IGNORED", logger.DEBUG)
                         curEp.status = IGNORED
+                        notifiers.notify_delete(curEp)
                     curEp.location = ''
                     curEp.hasnfo = False
                     curEp.hastbn = False


### PR DESCRIPTION
I have added a way for Sick Beard to notify Trakt that an episode that has been rescanned and ignored is no longer in the collection. To do so I have updated the updateLibrary() function in trakt.py to include a boolean argument to allow for deletions.

PS. This is a rewrite of pull request 289 (https://github.com/midgetspy/Sick-Beard/pull/289), which messed up the other branches since I modified stuff in the master branch.
