### PR TITLE
Ignore failed downloads

### DIFF
--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -41,8 +41,7 @@ class AuthURLOpener(urllib.FancyURLopener):
         return urllib.FancyURLopener.open(self, url)
 
 
-def processEpisode(dirName, nzbName=None):
-
+def processEpisode(dirName, nzbName=None, failed=False):
     config = ConfigParser.ConfigParser()
     configFilename = os.path.join(os.path.dirname(sys.argv[0]), "autoProcessTV.cfg")
     print "Loading config from", configFilename
@@ -74,6 +73,8 @@ def processEpisode(dirName, nzbName=None):
     params['dir'] = dirName
     if nzbName != None:
         params['nzbName'] = nzbName
+
+    params['failed'] = failed
         
     myOpener = AuthURLOpener(username, password)
     

--- a/autoProcessTV/sabToSickBeard.py
+++ b/autoProcessTV/sabToSickBeard.py
@@ -22,10 +22,17 @@
 import sys
 import autoProcessTV
 
-if len(sys.argv) < 2:
-    print "No folder supplied - is this being called from SABnzbd?"
+if len(sys.argv) < 8:
+    print "Not enough arguments received from SABnzbd. Please update it."
     sys.exit()
-elif len(sys.argv) >= 3:
-    autoProcessTV.processEpisode(sys.argv[1], sys.argv[2])
 else:
-    autoProcessTV.processEpisode(sys.argv[1])
+    autoProcessTV.processEpisode(sys.argv[1], sys.argv[2], False if sys.argv[7] == 0 else True)
+
+# SABnzbd argv:
+# 1	The final directory of the job (full path)
+# 2	The original name of the NZB file
+# 3	Clean version of the job name (no path info and ".nzb" removed)
+# 4	Indexer's report number (if supported)
+# 5	User-defined category
+# 6	Group that the NZB was posted in e.g. alt.binaries.x
+# 7	Status of post processing. 0 = OK, 1=failed verification, 2=failed unpack, 3=1+21

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -91,6 +91,14 @@
                             </label>
                         </div>
 
+                        <div class="field-pair">
+                            <input type="checkbox" name="delete_failed" id="delete_failed" #if $sickbeard.DELETE_FAILED == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="delete_failed">
+                                <span class="component-title">Delete Failed</span>
+                                <span class="component-desc">Delete files left over from a failed download?</span>
+                            </label>
+                        </div>
+
                         <div class="clearfix"></div>
                         <input type="submit" class="config_submitter" value="Save Changes" /><br/>
 

--- a/data/interfaces/default/home_postprocess.tmpl
+++ b/data/interfaces/default/home_postprocess.tmpl
@@ -8,7 +8,7 @@
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
 <form name="processForm" method="post" action="processEpisode">
-Enter the folder containing the episode: <input type="text" name="dir" id="episodeDir" size="50" /> <input type="submit" value="Process" />
+Enter the folder containing the episode: <input type="text" name="dirName" id="episodeDir" size="50" /> <input type="submit" value="Process" />
 </form>
 <br />
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -165,6 +165,7 @@ TORRENT_DIR = None
 
 RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
+DELETE_FAILED = False
 KEEP_PROCESSED_DIR = False
 MOVE_ASSOCIATED_FILES = False
 TV_DOWNLOAD_DIR = None
@@ -394,7 +395,7 @@ def initialize(consoleLogging=True):
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 USE_PYTIVO, PYTIVO_NOTIFY_ONSNATCH, PYTIVO_NOTIFY_ONDOWNLOAD, PYTIVO_UPDATE_LIBRARY, PYTIVO_HOST, PYTIVO_SHARE_NAME, PYTIVO_TIVO_NAME, \
                 USE_NMA, NMA_NOTIFY_ONSNATCH, NMA_NOTIFY_ONDOWNLOAD, NMA_API, NMA_PRIORITY, \
-                NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, \
+                NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, DELETE_FAILED, \
                 KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, \
                 NAMING_SHOW_NAME, NAMING_EP_TYPE, NAMING_MULTI_EP_TYPE, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
@@ -532,6 +533,7 @@ def initialize(consoleLogging=True):
 
         TV_DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'tv_download_dir', '')
         PROCESS_AUTOMATICALLY = check_setting_int(CFG, 'General', 'process_automatically', 0)
