### PR TITLE
Fixed up issue in build 495 with CSS styling on Sort Arrows

### DIFF
--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -27,6 +27,8 @@
 
 .sf-sub-indicator { background: url("$sbRoot/images/arrows.png") no-repeat -10px -100px; }
 .sf-shadow ul { background: url("$sbRoot/images/shadow.png") no-repeat bottom right; }
+
+th {background-repeat: no-repeat;}
 th.tablesorter-header { background-image: url("$sbRoot/images/tablesorter/bg.gif"); }
 th.tablesorter-headerSortUp { background-image: url("$sbRoot/images/tablesorter/asc.gif"); }
 th.tablesorter-headerSortDown { background-image: url("$sbRoot/images/tablesorter/desc.gif"); }


### PR DESCRIPTION
Hi,

A small fix for CSS style on the sort arrows in the table headings where they were not set to no-repeat

Cheers

James
