### PR TITLE
Fix an issue where season banners don't always download for the most recent season

### DIFF
--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -582,7 +582,8 @@ class GenericMetadata():
         # Returns a nested dictionary of season art with the season
         # number as primary key. It's really overkill but gives the option
         # to present to user via ui to pick down the road.
-        for cur_season in range(num_seasons):
+        # Add '1' to num_seasons so range() will include all seasons for shows without a season 0 (Specials).
+        for cur_season in range(num_seasons+1):
 
             result[cur_season] = {}
             
@@ -592,7 +593,7 @@ class GenericMetadata():
                     result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
             
             if len(result[cur_season]) == 0:
-                continue
+                del result[cur_season]
 
         return result
 


### PR DESCRIPTION
Fix an issue where season banners don't download for the most recent season of a show that does not have a season 0 (specials season).

Currently:
If show X has three seasons and specials, num_seasons is 4 (tvdb_show_obj: [0, 1, 2, 3])
If show Y has three seasons and no specials, num_seasons is 3 (tvdb_show_obj: [1, 2, 3])

When iterating over range(num_seasons) to look for season banners:
Show X will check for banners for seasons [0, 1, 2, 3]
Show Y will check for banners for seasons [0, 1, 2]

This means Sick-Beard will never download season banners for the most recent season of a series without specials.

With this patch the iteration takes place over range(num_seasons+1) so:
Show X will check for banners for seasons [0, 1, 2, 3, 4]
Show Y will check for banners for seasons [0, 1, 2, 3]
