### PR TITLE
Revert init.fedora changes

### DIFF
--- a/init.fedora
+++ b/init.fedora
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 ### BEGIN INIT INFO
 # Provides:          Sick Beard application instance
 # Required-Start:    $all


### PR DESCRIPTION
This pull request reverts the init.fedora changes to the systemd format, but does add the initial shebang line which is required for systemd to fire legacy SysV initd scripts. This change will not affect how the script works on older Fedora/RHEL/CentOS or cloned distros.
