### PR TITLE
Add Notification: Execute Command

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -805,7 +805,41 @@
                     </fieldset>
                 </div><!-- /trakt component-group //-->
 
+				<br />
+                <h1>Other</h1>
+                <br />
+				              <div id="core-component-group11" class="component-group clearfix">
+                    <div class="component-group-desc">
+                        <h3>Execute Command</h3>
+                        <p>Execute a command when the download finishes.  Useful for rsync of .torrent files to a remote seedbox</p>
+                    </div>
 
+                    <fieldset class="component-group-list">
+                        <div class="field-pair">
+                            <input type="checkbox" class="enabler" name="use_commandnotify" id="use_commandnotify" #if $sickbeard.USE_COMMANDNOTIFY then "checked=\"checked\"" else ""# /> 
+                            <label class="clearfix" for="use_commandnotify">
+                                <span class="component-title">Enable</span>
+                                <span class="component-desc">Should Sick Beard execute a command notification?<br /><br />
+                                </span>
+                            </label>
+                        </div>
+                    <div id="content_use_commandnotify">
+                        <div class="field-pair">
+                            <label class="nocheck clearfix">
+                                <span class="component-title">Command to execute on download complete</span>
+                                <input type="text" name="notify_command" id="notify_command" value="$sickbeard.NOTIFY_COMMAND" size="35" />
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Ex. rysnc or a custom script</span>
+                            </label>
+                        </div>
+                        <div class="testNotification" id="testCommandNotify-result">Click below to test.</div>
+                        <input type="button" value="Test Command Notify" id="testCommandNotify" />
+                        <input type="submit" class="config_submitter" value="Save Changes" />
+                        </div><!-- /content_use_email //-->
+                    </fieldset>
+                </div><!-- /component-group //-->
             <br/><input type="submit" class="config_submitter" value="Save Changes" /><br/>
             </div><!-- /config-components //-->
         </form>

--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -135,4 +135,11 @@ $(document).ready(function(){
         var nma_result = $.get(sbRoot+"/home/testNMA", {'nma_api': nma_api, 'nma_priority': nma_priority}, 
         function (data){ $('#testNMA-result').html(data); });
     });
+
+    $('#testCommandNotify').click(function(){
+        $('#testCommandNotify-result').html(loading);
+        var notify_command = $("#notify_command").val();
+        $.get(sbRoot+"/home/testCommandNotify", {'command': notify_command},
+        function (data){ $('#testCommandNotify-result').html(data); });
+    });
 });

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -248,6 +248,9 @@ BOXCAR_USERNAME = None
 BOXCAR_PASSWORD = None
 BOXCAR_PREFIX = None
 
+USE_COMMANDNOTIFY = False
+NOTIFY_COMMAND = None
+
 USE_LIBNOTIFY = False
 LIBNOTIFY_NOTIFY_ONSNATCH = False
 LIBNOTIFY_NOTIFY_ONDOWNLOAD = False
@@ -407,6 +410,7 @@ def initialize(consoleLogging=True):
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
+                USE_COMMANDNOTIFY, NOTIFY_COMMAND, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS
 
         if __INITIALIZED__:
@@ -634,6 +638,9 @@ def initialize(consoleLogging=True):
         NMJ_HOST = check_setting_str(CFG, 'NMJ', 'nmj_host', '')
         NMJ_DATABASE = check_setting_str(CFG, 'NMJ', 'nmj_database', '')
         NMJ_MOUNT = check_setting_str(CFG, 'NMJ', 'nmj_mount', '')
+
+        USE_COMMANDNOTIFY = bool(check_setting_int(CFG, 'ExecuteCommand', 'use_commandnotify', 0))
+        NOTIFY_COMMAND = check_setting_str(CFG, 'ExecuteCommand', 'notify_command', '')
 
         USE_SYNOINDEX = bool(check_setting_int(CFG, 'Synology', 'use_synoindex', 0))
 
@@ -1201,6 +1208,10 @@ def save_config():
     new_config['GUI']['coming_eps_layout'] = COMING_EPS_LAYOUT
     new_config['GUI']['coming_eps_display_paused'] = int(COMING_EPS_DISPLAY_PAUSED)
     new_config['GUI']['coming_eps_sort'] = COMING_EPS_SORT
