### PR TITLE
cross-domain api

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -159,6 +159,8 @@ class Api:
         """ set cherrypy response to json """
         response = cherrypy.response
         response.headers['Content-Type'] = 'application/json;charset=UTF-8'
+        response.headers['Access-Control-Allow-Origin'] = '*'	
+        response.headers['Access-Control-Allow-Headers'] = 'x-requested-with'
         try:
             out = json.dumps(dict, indent=self.intent, sort_keys=True)
         except Exception, e: # if we fail to generate the output fake a error

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -159,7 +159,7 @@ class Api:
         """ set cherrypy response to json """
         response = cherrypy.response
         response.headers['Content-Type'] = 'application/json;charset=UTF-8'
-        response.headers['Access-Control-Allow-Origin'] = '*'	
+        response.headers['Access-Control-Allow-Origin'] = 'http://localhost'	
         response.headers['Access-Control-Allow-Headers'] = 'x-requested-with'
         try:
             out = json.dumps(dict, indent=self.intent, sort_keys=True)


### PR DESCRIPTION
allow other domains (and ports) to access the api.

useful so that you can make calls to the api from a different port/server, using a javascript ajax call
