### PR TITLE
Move entire directory (...)

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -73,6 +73,14 @@
                         </div>
 
                         <div class="field-pair">
+                            <input type="checkbox" name="move_entire_dir" id="move_entire_dir" #if $sickbeard.MOVE_ENTIRE_DIR == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="move_entire_dir">
+                                <span class="component-title">Move directory</span>
+                                <span class="component-desc">Move the entire directory?</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <input type="checkbox" name="rename_episodes" id="rename_episodes" #if $sickbeard.RENAME_EPISODES == True then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="rename_episodes">
                                 <span class="component-title">Rename Episodes</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -168,6 +168,7 @@ RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
 MOVE_ASSOCIATED_FILES = False
+MOVE_ENTIRE_DIR = False
 TV_DOWNLOAD_DIR = None
 
 NZBS = False
@@ -333,7 +334,7 @@ def initialize(consoleLogging=True):
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
-                NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
+                NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, MOVE_ENTIRE_DIR, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
                 ADD_SHOWS_WO_DIR
 
@@ -459,6 +460,7 @@ def initialize(consoleLogging=True):
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
+        MOVE_ENTIRE_DIR = check_setting_int(CFG, 'General', 'move_entire_dir', 0)
         CREATE_MISSING_SHOW_DIRS = check_setting_int(CFG, 'General', 'create_missing_show_dirs', 0)
         ADD_SHOWS_WO_DIR = check_setting_int(CFG, 'General', 'add_shows_wo_dir', 0)
         
@@ -972,6 +974,7 @@ def save_config():
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
+    new_config['General']['move_entire_dir'] = int(MOVE_ENTIRE_DIR)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
     new_config['General']['create_missing_show_dirs'] = CREATE_MISSING_SHOW_DIRS

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -28,7 +28,7 @@ mediaExtensions = ['avi', 'mkv', 'mpg', 'mpeg', 'wmv',
                    'ogm', 'mp4', 'iso', 'img', 'divx',
                    'm2ts', 'm4v', 'ts', 'flv', 'f4v',
                    'mov', 'rmvb', 'vob', 'dvr-ms', 'wtv',
-                   'ogv']
+                   'ogv', 'sfv']
 
 ### Other constants
 MULTI_EP_RESULT = -1

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -414,6 +414,18 @@ def moveFile(srcFile, destFile):
         copyFile(srcFile, destFile)
         ek.ek(os.unlink, srcFile)
 
+def copyDir(srcDir, destDir):
+    try:
+        ek.ek(shutil.copytree, srcDir, destDir)
+    except OSError:
+        logger.log(u"Failed copying " + srcDir + " to " + destDir)
+
+def moveDir(srcDir, destDir):
+    try:
+        ek.ek(shutil.move, srcDir, destDir)
+    except OSError:
+        logger.log(u"Failed moving " + srcDir + " to " + destDir)
+
 def make_dirs(path):
     """
     Creates any folders that are missing and assigns them the permissions of their

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -101,6 +101,19 @@ class PostProcessor(object):
         """
         logger.log(message, level)
         self.log += message + '\n'