+
+    new_config['ExecuteCommand'] = {}
+    new_config['ExecuteCommand']['use_commandnotify'] = int(USE_COMMANDNOTIFY)
+    new_config['ExecuteCommand']['notify_command'] = NOTIFY_COMMAND
 
     new_config.write()
 

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -31,6 +31,7 @@ import synoindex
 import trakt
 import pytivo
 import nma
+import commandnotify
 
 from sickbeard.common import *
 
@@ -47,6 +48,7 @@ synoindex_notifier = synoindex.synoIndexNotifier()
 trakt_notifier = trakt.TraktNotifier()
 pytivo_notifier = pytivo.pyTivoNotifier()
 nma_notifier = nma.NMA_Notifier()
+command_notifier = commandnotify.CommandNotifier()
 
 notifiers = [
     # Libnotify notifier goes first because it doesn't involve blocking on
@@ -63,6 +65,7 @@ notifiers = [
     trakt_notifier,
     pytivo_notifier,
     nma_notifier,
+    command_notifier
 ]
 
 def notify_download(ep_name):

--- a/sickbeard/notifiers/commandnotify.py
+++ b/sickbeard/notifiers/commandnotify.py
@@ -1,0 +1,21 @@
+import string
+import sickbeard
+import os
+
+from sickbeard import logger
+
+class CommandNotifier:
+    
+    def test_notify(self, command):
+        return self._executeCommand(command)
+
+    def _executeCommand(self, command):
+        if not command:
+            command = sickbeard.NOTIFY_COMMAND
+        logger.log("Executing command notification: " + command, logger.DEBUG)
+        os.system(command)
+        return True
+    def notify_download(self, command):
+        self._executeCommand(command)
+        
+notifier = CommandNotifier

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1206,7 +1206,8 @@ class ConfigNotifications:
                           use_trakt=None, trakt_username=None, trakt_password=None, trakt_api=None,
                           use_pytivo=None, pytivo_notify_onsnatch=None, pytivo_notify_ondownload=None, pytivo_update_library=None, 
                           pytivo_host=None, pytivo_share_name=None, pytivo_tivo_name=None,
-                          use_nma=None, nma_notify_onsnatch=None, nma_notify_ondownload=None, nma_api=None, nma_priority=0 ):
+                          use_nma=None, nma_notify_onsnatch=None, nma_notify_ondownload=None, nma_api=None, nma_priority=0,
+                          use_commandnotify=None, notify_command=None):
 
         results = []
 
@@ -1376,6 +1377,11 @@ class ConfigNotifications:
         else:
             nma_notify_ondownload = 0
 
+        if use_commandnotify == "on":
+            use_commandnotify = 1
+        else:
+            use_commandnotify = 0
+
         sickbeard.USE_XBMC = use_xbmc
         sickbeard.XBMC_NOTIFY_ONSNATCH = xbmc_notify_onsnatch
         sickbeard.XBMC_NOTIFY_ONDOWNLOAD = xbmc_notify_ondownload
@@ -1429,6 +1435,9 @@ class ConfigNotifications:
         sickbeard.NMJ_HOST = nmj_host
         sickbeard.NMJ_DATABASE = nmj_database
         sickbeard.NMJ_MOUNT = nmj_mount
+
+        sickbeard.USE_COMMANDNOTIFY = use_commandnotify
+        sickbeard.NOTIFY_COMMAND = notify_command
 
         sickbeard.USE_SYNOINDEX = use_synoindex
 
@@ -2114,6 +2123,15 @@ class Home:
             return "Test NMA notice sent successfully"
         else:
             return "Test NMA notice failed"
+
+    @cherrypy.expose
+    def testCommandNotify(self, command=None):
+        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
+        result = notifiers.command_notifier.test_notify(command)
+        if result:
+            return "Successfully executed"
+        else:
+            return "Test failed"
 
     @cherrypy.expose
     def shutdown(self):


### PR DESCRIPTION
Added category 'Other' and included a notification to execute a command when a torrent finishes.

Ex. Execute an rsync to push .torrent files to a watch directory on a remote seedbox eliminating a cron job and wasted bandwidth
