### PR TITLE
Don't require zero-padding on episode numbers

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -31,7 +31,7 @@ ep_regexes = [
                [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
                ((?<![. _-])-(?P<release_group>[^-]+))?)?$  # Group
                '''),
-              
+
               ('fov_repeat',
                # Show.Name.1x02.1x03.Source.Quality.Etc-Group
                # Show Name - 1x02 - 1x03 - 1x04 - Ep Name
@@ -44,7 +44,7 @@ ep_regexes = [
                [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
                ((?<![. _-])-(?P<release_group>[^-]+))?)?$  # Group
                '''),
-              
+
               ('standard',
                # Show.Name.S01E02.Source.Quality.Etc-Group
                # Show Name - S01E02 - My Ep Name
@@ -78,7 +78,7 @@ ep_regexes = [
                [\]. _-]*((?P<extra_info>.+?)               # Source_Quality_Etc-
                ((?<![. _-])-(?P<release_group>[^-]+))?)?$  # Group
                '''),
-        
+
               ('scene_date_format',
                # Show.Name.2010.11.23.Source.Quality.Etc-Group
                # Show Name - 2010-11-23 - Ep Name
@@ -90,7 +90,7 @@ ep_regexes = [
                [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
                ((?<![. _-])-(?P<release_group>[^-]+))?)?$  # Group
                '''),
-              
+
               ('stupid',
                # tpz-abc102
                '''
@@ -99,7 +99,7 @@ ep_regexes = [
                (?P<season_num>\d{1,2})                     # 1
                (?P<ep_num>\d{2})$                          # 02
                '''),
-              
+
               ('verbose',
                # Show Name Season 1 Episode 2 Ep Name
                '''
@@ -110,7 +110,7 @@ ep_regexes = [
                (?P<ep_num>\d+)[. _-]+                      # 02 and separator
                (?P<extra_info>.+)$                         # Source_Quality_Etc-
                '''),
-              
+
               ('season_only',
                # Show.Name.S01.Source.Quality.Etc-Group
                '''
@@ -162,13 +162,13 @@ ep_regexes = [
                ([. _-]+(?P<extra_info>(?!\d{3}[. _-]+)[^-]+) # Source_Quality_Etc-
                (-(?P<release_group>.+))?)?$                # Group
                '''),
