### PR TITLE
Issue 1629: Add full Synology index command set (addendum)

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1797,6 +1797,8 @@ class NewHomeAddShows:
             redirect("/home")
         else:
             helpers.chmodAsParent(show_dir)
+            # do the library update for synoindex
+            notifiers.synoindex_notifier.addFolder(show_dir)
 
         # prepare the inputs for passing along
         if seasonFolders == "on":


### PR DESCRIPTION
This amends the previous pull request #208 which added the complete 'synoindex' command library to Sick-Beard. The specific fix is to include the notifier for the creation of a new TV show.
