### PR TITLE
Make restart code work when behind reverse proxy

### DIFF
--- a/data/js/restart.js
+++ b/data/js/restart.js
@@ -1,78 +1,74 @@
-if (sbHttpsEnabled != "False" && sbHttpsEnabled != 0) 
-	var sb_base_url = 'https://'+sbHost+':'+sbHttpPort+sbRoot;
-else
-    var sb_base_url = 'http://'+sbHost+':'+sbHttpPort+sbRoot;
+var force_https = (sbHttpsEnabled != "False" && sbHttpsEnabled != 0);
+// We use the pathname and .. segments so we don't need to worry about how a
+// proxy may alter the path.
+var url_stem = '//' + window.location.host + window.location.pathname + '../../';
+var old_base_url = window.location.protocol + url_stem;
+// The config might have changed to enable HTTPS, in which case we'll need to
+// check a new URL and redirect there.  Since web_root can only be changed by
+// editing the config file we can assume it's constant (it'll be overwritten as
+// Sick Beard shuts down anyway... oops.)  Note that we might have HTTPS via a
+// proxy, so we defer to the current URL's protocol if not overridden.
+var new_base_url = (force_https ? 'https:' : window.location.protocol) + url_stem;
 
-var base_url = window.location.protocol+'//'+window.location.host+sbRoot;
-var is_alive_url = sbRoot+'/home/is_alive';
-var timeout_id;
-var current_pid = '';
+var is_alive_url = '../is_alive';
 var num_restart_waits = 0;
+var current_pid = '';
 
-function is_alive() {
+
+$(document).ready(function poll() {
     timeout_id = 0;
     $.get(is_alive_url, function(data) {
-                                        
-        // if it's still initalizing then just wait and try again
-        if (data.msg == 'nope') {
+        if (data.msg === 'nope') {
+            // if it's still initalizing then just wait and try again
             $('#shut_down_loading').hide();
             $('#shut_down_success').show();
             $('#restart_message').show();
-            setTimeout('is_alive()', 1000);
+            setTimeout(poll, 1000);
         } else {
             // if this is before we've even shut down then just try again later
             if (current_pid == '' || data.msg == current_pid) {
                 current_pid = data.msg;
-                setTimeout(is_alive, 1000);
-
-            // if we're ready to go then redirect to new url
-            } else {
+                setTimeout(poll, 1000);
+            } else { // if we're ready to go then redirect to new url
                 $('#restart_loading').hide();
                 $('#restart_success').show();
                 $('#refresh_message').show();
-                window.location = sb_base_url+'/home';
+                window.location = new_base_url + 'home';
             }
         }
-    }, 'jsonp');
-}
-
-$(document).ready(function() 
-{ 
-
-    is_alive();
-    
-    $('#shut_down_message').ajaxError(function(e, jqxhr, settings, exception) {
+    }, 'jsonp').fail(function() {
+        // Connection or decoding errors mean that Sick Beard is down.
         num_restart_waits += 1;
-
-        $('#shut_down_loading').hide();
-        $('#shut_down_success').show();
-        $('#restart_message').show();
-        is_alive_url = sb_base_url+'/home/is_alive';
-
-        // if https is enabled or you are currently on https and the port or protocol changed just wait 5 seconds then redirect. 
-        // This is because the ajax will fail if the cert is untrusted or the the http ajax requst from https will fail because of mixed content error.
-        if ((sbHttpsEnabled != "False" && sbHttpsEnabled != 0) || window.location.protocol == "https:") {
-            if (base_url != sb_base_url) {
-                timeout_id = 1;
+        if (num_restart_waits > 90) {
+            // if it is taking forever just give up
+            $('#restart_loading').hide();
+            $('#restart_failure').show();
+            $('#restart_fail_message').show();
+            return;
+        } else {
+            // When we first encounter an error it means Sick Beard has shut down.
+            if (force_https) {
+                // if https is enabled or you are currently on https and the
+                // port or protocol changed just wait 5 seconds then redirect.
+                // This is because the ajax will fail if the cert is untrusted
+                // or if the http ajax requst from https will fail because of
+                // mixed content error.
                 setTimeout(function(){
                     $('#restart_loading').hide();
                     $('#restart_success').show();
                     $('#refresh_message').show();
                 }, 3000);
-                setTimeout("window.location = sb_base_url+'/home'", 5000);
+                setTimeout(function() {
+                    window.location = new_base_url + 'home';
+                }, 5000);
+            } else {
+                if (num_restart_waits === 1) {
+                    $('#shut_down_loading').hide();
+                    $('#shut_down_success').show();
+                    $('#restart_message').show();
+                }
+                setTimeout(poll, 1000);
             }
         }
-
-        // if it is taking forever just give up
-        if (num_restart_waits > 90) {
-            $('#restart_loading').hide();
-            $('#restart_failure').show();
-            $('#restart_fail_message').show();
-            return;
-        }
-
-        if (timeout_id == 0)
-            timeout_id = setTimeout('is_alive()', 1000);
     });
-
 });


### PR DESCRIPTION
the restart code used to not take the web_root case into account. it would redirect to the wrong location following a restart.

I have tested this patch in the following cases:
- http -> http restart (no web_root)
- http -> https restart (no web_root)
- https -> https restart (no web_root)
- and of course, HTTP-via-reverse-proxy -> same, with web_root configured, apache for the proxy

the original code didn't handle the https -> http case, and i haven't added support because anyone who manages to get https working well enough to switch back to http should be able to figure it out themself!