+
+    def _checkForExistingDir(self, existing_dir):
+        if not existing_dir:
+            self._log(u"There is no existing directory so there's no worries about replacing it", logger.DEBUG)
+            return PostProcessor.DOESNT_EXIST
+
+        if ek.ek(os.path.isdir, existing_dir):
+            self._log(u"Directory " + existing_dir + " already exists", logger.DEBUG)
+            return PostProcessor.EXISTS_SAME
+
+        else:
+            self._log(u"There is no existing directory so there's no worries about replacing it", logger.DEBUG)
+            return PostProcessor.DOESNT_EXIST
     
     def _checkForExistingFile(self, existing_file):
         """
@@ -731,12 +744,15 @@ class PostProcessor(object):
         # set the status of the episodes
         for curEp in [ep_obj] + ep_obj.relatedEps:
             curEp.status = common.Quality.compositeStatus(common.SNATCHED, new_ep_quality)
-        
-        # check for an existing file
-        existing_file_status = self._checkForExistingFile(ep_obj.location)
+
+        # check for an existing file/dir
+        if sickbeard.MOVE_ENTIRE_DIR:
+            existing_file_status = self._checkForExistingDir(ep_obj.location)
+        else:
+            existing_file_status = self._checkForExistingFile(ep_obj.location)
 
         # if it's not priority then we don't want to replace smaller files in case it was a mistake
-        if not priority_download:
+        if not priority_download or sickbeard.MOVE_ENTIRE_DIR:
         
             # if there's an existing file that we don't want to replace stop here
             if existing_file_status in (PostProcessor.EXISTS_LARGER, PostProcessor.EXISTS_SAME):
@@ -823,18 +839,29 @@ class PostProcessor(object):
             new_file_name = self.file_name 
                        
         try:
-            # move the episode and associated files to the show dir
-            if sickbeard.KEEP_PROCESSED_DIR:
-                self._copy(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+            if sickbeard.MOVE_ENTIRE_DIR:
+                # move the entire dir
+                if sickbeard.KEEP_PROCESSED_DIR:
+                    helpers.copyDir(os.path.dirname(self.file_path), os.path.join(dest_path, self.folder_name))
+                else:
+                    helpers.moveDir(os.path.dirname(self.file_path), dest_path)
             else:
-                self._move(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+                # move the episode and associated files to the show dir
+                if sickbeard.KEEP_PROCESSED_DIR:
+                    self._copy(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+                else:
+                    self._move(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
         except OSError, IOError:
             raise exceptions.PostProcessingFailed("Unable to move the files to their new home")
-        
+
+
         # put the new location in the database
         for cur_ep in [ep_obj] + ep_obj.relatedEps:
             with cur_ep.lock:
-                cur_ep.location = ek.ek(os.path.join, dest_path, new_file_name)
+                if sickbeard.MOVE_ENTIRE_DIR:
+                    cur_ep.location = ek.ek(os.path.join, dest_path, self.folder_name)
+                else:
+                    cur_ep.location = ek.ek(os.path.join, dest_path, new_file_name)
                 cur_ep.saveToDB()
         
         # log it to history

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -114,7 +114,7 @@ def processDir (dirName, nzbName=None, recurse=False):
 
             if len(videoFiles) == 1 and not sickbeard.KEEP_PROCESSED_DIR and \
                 ek.ek(os.path.normpath, dirName) != ek.ek(os.path.normpath, sickbeard.TV_DOWNLOAD_DIR) and \
-                len(remainingFolders) == 0:
+                len(remainingFolders) == 0 and not sickbeard.MOVE_ENTIRE_DIR:
 
                 returnStr += logHelper(u"Deleting folder " + dirName, logger.DEBUG)
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -406,6 +406,11 @@ class TVShow(object):
             logger.log(str(self.tvdbid) + ": That isn't even a real file dude... " + file)
             return None
 
+        # If working with movedir, pass the current folder
+        if sickbeard.MOVE_ENTIRE_DIR:
+            fileName = file
+            file = os.path.dirname(file)
+
         logger.log(str(self.tvdbid) + ": Creating episode object from " + file, logger.DEBUG)
 
         try:
@@ -501,7 +506,7 @@ class TVShow(object):
 
 
             # check for status/quality changes as long as it's a new file
-            elif not same_file and sickbeard.helpers.isMediaFile(file) and curEp.status not in Quality.DOWNLOADED + [ARCHIVED, IGNORED]:
+            elif not same_file and (sickbeard.helpers.isMediaFile(file) or sickbeard.helpers.isMediaFile(fileName)) and curEp.status not in Quality.DOWNLOADED + [ARCHIVED, IGNORED]:
 
                 oldStatus, oldQuality = Quality.splitCompositeStatus(curEp.status)
                 newQuality = Quality.nameQuality(file)
@@ -766,7 +771,9 @@ class TVShow(object):
 
             # if the path doesn't exist or if it's not in our show dir
             if not ek.ek(os.path.isfile, curLoc) or not os.path.normpath(curLoc).startswith(os.path.normpath(self.location)):
-
+                if sickbeard.MOVE_ENTIRE_DIR:
+                    if ek.ek(os.path.isdir, curLog):
+                        return
                 with curEp.lock:
                     # if it used to have a file associated with it and it doesn't anymore then set it to IGNORED
                     if curEp.location and curEp.status in Quality.DOWNLOADED:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -845,7 +845,7 @@ class ConfigPostProcessing:
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                     xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
-                    move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
+                    move_associated_files=None, move_entire_dir=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
         results = []
 
@@ -877,6 +877,11 @@ class ConfigPostProcessing:
         else:
             move_associated_files = 0
 
+        if move_entire_dir == "on":
+            move_entire_dir = 1
+        else:
+            move_entire_dir = 0
+
         if naming_custom_abd == "on":
             naming_custom_abd = 1
         else:
@@ -886,6 +891,7 @@ class ConfigPostProcessing:
         sickbeard.KEEP_PROCESSED_DIR = keep_processed_dir
         sickbeard.RENAME_EPISODES = rename_episodes
         sickbeard.MOVE_ASSOCIATED_FILES = move_associated_files
+        sickbeard.MOVE_ENTIRE_DIR = move_entire_dir
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)


### PR DESCRIPTION
This pull request allows you to move (and keep!) the entire release directory rather than just moving the files within. This is useful for people who prefer keeping their releases in the original scene directories or just prefer this directory structure.

Example:

Sick-Beard finds "Breaking.Bad.S04E13.Face.Off.HDTV.XviD-FQM" in the download folder.
It will properly parse it and then move it to the proper dir (renaming is also
possible, use the Season 02\Show.Name.S02E03.HD.TV-RLSGROUP format and it will
put the release dir in the proper season folder).
