### PR TITLE
Don't download higher quality if the episode file has already been deleted

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -36,6 +36,18 @@
                         </div>
                         
                         <div class="field-pair">
+                            <input type="checkbox" name="check_existence" id="check_existence" #if $sickbeard.CHECK_EXISTENCE == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="check_existence">
+                                <span class="component-title">Check Files' Existence</span>
+                                <span class="component-desc">Check files' existence before downloading higher qualities?</span>
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Useful when you delete episodes right after watching them.</span>
+                            </label>
+                        </div>
+                        
+                        <div class="field-pair">
                             <label class="nocheck clearfix">
                                 <span class="component-title">Search Frequency</span>
                                 <input type="text" name="search_frequency" value="$sickbeard.SEARCH_FREQUENCY" size="5" />

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -142,6 +142,7 @@ NZB_METHOD = None
 NZB_DIR = None
 USENET_RETENTION = None
 DOWNLOAD_PROPERS = None
+CHECK_EXISTENCE = None
 
 SEARCH_FREQUENCY = None
 BACKLOG_SEARCH_FREQUENCY = 21
@@ -378,7 +379,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
+                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, CHECK_EXISTENCE, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
@@ -520,6 +521,7 @@ def initialize(consoleLogging=True):
             NZB_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        CHECK_EXISTENCE = bool(check_setting_int(CFG, 'General', 'check_existence', 0)) 
 
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
 
@@ -1013,6 +1015,7 @@ def save_config():
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['check_existence'] = int(CHECK_EXISTENCE)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)
     new_config['General']['season_folders_format'] = SEASON_FOLDERS_FORMAT

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -169,7 +169,10 @@ def searchForNeededEpisodes():
             if curEp.show.paused:
                 logger.log(u"Show "+curEp.show.name+" is paused, ignoring all RSS items for "+curEp.prettyName(True), logger.DEBUG)
                 continue
-
+            
+            if fileWasDeleted(curEp):
+                continue
+            
             # find the best result for the current episode
             bestResult = None
             for curResult in curFoundResults[curEp]:
@@ -255,6 +258,38 @@ def isFinalResult(result):
     else:
         return False
 
+def fileWasDeleted(epObj):
+    '''
+    Checks if the user has deleted file corresponding to epObj. This functionality is turned off by default. 
+    It will only perform this check if the user has explicitly requested it via the Search Settings configuration page.
+    
+    If the file is still present on disk, this function returns False. If it has been deleted, it returns True.
+    '''
+    logger.log(u"Starting check for files' existence", logger.DEBUG)
+    deleted = False
+    
+    # if epObj is None, we do not have this episode in the database yet, so it was not deleted
+    if epObj is not None:
+        if sickbeard.CHECK_EXISTENCE:
+            logger.log(u"The path to the episode is " + str(epObj.fullPath()) + ", storing it in epLoc", logger.DEBUG)
+            epLoc = epObj.fullPath()
+            logger.log(u"Checking file existence for episode " + epObj.prettyName())
+            
+            # if the episode object has no location data, it means that there is no location in the database 
+            if epLoc is not None:
+                logger.log(u"Making sure " + epObj.prettyName() + " is still present at '" + str(epLoc) + "'", logger.DEBUG)
+                
+                # if the path doesn't exist or if it's not in our show dir, consider it deleted
+                if not ek.ek(os.path.isfile, epLoc) or not epLoc.startswith(os.path.normpath(epObj.show.location)):
+                    logger.log(u"Episode " + str(epObj.episode) + " has already been deleted, not downloading it again")
+                    deleted = True
+                else:
+                    logger.log(u"Episode " + str(epObj.episode) + " has not yet been deleted, downloading higher quality version")
+            else:
+                logger.log(u"We don't have this episode's location in our database, it probably hasn't aired yet", logger.DEBUG)
+    
+    logger.log(u"Returning " + str(deleted), logger.DEBUG)
+    return deleted
 
 def findEpisode(episode, manualSearch=False):
 
@@ -326,7 +361,12 @@ def findSeason(show, season):
 
                 # skip non-tv crap
                 curResults[curEp] = filter(lambda x:  show_name_helpers.filterBadReleases(x.name) and show_name_helpers.isGoodResult(x.name, show), curResults[curEp])
-
+                
+                # get a TV Episode object for episode number 'curEp' of this backlog's season, but don't create anything new
+                curEpObj = show.getEpisode(season, curEp, None, True)
+                if fileWasDeleted(curEpObj):
+                    continue
+                
                 if curEp in foundResults:
                     foundResults[curEp] += curResults[curEp]
                 else:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -748,7 +748,7 @@ class ConfigSearch:
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
-                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None):
+                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, check_existence=None):
 
         results = []
 
@@ -764,6 +764,11 @@ class ConfigSearch:
             download_propers = 1
         else:
             download_propers = 0
+            
+        if check_existence == "on":
+            check_existence = 1
+        else:
+            check_existence = 0
 
         if use_nzbs == "on":
             use_nzbs = 1
@@ -785,6 +790,7 @@ class ConfigSearch:
         sickbeard.USENET_RETENTION = int(usenet_retention)
 
         sickbeard.DOWNLOAD_PROPERS = download_propers
+        sickbeard.CHECK_EXISTENCE = check_existence
 
         sickbeard.SAB_USERNAME = sab_username
         sickbeard.SAB_PASSWORD = sab_password


### PR DESCRIPTION
This pull request adds functionality to Sick Beard to allow users to enable the option to not download better qualities of episodes if the original file is no longer present on the system. This is useful for people who use Sick Beard to download episodes, watch them and then immediately delete them from their hard drives. The functionality is off by default and can be turned on via the Search Settings config page.

The reason for this functionality is that you sometimes watch an episode before a higher quality becomes available. Other times however, you may not have the time to watch a new downloaded episode straight away. Until you do, you still would want Sick Beard to download the higher quality episodes. This is not an issue if you never delete your episodes, but it is when you do, or when you have a limited plan with your usenet provider.

This functionality works for the backlog searches as well as the RSS searches. It is not fully finished yet, as I am still in doubt as to what to do if one episode of a multi-episode or a season has been deleted. You probably wouldn't want to have to download an entire season if that means you get 2 or 3 episodes in higher quality, but the question is where to draw the line?

PS. This is a rewrite of pull request 307 (https://github.com/midgetspy/Sick-Beard/pull/307), which messed up the other branches since I modified stuff in the master branch.
