### PR TITLE
Allow .mkv as extension for .dvdrip

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -126,7 +126,7 @@ class Quality:
 
         if checkName(["(pdtv|hdtv|dsr).(xvid|x264)"], all) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDTV
-        elif checkName(["(dvdrip|bdrip)(.ws)?.(xvid|divx|x264)"], any) and not checkName(["(720|1080)[pi]"], all):
+        elif checkName(["(dvdrip|bdrip)(.ws)?.(xvid|divx|x264|mkv)"], any) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDDVD
         elif checkName(["720p", "hdtv", "x264"], all) or checkName(["hr.ws.pdtv.x264"], any):
             return Quality.HDTV


### PR DESCRIPTION
Sick Beard assumed .mkv files to be HD TV even if they were DVD rips.

I use MakeMKV for all my rips, which of course means I end up with everything importing as HD TV rather than SD DVD; I'm not sure adding .mkv to the list of extensions checked will have a negative impact on anyone, as the filename contains .dvdrip anyway. (I assume .bdrip.mkv should still be counted as SD DVD quality?)
