### PR TITLE
Fix for bug #1883 - nzbmatrix search provider error on no results: list index out of range

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -172,8 +172,8 @@
                         <p>If post-processing 'Rename episodes' is enabled then use these settings.</p>
                     </div>
 
-                    #set $naming_ep_type_text = ("1x02", "s01e02", "S01E02")
-                    #set $naming_multi_ep_type_text = ("extend", "duplicate", "repeat")
+                    #set $naming_ep_type_text = ("1x02", "s01e02", "S01E02", "02")
+                    #set $naming_multi_ep_type_text = ("extend", "duplicate", "repeat", "first")
                     
                     <fieldset class="component-group-list">
                         <div class="field-pair">

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -193,14 +193,6 @@
                         </div>
 
                         <div class="field-pair">
-                            <input type="checkbox" name="naming_use_periods" id="naming_use_periods" #if $sickbeard.NAMING_USE_PERIODS then "checked=\"checked\"" else ""#/>
-                            <label class="clearfix" for="naming_use_periods">
-                                <span class="component-title">Use Periods</span>
-                                <span class="component-desc">Replace the spaces with periods in the filename instead?</span>
-                            </label>
-                        </div>
-
-                        <div class="field-pair">
                             <input type="checkbox" name="naming_quality" id="naming_quality" #if $sickbeard.NAMING_QUALITY then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="naming_quality">
                                 <span class="component-title">Quality</span>
@@ -217,6 +209,19 @@
                             <label class="nocheck clearfix">
                                 <span class="component-title">&nbsp;</span>
                                 <span class="component-desc">Only applies to air-by-date shows. (eg. 2010-02-15 vs S12E23)</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label class="nocheck clearfix" for="naming_word_sep_type">
+                                <span class="component-title">Word Separator Style</span>
+                                <span class="component-desc">
+                                    <select name="naming_word_sep_type" id="naming_word_sep_type">
+                                    #for ($i, $ex) in enumerate($config.naming_word_sep_text):
+                                    <option value="$i" #if $i == int($sickbeard.NAMING_WORD_SEP_TYPE) then "selected=\"selected\"" else ""#>$ex</option>
+                                    #end for
+                                    </select>
+                                </span>
                             </label>
                         </div>
 

--- a/data/js/configPostProcessing.js
+++ b/data/js/configPostProcessing.js
@@ -6,9 +6,9 @@ $(document).ready(function(){
                   'ep_type': $('#naming_ep_type :selected').val(),
                   'multi_ep_type': $('#naming_multi_ep_type :selected').val(),
                   'ep_name': $('#naming_ep_name').prop('checked')?"1":"0",
-                  'use_periods': $('#naming_use_periods').prop('checked')?"1":"0",
                   'quality': $('#naming_quality').prop('checked')?"1":"0",
                   'sep_type': $('#naming_sep_type :selected').val(),
+                  'word_sep_type': $('#naming_word_sep_type :selected').val(),
                   'whichTest': 'single'
                   }
         
@@ -37,10 +37,6 @@ $(document).ready(function(){
         $(this).setExampleText();
     });  
 
-  $('#naming_use_periods').click(function(){
-        $(this).setExampleText();
-    });  
-
   $('#naming_quality').click(function(){
         $(this).setExampleText();
     });  
@@ -54,6 +50,10 @@ $(document).ready(function(){
     });  
 
   $('#naming_sep_type').change(function(){
+        $(this).setExampleText();
+    });  
+
+  $('#naming_word_sep_type').change(function(){
         $(this).setExampleText();
     });  
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -127,7 +127,7 @@ NAMING_EP_NAME = None
 NAMING_EP_TYPE = None
 NAMING_MULTI_EP_TYPE = None
 NAMING_SEP_TYPE = None
-NAMING_USE_PERIODS = None
+NAMING_WORD_SEP_TYPE = None
 NAMING_QUALITY = None
 NAMING_DATES = None
 
@@ -399,7 +399,7 @@ def initialize(consoleLogging=True):
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, \
                 NAMING_SHOW_NAME, NAMING_EP_TYPE, NAMING_MULTI_EP_TYPE, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
-                NAMING_EP_NAME, NAMING_SEP_TYPE, NAMING_USE_PERIODS, WOMBLE, \
+                NAMING_EP_NAME, NAMING_SEP_TYPE, NAMING_WORD_SEP_TYPE, WOMBLE, \
                 NZBSRUS, NZBSRUS_UID, NZBSRUS_HASH, NAMING_QUALITY, providerList, newznabProviderList, \
                 NAMING_DATES, EXTRA_SCRIPTS, USE_TWITTER, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
@@ -506,7 +506,7 @@ def initialize(consoleLogging=True):
         NAMING_EP_TYPE = check_setting_int(CFG, 'General', 'naming_ep_type', 0)
         NAMING_MULTI_EP_TYPE = check_setting_int(CFG, 'General', 'naming_multi_ep_type', 0)
         NAMING_SEP_TYPE = check_setting_int(CFG, 'General', 'naming_sep_type', 0)
-        NAMING_USE_PERIODS = bool(check_setting_int(CFG, 'General', 'naming_use_periods', 0))
+        NAMING_WORD_SEP_TYPE = check_setting_int(CFG, 'General', 'naming_word_sep', 0)
         NAMING_QUALITY = bool(check_setting_int(CFG, 'General', 'naming_quality', 0))
         NAMING_DATES = bool(check_setting_int(CFG, 'General', 'naming_dates', 1))
 
@@ -1024,7 +1024,7 @@ def save_config():
     new_config['General']['naming_ep_type'] = int(NAMING_EP_TYPE)
     new_config['General']['naming_multi_ep_type'] = int(NAMING_MULTI_EP_TYPE)
     new_config['General']['naming_sep_type'] = int(NAMING_SEP_TYPE)
-    new_config['General']['naming_use_periods'] = int(NAMING_USE_PERIODS)
+    new_config['General']['naming_word_sep_type'] = int(NAMING_WORD_SEP_TYPE)
     new_config['General']['naming_quality'] = int(NAMING_QUALITY)
     new_config['General']['naming_dates'] = int(NAMING_DATES)
     new_config['General']['launch_browser'] = int(LAUNCH_BROWSER)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -30,16 +30,18 @@ import sickbeard
 naming_ep_type = ("%(seasonnumber)dx%(episodenumber)02d",
                   "s%(seasonnumber)02de%(episodenumber)02d",
                    "S%(seasonnumber)02dE%(episodenumber)02d",
-                   "%(seasonnumber)02dx%(episodenumber)02d")
-naming_ep_type_text = ("1x02", "s01e02", "S01E02", "01x02")
+                   "%(seasonnumber)02dx%(episodenumber)02d",
+                   "%(episodenumber)02d")
+naming_ep_type_text = ("1x02", "s01e02", "S01E02", "01x02", "02")
 
 naming_multi_ep_type = {0: ["-%(episodenumber)02d"]*len(naming_ep_type),
                         1: [" - " + x for x in naming_ep_type],
-                        2: [x + "%(episodenumber)02d" for x in ("x", "e", "E", "x")]}
-naming_multi_ep_type_text = ("extend", "duplicate", "repeat")
+                        2: [x + "%(episodenumber)02d" for x in ("x", "e", "E", "x")],
+                        3: [""]*len(naming_ep_type)}
+naming_multi_ep_type_text = ("extend", "duplicate", "repeat", "first")
 
