### PR TITLE
fixed the version checker message to properly pluralize 'commit' in the

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -330,7 +330,9 @@ class GitUpdateManager(UpdateManager):
             message = "or else you're ahead of master"
 
         elif self._num_commits_behind > 0:
-            message = "you're "+str(self._num_commits_behind)+' commits behind'
+          message = "you're %d commit" % self._num_commits_behind
+          if self._num_commits_behind > 1: message += 's'
+          message += ' behind'
 
         else:
             return


### PR DESCRIPTION
Hey,

This typo has been annoying me for the last year, so I fixed it for you.

Basically, when the user is a single commit behind the master branch, it says:

```
 There is a newer version available (you're 1 commits behind)— Update Now
```

this patch will fix that to read: `you're 1 commit behind` and pluralize it to "commits" when the user is more than 1 commit behind.
