### PR TITLE
Nonzero result code on error.

### DIFF
--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -90,7 +90,7 @@ def processEpisode(dirName, nzbName=None):
         urlObj = myOpener.openit(url)
     except IOError, e:
         print "Unable to open URL: ", str(e)
-        sys.exit()
+        sys.exit(1)
     
     result = urlObj.readlines()
     for line in result:


### PR DESCRIPTION
Make url error return non-zero result code to allow sabznbd to display retry button.
