### PR TITLE
determining the DATA_DIR (~/.sickbeard) is broken in init.ubuntu

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -29,11 +29,14 @@ NAME=sickbeard
 # app name
 DESC=SickBeard
 
-# user
+# username to run SickBeard as
 RUN_AS=SICKBEARD_USER
 
+# homedir of the user running sickbeard (field 6 is the homedir spec)
+USER_HOME=$(grep ${RUN_AS} /etc/passwd | cut -d ":" -f6)
+
 # data directory
-DATA_DIR=~/.sickbeard
+DATA_DIR=$USER_HOME/.sickbeard
 
 # startup args
 DAEMON_OPTS=" SickBeard.py -q --daemon --pidfile=${PID_FILE} --datadir=${DATA_DIR}"


### PR DESCRIPTION
The current way of determining the $DATA_DIR (~/.sickbeard) is broken, and will create the configs in /root instead of the running user's homedir on both Ubuntu and Debian. Parsing /etc/passwd is the canonical way to determine a users homedir. This also causes all sorts of issues as later on /root/.sickbeard is chown to $RUN_AS, hence allowing writes in root's homedir.