+        DELETE_FAILED = check_setting_int(CFG, 'General', 'delete_failed', 0)
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
@@ -1043,6 +1045,7 @@ def save_config():
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
+    new_config['General']['delete_failed'] = int(DELETE_FAILED)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
     
     new_config['General']['extra_scripts'] = '|'.join(EXTRA_SCRIPTS)

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -398,3 +398,21 @@ class FixAirByDateSetting(SetNzbTorrentSettings):
                 self.connection.action("UPDATE tv_shows SET air_by_date = ? WHERE tvdb_id = ?", [1, cur_show["tvdb_id"]])
         
         self.incDBVersion()
+
+class TrackFailedInHistory(FixAirByDateSetting):
+
+    def test(self):
+        return self.checkDBVersion() >= 10
+
+    def execute(self):
+        self.connection.action("ALTER TABLE history RENAME TO history_old")
+        self.connection.action("CREATE TABLE history (history_id INTEGER PRIMARY KEY, action NUMERIC, date NUMERIC, showid NUMERIC, season NUMERIC, episode NUMERIC, quality NUMERIC, resource TEXT, provider TEXT, failed NUMERIC);")
+
+        oldHistory = self.connection.action("SELECT * FROM history_old").fetchall()
+        for curResult in oldHistory:
+            sql = "INSERT INTO history (action, date, showid, season, episode, quality, resource, provider) VALUES (?,?,?,?,?,?,?,?)"
+            args = [curResult["action"], curResult["date"], curResult["showid"], curResult["season"], curResult["episode"], curResult["quality"], curResult["resource"], curResult["provider"]]
+            self.connection.action(sql, args)
+
+        self.connection.action("DROP TABLE history_old")
+        self.incDBVersion()

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -23,7 +23,6 @@ import os
 import re
 import shlex
 import subprocess
-import shutil
 
 import sickbeard
 
@@ -303,47 +302,6 @@ class PostProcessor(object):
         self.in_history = False
         return to_return
     
-    def _history_lookup_id(self):
-        """
-        Look up the NZB name in the history and see if it contains a record for self.nzb_name
-        
-        Returns the history_id of the record if found
-        """
-
-        to_return = None
-
-        if self.in_history == False:
-            return to_return
-        
-        if not self.nzb_name and not self.folder_name:
-            self.in_history = False
-            return to_return
-
-        names = []
-        if self.nzb_name:
-            names.append(self.nzb_name)
-            if '.' in self.nzb_name:
-                names.append(self.nzb_name.rpartition(".")[0])
-        if self.folder_name:
-            names.append(self.folder_name)
-
-        myDB = db.DBConnection()
-    
-        for curName in names:
-            sql_results = myDB.select("SELECT history_id FROM history WHERE resource LIKE ?", [re.sub("[\.\-\ ]", "_", curName)])
-    
-            if len(sql_results) == 0:
-                continue
-    
-            to_return = int(sql_results[0]["history_id"])
-
-            self._log("Found history_id in history: "+str(to_return), logger.DEBUG)
-            self.in_history = True
-            return to_return
-       
-        self.in_history = False
-        return to_return
-
     def _analyze_name(self, name, file=True):
         """
         Takes a name and tries to figure out a show, season, and episode from it.
@@ -642,23 +600,6 @@ class PostProcessor(object):
         # reset per-file stuff
         self.in_history = False
         
-        # if the download failed, mark it as bad in the history DB, optionally delete it, and give up
-        if self.folder_name.startswith("_FAILED_"):
-            history_id = self._history_lookup_id()
-            if history_id:
-                myDB = db.DBConnection()
-                self._log(u"Marking nzb as failed: " + self.nzb_name + "(" + history_id + ")", logger.DEBUG)
-                sql_results = myDB.select("UPDATE history SET failed = 1 WHERE history_id = ?", [history_id])
-
-            if sickbeard.DELETE_FAILED:
-                self._log(u"Deleting folder of failed download " + self.folder_path, logger.DEBUG)
-                try:
-                    shutil.rmtree(self.folder_path)
-                except (OSError, IOError), e:
-                    self._log(u"Warning: unable to remove the failed folder " + dirName + ": " + ex(e), logger.WARNING)
-
-            return False
-
         # try to find the file info
         (tvdb_id, season, episodes) = self._find_info()
         

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -55,11 +55,7 @@ def processDir (dirName, nzbName=None, recurse=False):
         returnStr += logHelper(u"Unable to figure out what folder to process. If your downloader and Sick Beard aren't on the same PC make sure you fill out your TV download dir in the config.", logger.DEBUG)
         return returnStr
 
-    # TODO: check if it's failed and deal with it if it is
-    if ek.ek(os.path.basename, dirName).startswith('_FAILED_'):
-        returnStr += logHelper(u"The directory name indicates it failed to extract, cancelling", logger.DEBUG)
-        return returnStr
-    elif ek.ek(os.path.basename, dirName).startswith('_UNDERSIZED_'):
+    if ek.ek(os.path.basename, dirName).startswith('_UNDERSIZED_'):
         returnStr += logHelper(u"The directory name indicates that it was previously rejected for being undersized, cancelling", logger.DEBUG)
         return returnStr
     elif ek.ek(os.path.basename, dirName).startswith('_UNPACK_'):

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -55,7 +55,9 @@ def processDir (dirName, nzbName=None, recurse=False):
         returnStr += logHelper(u"Unable to figure out what folder to process. If your downloader and Sick Beard aren't on the same PC make sure you fill out your TV download dir in the config.", logger.DEBUG)
         return returnStr
 
-    if ek.ek(os.path.basename, dirName).startswith('_UNDERSIZED_'):
+    if ek.ek(os.path.basename, dirName).startswith('_FAILED_'):
+        returnStr += logHelper(u"The directory name indicates that it failed", logger.DEBUG)
+    elif ek.ek(os.path.basename, dirName).startswith('_UNDERSIZED_'):
         returnStr += logHelper(u"The directory name indicates that it was previously rejected for being undersized, cancelling", logger.DEBUG)
         return returnStr
     elif ek.ek(os.path.basename, dirName).startswith('_UNPACK_'):

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -35,6 +35,7 @@ from sickbeard import ui
 from sickbeard import encodingKludge as ek
 from sickbeard.exceptions import ex
 from sickbeard import providers
+from sickbeard import db
 
 def _downloadResult(result):
     """
