### PR TITLE
Fix BTN so it's not always enabled

### DIFF
--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -35,7 +35,7 @@ class BTNProvider(generic.TorrentProvider):
         self.url = 'http://broadcasthe.net/'
 
     def isEnabled(self):
-        return True
+        return sickbeard.BTN
         
     def imageName(self):
         return 'btn.gif'


### PR DESCRIPTION
BTN was set to be always enabled regardless of the config.  This fixes
it so that it actually uses the config to see if it's enabled or not.
