### PR TITLE
displayShow poster art, other fixes

### DIFF
--- a/data/css/default.css
+++ b/data/css/default.css
@@ -248,6 +248,10 @@ background-color:#efefef;
 padding:10px;
 border:1px solid #DFDEDE;
 margin:10px;
+overflow: auto;
+}
+div#summary img.posterThumb {
+float: right;
 }
 div#summary tr {
 line-height: 17px;

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -56,6 +56,7 @@
 </div>
 
 <div id="summary" class="align-left">
+<img alt="" class="posterThumb" src="$sbRoot/showPoster/?show=$show.tvdbid&amp;which=poster" />
 <table class="infoTable" cellspacing="1" border="0" cellpadding="0">
 #if $show.network and $show.airs:
     <tr><td class="showLegend">Airs: </td><td>$show.airs on $show.network</td></tr>

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -474,11 +474,7 @@ class TVDBShorthandWrapper(ApiCall):
 
     def run(self):
         """ internal function wrapper """
-        # how to add a var to a tuple
-        # http://stackoverflow.com/questions/1380860/add-variables-to-tuple
-        argstmp = (0, self.sid) # make a new tuple
-        args = argstmp + self.origArgs # add both
-        args = args[1:] # remove first fake element
+        args = (self.sid,) + self.origArgs
         if self.e:
             return CMD_Episode(args, self.kwargs).run()
         elif self.s:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2704,7 +2704,7 @@ class WebInterface:
                 if im.mode == 'P': # Convert GIFs to RGB
                     im = im.convert('RGB')
                 if which == 'banner':
-                    size = 600, 112
+                    size = 606, 112
                 elif which == 'poster':
                     size = 136, 200
                 else:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2677,13 +2677,13 @@ class WebInterface:
             default_image_name = 'banner.png'
 
         default_image_path = ek.ek(os.path.join, sickbeard.PROG_DIR, 'data', 'images', default_image_name)
-        if show == None:
-            return cherrypy.lib.static.serve_file(default_image_path, content_type="image/jpeg")
+        if show is None:
+            return cherrypy.lib.static.serve_file(default_image_path, content_type="image/png")
         else:
             showObj = sickbeard.helpers.findCertainShow(sickbeard.showList, int(show))
 
-        if showObj == None:
-            return cherrypy.lib.static.serve_file(default_image_path, content_type="image/jpeg")
+        if showObj is None:
+            return cherrypy.lib.static.serve_file(default_image_path, content_type="image/png")
 
         cache_obj = image_cache.ImageCache()
         
@@ -2715,7 +2715,7 @@ class WebInterface:
                 cherrypy.response.headers['Content-Type'] = 'image/jpeg'
                 return buffer.getvalue()
         else:
-            return cherrypy.lib.static.serve_file(default_image_path, content_type="image/jpeg")
+            return cherrypy.lib.static.serve_file(default_image_path, content_type="image/png")
 
     @cherrypy.expose
     def setComingEpsLayout(self, layout):


### PR DESCRIPTION
- adds the show's poster to the top of its displayShow page in the summary block
- fix the banner size to match the CSS (was making images blurry)
- fix the content-type header to match the image type