@@ -201,6 +202,12 @@ def pickBestResult(results, quality_list=None):
         
         if quality_list and cur_result.quality not in quality_list:
             logger.log(cur_result.name+" is a quality we know we don't want, rejecting it", logger.DEBUG)
+            continue
+
+        myDB = db.DBConnection()
+        sql_results = myDB.select("SELECT history_id FROM history WHERE failed = 1 AND resource = ?", [cur_result.name])
+        if len(sql_results) > 0:
+            logger.log(cur_result.name+" has previously failed, rejecting it")
             continue
         
         if not bestResult or bestResult.quality < cur_result.quality and cur_result.quality != Quality.UNKNOWN:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -888,10 +888,16 @@ class ConfigPostProcessing:
         else:
             move_associated_files = 0
 
+        if delete_failed == "on":
+            delete_failed = 1
+        else:
+            delete_failed = 0
+
         sickbeard.PROCESS_AUTOMATICALLY = process_automatically
         sickbeard.KEEP_PROCESSED_DIR = keep_processed_dir
         sickbeard.RENAME_EPISODES = rename_episodes
         sickbeard.MOVE_ASSOCIATED_FILES = move_associated_files
+        sickbeard.DELETE_FAILED = delete_failed
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1515,12 +1515,12 @@ class HomePostProcess:
         return _munge(t)
 
     @cherrypy.expose
-    def processEpisode(self, dir=None, nzbName=None, jobName=None, quiet=None):
+    def processEpisode(self, dirName=None, nzbName=None, jobName=None, quiet=None, failed=False):
 
-        if dir == None:
+        if dirName == None:
             redirect("/home/postprocess")
         else:
-            result = processTV.processDir(dir, nzbName)
+            result = processTV.processDir(dirName, nzbName, failed=failed)
             if quiet != None and int(quiet) == 1:
                 return result
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -831,7 +831,7 @@ class ConfigPostProcessing:
                     naming_sep_type=None, naming_quality=None, naming_dates=None,
                     xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
-                    move_associated_files=None, tv_download_dir=None):
+                    move_associated_files=None, tv_download_dir=None, delete_failed=None):
 
         results = []
 


### PR DESCRIPTION
So, here's a patch that tracks in the history database when a download fails. (Based on it starting with _FAILED_ during post-processing). Additionally, there's a setting on the post-processing page that determines whether or not failed downloads are deleted after being marked.

The initial database update takes foreeever, though. Can't do an update table when adding a primary key, unfortunately.
