### PR TITLE
Converted cookie references over to localStorage (html5).

### DIFF
--- a/data/js/browser.js
+++ b/data/js/browser.js
@@ -137,9 +137,13 @@
                 };
         }
 
-        var initialDir, path, callback = null;
-        // if the text field is empty and we're given a key then populate it with the last browsed value from a cookie
-        if (options.key && options.field.val().length === 0 && (path = $.cookie('fileBrowser-' + options.key))) {
+        var initialDir, path, callback, ls = false;
+        // if the text field is empty and we're given a key then populate it with the last browsed value from localStorage
+        try { ls = !!(localStorage.getItem); } catch (e) {}
+        if (ls && options.key) {
+            path = localStorage['fileBrowser-' + options.key];
+        }
+        if (options.key && options.field.val().length === 0 && (path)) {
             options.field.val(path);
         }
 
@@ -147,13 +151,14 @@
             // store the browsed path to the associated text field
             options.field.val(path);
 
-            // use a cookie to remember for next time
-            if (options.key) {
-                $.cookie('fileBrowser-' + options.key, path);
+            // use a localStorage to remember for next time -- no ie6/7
+            if (ls && options.key) {
+                localStorage['fileBrowser-' + options.key] = path;
             }
+
         };
 
-        initialDir = options.field.val() || (options.key && $.cookie('fileBrowser-' + options.key)) || '';
+        initialDir = options.field.val() || (options.key && path) || '';
 
         options = $.extend(options, {initialDir: initialDir});
 


### PR DESCRIPTION
This saves HTTP requests and keeps the scope of the data local to the machine.
DOM storage has been around for awhile and basically any browser EXCEPT IE6/7 is supported (oh no!).
This means we could retire the use of the cookie/cookiejar/JSON js libs.. _However, I've left them alone for now._