-naming_sep_type = (" - ", " ")
-naming_sep_type_text = (" - ", "space")
+naming_sep_type = (" - ", " . ", " ")
+naming_sep_type_text = (" - ", " . ", "space")
 
 def change_HTTPS_CERT(https_cert):
 

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -43,6 +43,9 @@ naming_multi_ep_type_text = ("extend", "duplicate", "repeat", "first")
 naming_sep_type = (" - ", " . ", " ")
 naming_sep_type_text = (" - ", " . ", "space")
 
+naming_word_sep_type = (" ", ".", "_")
+naming_word_sep_text = ("space", ".", "_")
+
 def change_HTTPS_CERT(https_cert):
 
     if https_cert == '':

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -209,9 +209,12 @@ class GenericProvider:
         Returns: A tuple containing two strings representing title and URL respectively
         """
         title = helpers.get_xml_text(item.getElementsByTagName('title')[0])
-        url = helpers.get_xml_text(item.getElementsByTagName('link')[0])
-        if url:
+        urlEl = item.getElementsByTagName('link')[0]
+        if urlEl:
+            url = helpers.get_xml_text(urlEl)
             url = url.replace('&amp;','&')
+        else:
+            url = None
         
         return (title, url)
     

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1352,7 +1352,7 @@ class TVEpisode(object):
         return self.show.getOverview(self.status)
 
     def prettyName (self, naming_show_name=None, naming_ep_type=None, naming_multi_ep_type=None,
-                    naming_ep_name=None, naming_sep_type=None, naming_use_periods=None, naming_quality=None):
+                    naming_ep_name=None, naming_sep_type=None, naming_word_sep_type=None, naming_quality=None):
 
         regex = "(.*) \(\d\)"
 
@@ -1405,8 +1405,8 @@ class TVEpisode(object):
         if naming_sep_type == None:
             naming_sep_type = sickbeard.NAMING_SEP_TYPE
 
-        if naming_use_periods == None:
-            naming_use_periods = sickbeard.NAMING_USE_PERIODS
+        if naming_word_sep_type == None:
+            naming_word_sep_type = sickbeard.NAMING_WORD_SEP_TYPE
 
         if naming_quality == None:
             naming_quality = sickbeard.NAMING_QUALITY
@@ -1424,13 +1424,17 @@ class TVEpisode(object):
         for relEp in self.relatedEps:
             goodEpString += config.naming_multi_ep_type[naming_multi_ep_type][naming_ep_type] % {'seasonnumber': relEp.season, 'episodenumber': relEp.episode}
 
+        naming_sep = config.naming_sep_type[naming_sep_type]
+        if naming_word_sep_type != 0: # Not the space character
+            naming_sep = re.sub("\s+", '', naming_sep)
+
         if goodName != '':
-            goodName = config.naming_sep_type[naming_sep_type] + goodName
+            goodName = naming_sep + goodName
 
         finalName = ""
 
         if naming_show_name:
-            finalName += self.show.name + config.naming_sep_type[naming_sep_type]
+            finalName += self.show.name + naming_sep
 
         finalName += goodEpString
 
@@ -1440,10 +1444,10 @@ class TVEpisode(object):
         if naming_quality:
             epStatus, epQual = Quality.splitCompositeStatus(self.status) #@UnusedVariable
             if epQual != Quality.NONE:
-                finalName += config.naming_sep_type[naming_sep_type] + Quality.qualityStrings[epQual]
+                finalName += naming_sep + Quality.qualityStrings[epQual]
 
-        if naming_use_periods:
-            finalName = re.sub("\s+", ".", finalName)
+        if naming_word_sep_type != 0:
+            finalName = re.sub("\s+", config.naming_word_sep_type[naming_word_sep_type], finalName)
 
         return finalName
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -827,7 +827,7 @@ class ConfigPostProcessing:
 
     @cherrypy.expose
     def savePostProcessing(self, season_folders_format=None, naming_show_name=None, naming_ep_type=None,
-                    naming_multi_ep_type=None, naming_ep_name=None, naming_use_periods=None,
+                    naming_multi_ep_type=None, naming_ep_name=None, naming_word_sep_type=None,
                     naming_sep_type=None, naming_quality=None, naming_dates=None,
                     xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
@@ -847,11 +847,6 @@ class ConfigPostProcessing:
             naming_ep_name = 1
         else:
             naming_ep_name = 0
-
-        if naming_use_periods == "on":
-            naming_use_periods = 1
-        else:
-            naming_use_periods = 0
 
         if naming_quality == "on":
             naming_quality = 1
@@ -904,7 +899,7 @@ class ConfigPostProcessing:
 
         sickbeard.NAMING_SHOW_NAME = naming_show_name
         sickbeard.NAMING_EP_NAME = naming_ep_name
-        sickbeard.NAMING_USE_PERIODS = naming_use_periods
+        sickbeard.NAMING_WORD_SEP_TYPE = int(naming_word_sep_type)
         sickbeard.NAMING_QUALITY = naming_quality
         sickbeard.NAMING_DATES = naming_dates
         sickbeard.NAMING_EP_TYPE = int(naming_ep_type)
@@ -927,7 +922,7 @@ class ConfigPostProcessing:
 
     @cherrypy.expose
     def testNaming(self, show_name=None, ep_type=None, multi_ep_type=None, ep_name=None,
-                   sep_type=None, use_periods=None, quality=None, whichTest="single"):
+                   sep_type=None, word_sep_type=None, quality=None, whichTest="single"):
 
         if show_name == None:
             show_name = sickbeard.NAMING_SHOW_NAME
@@ -945,13 +940,10 @@ class ConfigPostProcessing:
             else:
                 ep_name = True
 
-        if use_periods == None:
-            use_periods = sickbeard.NAMING_USE_PERIODS
+        if word_sep_type == None:
+            word_sep_type = sickbeard.NAMING_WORD_SEP_TYPE
         else:
-            if use_periods == "0":
-                use_periods = False
-            else:
-                use_periods = True
+            word_sep_type = int(word_sep_type)
 
         if quality == None:
             quality = sickbeard.NAMING_QUALITY
@@ -1002,7 +994,7 @@ class ConfigPostProcessing:
             ep.relatedEps.append(secondEp)
 
         # get the name
-        name = ep.prettyName(show_name, ep_type, multi_ep_type, ep_name, sep_type, use_periods, quality)
+        name = ep.prettyName(show_name, ep_type, multi_ep_type, ep_name, sep_type, word_sep_type, quality)
 
         return name
 


### PR DESCRIPTION
The minidom refactor created a small problem for the nzbmatrix provider. Nzbmatrix returns a single RSS item when a search isnt found but the item is missing the <link> tag:

```
<?xml version="1.0" encoding="iso-8859-1"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
<channel>
<generator>NZBMatrix.com RSS 2.0</generator>
<language>en</language>
<title>NZBMatrix</title>
<description>NZBMatrix.com RSS Feed - Usenet</description>
<link>http://nzbmatrix.com</link>
<copyright>Copyright 2012 NZBMatrix</copyright>
<pubDate>Sun, 04 Mar 2012 18:49:15 +0100</pubDate>
    <item>
        <title>Error: No Results Found For Your Search</title>
        <description>Error: No Results Found For Your Search</description>
    </item>
</channel>
</rss>
```

 This causes an exception since item.getElementsByTagName('link') returns an empty list in this case. 
