### PR TITLE
Fixed exception handling in _compile_regexes.

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -61,7 +61,7 @@ class NameParser(object):
             try:
                 cur_regex = re.compile(cur_pattern, re.VERBOSE | re.IGNORECASE)
             except re.error, errormsg:
-                logger.log(u"WARNING: Invalid episode_pattern, %s. %s" % (errormsg, cur_regex.pattern))
+                logger.log(u"WARNING: Invalid episode_pattern, %s. %s" % (errormsg, cur_pattern))
             else:
                 self.compiled_regexes.append((cur_pattern_name, cur_regex))
 


### PR DESCRIPTION
If regex compilation fails then cur_regex is not defined for the except block and accessing its pattern attribute raises an exception. Fixed by using cur_pattern instead.
