### PR TITLE
Accept comma separated list for Plex Media Server hosts

### DIFF
--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -66,26 +66,27 @@ class PLEXNotifier(XBMCNotifier):
             logger.log(u"No host specified, no updates done", logger.DEBUG)
             return False
 
-        logger.log(u"Plex Media Server updating " + sickbeard.PLEX_SERVER_HOST, logger.DEBUG)
+        for curHost in [x.strip() for x in sickbeard.PLEX_SERVER_HOST.split(",")]:
+            logger.log(u"Plex Media Server updating " + curHost, logger.DEBUG)
 
-        url = "http://%s/library/sections" % sickbeard.PLEX_SERVER_HOST
-        try:
-            xml_sections = minidom.parse(urllib.urlopen(url))
-        except IOError, e:
-            logger.log(u"Error while trying to contact your plex server: "+ex(e), logger.ERROR)
-            return False
+            url = "http://%s/library/sections" % curHost
+            try:
+                xml_sections = minidom.parse(urllib.urlopen(url))
+            except IOError, e:
+                logger.log(u"Error while trying to contact your plex server: "+ex(e), logger.ERROR)
+                return False
 
-        sections = xml_sections.getElementsByTagName('Directory')
+            sections = xml_sections.getElementsByTagName('Directory')
 
-        for s in sections:
-            if s.getAttribute('type') == "show":
-                url = "http://%s/library/sections/%s/refresh" % (sickbeard.PLEX_SERVER_HOST, s.getAttribute('key'))
+            for s in sections:
+                if s.getAttribute('type') == "show":
+                    url = "http://%s/library/sections/%s/refresh" % (curHost, s.getAttribute('key'))
 
-                try:
-                    urllib.urlopen(url)
-                except Exception, e:
-                    logger.log(u"Error updating library section: "+ex(e), logger.ERROR)
-                    return False
+                    try:
+                        urllib.urlopen(url)
+                    except Exception, e:
+                        logger.log(u"Error updating library section: "+ex(e), logger.ERROR)
+                        return False
 
         return True
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2471,11 +2471,11 @@ class Home:
     def updatePLEX(self):
 
         if notifiers.plex_notifier._update_library():
-            ui.notifications.message("Command sent to Plex Media Server host " + sickbeard.PLEX_HOST + " to update library")
-            logger.log(u"Plex library update initiated for host " + sickbeard.PLEX_HOST, logger.DEBUG)
+            ui.notifications.message("Command sent to Plex Media Server host " + sickbeard.PLEX_SERVER_HOST + " to update library")
+            logger.log(u"Plex library update initiated for host " + sickbeard.PLEX_SERVER_HOST, logger.DEBUG)
         else:
-            ui.notifications.error("Unable to contact Plex Media Server host " + sickbeard.PLEX_HOST)
-            logger.log(u"Plex library update failed for host " + sickbeard.PLEX_HOST, logger.ERROR)
+            ui.notifications.error("Unable to contact Plex Media Server host " + sickbeard.PLEX_SERVER_HOST)
+            logger.log(u"Plex library update failed for host " + sickbeard.PLEX_SERVER_HOST, logger.ERROR)
         redirect('/home')
 
 


### PR DESCRIPTION
Accept comma separated list for Plex Media Server hosts (just like in the XBMC notifier) for the rare case someone wants or needs to update more than one Plex library.