-              
+
               ('no_season',
                # Show Name - 01 - Ep Name
                # 01 - Ep Name
                '''
                ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
-               (?P<ep_num>\d{2})                           # 02
+               (?P<ep_num>\d{1,2})                         # 02
                [. _-]+((?P<extra_info>.+?)                 # Source_Quality_Etc-
                ((?<![. _-])-(?P<release_group>[^-]+))?)?$  # Group
                '''

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -28,7 +28,7 @@ simple_test_cases = {
               'Show-Name-S06E01-720p': parser.ParseResult(None, 'Show-Name', 6, [1], '720p' ),
               'Show-Name-S06E01-1080i': parser.ParseResult(None, 'Show-Name', 6, [1], '1080i' ),
               },
-              
+
               'fov': {
               'Show_Name.1x02.Source_Quality_Etc-Group': parser.ParseResult(None, 'Show Name', 1, [2], 'Source_Quality_Etc', 'Group'),
               'Show Name 1x02': parser.ParseResult(None, 'Show Name', 1, [2]),
@@ -47,7 +47,7 @@ simple_test_cases = {
               'Show.Name.S01E02.S01E03': parser.ParseResult(None, 'Show Name', 1, [2,3]),
               'Show Name - S01E02 - S01E03 - S01E04 - Ep Name': parser.ParseResult(None, 'Show Name', 1, [2,3,4], 'Ep Name'),
               },
-              
+
               'fov_repeat': {
               'Show.Name.1x02.1x03.Source.Quality.Etc-Group': parser.ParseResult(None, 'Show Name', 1, [2,3], 'Source.Quality.Etc', 'Group'),
               'Show.Name.1x02.1x03': parser.ParseResult(None, 'Show Name', 1, [2,3]),
@@ -62,15 +62,17 @@ simple_test_cases = {
               'the.event.401.hdtv-lol': parser.ParseResult(None, 'the event', 4, [1], 'hdtv', 'lol'),
               'show.name.2010.special.hdtv-blah': None,
               },
-              
+
               'stupid': {
               'tpz-abc102': parser.ParseResult(None, None, 1, [2], None, 'tpz'),
               'tpz-abc.102': parser.ParseResult(None, None, 1, [2], None, 'tpz'),
               },
-              
+
               'no_season': {
               'Show Name - 01 - Ep Name': parser.ParseResult(None, 'Show Name', None, [1], 'Ep Name'),
               '01 - Ep Name': parser.ParseResult(None, None, None, [1], 'Ep Name'),
+              '1 - Ep Name': parser.ParseResult(None, None, None, [1], 'Ep Name'),
+              '1-Ep Name': parser.ParseResult(None, None, None, [1], 'Ep Name'),
               },
 
               'no_season_general': {
@@ -92,7 +94,7 @@ simple_test_cases = {
               'Show Name Season 2': parser.ParseResult(None, 'Show Name', 2),
               'Season 02': parser.ParseResult(None, None, 2),
               },
-              
+
               'scene_date_format': {
               'Show.Name.2010.11.23.Source.Quality.Etc-Group': parser.ParseResult(None, 'Show Name', None, [], 'Source.Quality.Etc', 'Group', datetime.date(2010,11,23)),
               'Show Name - 2010.11.23': parser.ParseResult(None, 'Show Name', air_date = datetime.date(2010,11,23)),
@@ -106,7 +108,7 @@ combination_test_cases = [
                           ('/test/path/to/Season 02/03 - Ep Name.avi',
                            parser.ParseResult(None, None, 2, [3], 'Ep Name'),
                            ['no_season', 'season_only']),
-                          
+
                           ('Show.Name.S02.Source.Quality.Etc-Group/tpz-sn203.avi',
                            parser.ParseResult(None, 'Show Name', 2, [3], 'Source.Quality.Etc', 'Group'),
                            ['stupid', 'season_only']),
@@ -114,11 +116,11 @@ combination_test_cases = [
                           ('MythBusters.S08E16.720p.HDTV.x264-aAF/aaf-mb.s08e16.720p.mkv',
                            parser.ParseResult(None, 'MythBusters', 8, [16], '720p.HDTV.x264', 'aAF'),
                            ['standard']),
-                           
+
                           ('/home/drop/storage/TV/Terminator The Sarah Connor Chronicles/Season 2/S02E06 The Tower is Tall, But the Fall is Short.mkv',
                            parser.ParseResult(None, None, 2, [6], 'The Tower is Tall, But the Fall is Short'),
                            ['standard']),
-                           
+
                           (r'/Test/TV/Jimmy Fallon/Season 2/Jimmy Fallon - 2010-12-15 - blah.avi',
                            parser.ParseResult(None, 'Jimmy Fallon', extra_info = 'blah', air_date = datetime.date(2010,12,15)),
                            ['scene_date_format']),
@@ -126,7 +128,7 @@ combination_test_cases = [
                           (r'/X/30 Rock/Season 4/30 Rock - 4x22 -.avi',
                            parser.ParseResult(None, '30 Rock', 4, [22]),
                            ['fov']),
-                           
+
                           ]
 
 unicode_test_cases = [
@@ -142,49 +144,49 @@ failure_cases = ['7sins-jfcs01e09-720p-bluray-x264']
 
 
 class UnicodeTests(unittest.TestCase):
-    
+
     def _test_unicode(self, name, result):
         np = parser.NameParser(True)
         parse_result = np.parse(name)
         # this shouldn't raise an exception
         a = repr(str(parse_result))
-    
+
     def test_unicode(self):
         for (name, result) in unicode_test_cases:
             self._test_unicode(name, result)
 
 class FailureCaseTests(unittest.TestCase):
-    
+
     def _test_name(self, name):
         np = parser.NameParser(True)
         try:
             parse_result = np.parse(name)
         except parser.InvalidNameException:
             return True
-        
+
         if VERBOSE:
             print 'Actual: ', parse_result.which_regex, parse_result
         return False
-    
+
     def test_failures(self):
         for name in failure_cases:
             self.assertTrue(self._test_name(name))
 
 class ComboTests(unittest.TestCase):
-    
+
     def _test_combo(self, name, result, which_regexes):
-        
+
         if VERBOSE:
             print
-            print 'Testing', name 
-        
+            print 'Testing', name
+
         np = parser.NameParser(True)
         test_result = np.parse(name)
-        
+
         if DEBUG:
             print test_result, test_result.which_regex
             print result, which_regexes
-            
+
 
         self.assertEqual(test_result, result)
         for cur_regex in which_regexes:
@@ -192,7 +194,7 @@ class ComboTests(unittest.TestCase):
         self.assertEqual(len(which_regexes), len(test_result.which_regex))
 
     def test_combos(self):
-        
+
         for (name, result, which_regexes) in combination_test_cases:
             # Normalise the paths. Converts UNIX-style paths into Windows-style
             # paths when test is run on Windows.
@@ -219,7 +221,7 @@ class BasicTests(unittest.TestCase):
                 return
             else:
                 test_result = np.parse(cur_test)
-            
+
             if DEBUG or verbose:
                 print 'air_by_date:', test_result.air_by_date, 'air_date:', test_result.air_date
                 print test_result


### PR DESCRIPTION
no_season will now match episode numbers < 10 when the value is not zero-padded.

Tests come up clean:

```
:::console
$ python all_tests.py
==================
STARTING - ALL TESTS
==================
this will include
- db_tests.py
- name_parser_tests.py
- pp_tests.py
- scene_helpers_tests.py
- snatch_tests.py
- tv_tests.py
.............................................
----------------------------------------------------------------------
Ran 45 tests in 8.343s

OK
```
