### PR TITLE
Update the scene exception db before checking for updates

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -48,10 +48,10 @@ class CheckVersion():
             self.updater = None
 
     def run(self):
-        self.check_for_new_version()
-        
         # refresh scene exceptions too
         scene_exceptions.retrieve_exceptions()
+
+        self.check_for_new_version()
 
     def find_install_type(self):
         """


### PR DESCRIPTION
This addresses an issue that can occur when using a zipball/tarball of a tagged version. The version checker encounters an exception which ends the thread before the scene exceptions are populated. Swapping the order so the more stable exception retrieval runs first fixes the issue.
