### PR TITLE
Fix get images with api error

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1795,10 +1795,10 @@ class CMD_ShowAddNew(ApiCall):
 
         # moved the logic check to the end in an attempt to eliminate empty directory being created from previous errors
         showPath = ek.ek(os.path.join, self.location, helpers.sanitizeFileName(tvdbName))
-        
+
         # don't create show dir if config says not to
         if sickbeard.ADD_SHOWS_WO_DIR:
-            logger.log(u"Skipping initial creation of "+showPath+" due to config.ini setting")
+            logger.log(u"Skipping initial creation of " + showPath + " due to config.ini setting")
         else:
             dir_exists = helpers.makeDir(showPath)
             if not dir_exists:

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -104,6 +104,8 @@ class Api:
         else:# if debug was not set we wrap the "call_dispatcher" in a try block to assure a json output
             try:
                 outDict = _call_dispatcher(args, kwargs)
+            except cherrypy.HTTPRedirect: # seams like cherrypy uses exceptions for redirecting apparently this can happen when requesting images but it is ok so lets re raise it
+                raise
             except Exception, e: # real internal error oohhh nooo :(
                 logger.log(u"API :: " + ex(e), logger.ERROR)
                 errorData = {"error_msg": ex(e),


### PR DESCRIPTION
this fixes an issue where some images would not get returned this is due cherrypy throws a HTTPRedirect exception in some cases

you could fix this by adding &debug=1 to the request url because the exception would be handled by cherrypy itself and not by our catch block

this fix anticipates the HTTPRedirect exception and does not "kill" the output of the image
