### PR TITLE
Add ability to set SABnzbd/NZBGet download queue priority for each show

### DIFF
--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -89,13 +89,12 @@ replace with: <b><%=", ".join([Quality.qualityStrings[x] for x in bestQualities]
     <tr><td class="showLegend">Flatten files (no folders): </td><td><img src="$sbRoot/images/#if $show.flatten_folders == 1 or $sickbeard.NAMING_FORCE_FOLDERS then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Paused: </td><td><img src="$sbRoot/images/#if int($show.paused) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Air-by-Date: </td><td><img src="$sbRoot/images/#if int($show.air_by_date) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
-#if $sickbeard.USE_NZBS and sickbeard.NZB_METHOD != "blackhole":
+#if $sickbeard.DISPLAY_QUEUE_PRIORITIES and $sickbeard.USE_NZBS and sickbeard.NZB_METHOD != "blackhole":
 	<tr><td class="showLegend">Queue Priority Recent Eps: </td><td>$QueuePriority.queuePriorityStringsAllSAB[$show.priority_recent]</td></tr>
 	<tr><td class="showLegend">Queue Priority Older Eps: </td><td>$QueuePriority.queuePriorityStringsAllSAB[$show.priority_older]</td></tr>
 #end if
 </table>
 </div>
-
 <div class="float-left">
 Change selected episodes to 
 <select id="statusSelect">

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -89,6 +89,10 @@ replace with: <b><%=", ".join([Quality.qualityStrings[x] for x in bestQualities]
     <tr><td class="showLegend">Flatten files (no folders): </td><td><img src="$sbRoot/images/#if $show.flatten_folders == 1 or $sickbeard.NAMING_FORCE_FOLDERS then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Paused: </td><td><img src="$sbRoot/images/#if int($show.paused) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Air-by-Date: </td><td><img src="$sbRoot/images/#if int($show.air_by_date) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
+#if $sickbeard.USE_NZBS and sickbeard.NZB_METHOD != "blackhole":
+	<tr><td class="showLegend">Queue Priority Recent Eps: </td><td>$QueuePriority.queuePriorityStringsAllSAB[$show.priority_recent]</td></tr>
+	<tr><td class="showLegend">Queue Priority Older Eps: </td><td>$QueuePriority.queuePriorityStringsAllSAB[$show.priority_older]</td></tr>
+#end if
 </table>
 </div>
 

--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -72,6 +72,11 @@ Air by date:
 <input type="checkbox" name="air_by_date" #if $show.air_by_date == 1 then "checked=\"checked\"" else ""# /><br />
 (check this if the show is released as Show.03.02.2010 rather than Show.S02E03) 
 <br /><br />
+
+#set global $select_priority_recent = $show.priority_recent 
+#set global $select_priority_older = $show.priority_older
+#include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_queuePriorityChooser.tmpl")
+<br />
 <input class="btn" type="submit" value="Submit" />
 </form>
 

--- a/data/interfaces/default/inc_addShowOptions.tmpl
+++ b/data/interfaces/default/inc_addShowOptions.tmpl
@@ -21,6 +21,10 @@
             </label>
         </div>
 
+		#set global $select_priority_recent = $sickbeard.QUEUE_PRIORITY_RECENT 
+		#set global $select_priority_older = $sickbeard.QUEUE_PRIORITY_OLDER
+		#include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_queuePriorityChooser.tmpl")
+		
         #set $qualities = $Quality.splitQuality($sickbeard.QUALITY_DEFAULT)
         #set global $anyQualities = $qualities[0]
         #set global $bestQualities = $qualities[1]

--- a/data/interfaces/default/inc_queuePriorityChooser.tmpl
+++ b/data/interfaces/default/inc_queuePriorityChooser.tmpl
@@ -4,8 +4,9 @@
 #set $priorities = $QueuePriority.getQueuePriorities($sickbeard.NZB_METHOD == "sabnzbd")
 <script type="text/javascript" charset="utf-8">
 <!--
-nzb_method = "$sickbeard.NZB_METHOD"
-use_nzbs = "$sickbeard.USE_NZBS"
+display_priorities = #if $sickbeard.DISPLAY_QUEUE_PRIORITIES then "true" else "false"#;
+nzb_method = "$sickbeard.NZB_METHOD";
+use_nzbs = #if $sickbeard.USE_NZBS then "true" else "false"#;
 //-->
 </script>
 <script type="text/javascript" src="$sbRoot/js/queuePriorityChooser.js?$sbPID"></script>

--- a/data/interfaces/default/inc_queuePriorityChooser.tmpl
+++ b/data/interfaces/default/inc_queuePriorityChooser.tmpl
@@ -1,7 +1,7 @@
 #import sickbeard
 #from sickbeard.common import QueuePriority
 
-#set $priorities = $QueuePriority.getQueuePriorities($sickbeard.NZB_METHOD == "sabnzbd" and $sickbeard.SAB_ALL_PRIORITIES)
+#set $priorities = $QueuePriority.getQueuePriorities($sickbeard.NZB_METHOD == "sabnzbd")
 <script type="text/javascript" charset="utf-8">
 <!--
 nzb_method = "$sickbeard.NZB_METHOD"

--- a/data/interfaces/default/inc_queuePriorityChooser.tmpl
+++ b/data/interfaces/default/inc_queuePriorityChooser.tmpl
@@ -1,0 +1,37 @@
+#import sickbeard
+#from sickbeard.common import QueuePriority
+
+#set $priorities = $QueuePriority.getQueuePriorities($sickbeard.NZB_METHOD == "sabnzbd" and $sickbeard.SAB_ALL_PRIORITIES)
+<script type="text/javascript" charset="utf-8">
+<!--
+nzb_method = "$sickbeard.NZB_METHOD"
+use_nzbs = "$sickbeard.USE_NZBS"
+//-->
+</script>
+<script type="text/javascript" src="$sbRoot/js/queuePriorityChooser.js?$sbPID"></script>
+<div id="queuePriorities">
+	<div class="field-pair">
+		<label for="priorityRecent" class="nocheck clearfix">
+		<span class="component-title">
+		<select name="priority_recent" id="priorityRecent">
+		#for $priority_value, $priority_string in $priorities.iteritems():
+		<option #if $select_priority_recent == $priority_value then "selected=\"selected\"" else ""# value="$priority_value" >$priority_string</option>
+		#end for
+		</select>
+		</span>
+		<span class="component-desc">Download queue priority for episodes that have aired within the last 7 days</span>
+		</label>
+	</div>
+	<div class="field-pair">
+		<label for="priorityOlder" class="nocheck clearfix">
+		<span class="component-title">
+		<select name="priority_older"  id="priorityOlder"> 
+		#for $priority_value, $priority_string in $priorities.iteritems():
+		<option #if $select_priority_older == $priority_value then "selected=\"selected\"" else ""# value="$priority_value" >$priority_string</option>
+		#end for
+		</select>
+		</span>
+		<span class="component-desc">Download queue priority for episodes that aired more than 7 days ago</span>
+		</label>
+	</div>
+</div>

--- a/data/js/addShowOptions.js
+++ b/data/js/addShowOptions.js
@@ -9,7 +9,9 @@ $(document).ready(function(){
         $.get(sbRoot+'/config/general/saveAddShowDefaults', {defaultStatus: $('#statusSelect').val(),
                                                              anyQualities: anyQualArray.join(','),
                                                              bestQualities: bestQualArray.join(','),
-                                                             defaultFlattenFolders: $('#flatten_folders').prop('checked')} );
+                                                             defaultFlattenFolders: $('#flatten_folders').prop('checked'),
+                                                             queuePriorityRecent: $('#priorityRecent').val(),
+                                                             queuePriorityOlder: $('#priorityOlder').val()} );
         $(this).attr('disabled', true);
         $.pnotify({
             pnotify_title: 'Saved Defaults',
@@ -17,7 +19,7 @@ $(document).ready(function(){
         });
     });
 
-    $('#statusSelect, #qualityPreset, #flatten_folders, #anyQualities, #bestQualities').change(function(){
+    $('#statusSelect, #qualityPreset, #flatten_folders, #anyQualities, #bestQualities, #priorityRecent, #priorityOlder').change(function(){
         $('#saveDefaultsButton').attr('disabled', false);
     });
 

--- a/data/js/queuePriorityChooser.js
+++ b/data/js/queuePriorityChooser.js
@@ -1,0 +1,7 @@
+$(document).ready(function(){
+	if (use_nzbs && nzb_method != "blackhole") {
+		$('#queuePriorities').show();
+	}else{
+		$('#queuePriorities').hide();
+	}
+});

--- a/data/js/queuePriorityChooser.js
+++ b/data/js/queuePriorityChooser.js
@@ -1,5 +1,5 @@
 $(document).ready(function(){
-	if (use_nzbs && nzb_method != "blackhole") {
+	if (display_priorities && use_nzbs && nzb_method != "blackhole") {
 		$('#queuePriorities').show();
 	}else{
 		$('#queuePriorities').hide();

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -154,6 +154,7 @@ DEFAULT_SEARCH_FREQUENCY = 60
 
 QUEUE_PRIORITY_RECENT = None
 QUEUE_PRIORITY_OLDER = None
+DISPLAY_QUEUE_PRIORITIES = None
 
 EZRSS = False
 TVTORRENTS = False
@@ -319,7 +320,7 @@ def initialize(consoleLogging=True):
                 showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
                 NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, BTN, BTN_API_KEY, TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
                 SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
-                QUEUE_PRIORITY_RECENT, QUEUE_PRIORITY_OLDER, QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, STATUS_DEFAULT, \
+                QUEUE_PRIORITY_RECENT, QUEUE_PRIORITY_OLDER, DISPLAY_QUEUE_PRIORITIES, QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, STATUS_DEFAULT, \
                 GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 USE_PYTIVO, PYTIVO_NOTIFY_ONSNATCH, PYTIVO_NOTIFY_ONDOWNLOAD, PYTIVO_UPDATE_LIBRARY, PYTIVO_HOST, PYTIVO_SHARE_NAME, PYTIVO_TIVO_NAME, \
@@ -456,7 +457,8 @@ def initialize(consoleLogging=True):
 
         QUEUE_PRIORITY_RECENT = check_setting_int(CFG, 'General', 'queue_priority_recent', 1)
         QUEUE_PRIORITY_OLDER = check_setting_int(CFG, 'General', 'queue_priority_older', -100)
-
+        DISPLAY_QUEUE_PRIORITIES = bool(check_setting_int(CFG, 'General', 'display_queue_priorities', 0))
+        
         NZB_DIR = check_setting_str(CFG, 'Blackhole', 'nzb_dir', '')
         TORRENT_DIR = check_setting_str(CFG, 'Blackhole', 'torrent_dir', '')
 
@@ -955,6 +957,7 @@ def save_config():
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
     new_config['General']['queue_priority_recent'] = int(QUEUE_PRIORITY_RECENT)
     new_config['General']['queue_priority_older'] = int(QUEUE_PRIORITY_OLDER)
+    new_config['General']['display_queue_priorities'] = int(DISPLAY_QUEUE_PRIORITIES)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)
     new_config['General']['flatten_folders_default'] = int(FLATTEN_FOLDERS_DEFAULT)

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -196,7 +196,6 @@ SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = ''
-SAB_ALL_PRIORITIES = False
 
 NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
@@ -310,7 +309,7 @@ def initialize(consoleLogging=True):
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
-                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, SAB_ALL_PRIORITIES, \
+                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
@@ -503,7 +502,6 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
-        SAB_ALL_PRIORITIES  = bool(check_setting_int(CFG, 'SABnzbd', 'sab_all_priorities', 0))
 
         NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789')
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
@@ -1036,7 +1034,6 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
-    new_config['SABnzbd']['sab_all_priorities'] = int(SAB_ALL_PRIORITIES)
 
     new_config['NZBget'] = {}
     new_config['NZBget']['nzbget_password'] = NZBGET_PASSWORD

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -152,6 +152,9 @@ MIN_SEARCH_FREQUENCY = 10
 
 DEFAULT_SEARCH_FREQUENCY = 60
 
+QUEUE_PRIORITY_RECENT = None
+QUEUE_PRIORITY_OLDER = None
+
 EZRSS = False
 TVTORRENTS = False
 TVTORRENTS_DIGEST = None
@@ -193,6 +196,7 @@ SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = ''
+SAB_ALL_PRIORITIES = False
 
 NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
@@ -306,7 +310,7 @@ def initialize(consoleLogging=True):
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
-                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
+                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, SAB_ALL_PRIORITIES, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
@@ -316,7 +320,7 @@ def initialize(consoleLogging=True):
                 showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
                 NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, BTN, BTN_API_KEY, TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
                 SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
-                QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, STATUS_DEFAULT, \
+                QUEUE_PRIORITY_RECENT, QUEUE_PRIORITY_OLDER, QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, STATUS_DEFAULT, \
                 GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 USE_PYTIVO, PYTIVO_NOTIFY_ONSNATCH, PYTIVO_NOTIFY_ONDOWNLOAD, PYTIVO_UPDATE_LIBRARY, PYTIVO_HOST, PYTIVO_SHARE_NAME, PYTIVO_TIVO_NAME, \
@@ -451,6 +455,9 @@ def initialize(consoleLogging=True):
         if SEARCH_FREQUENCY < MIN_SEARCH_FREQUENCY:
             SEARCH_FREQUENCY = MIN_SEARCH_FREQUENCY
 
+        QUEUE_PRIORITY_RECENT = check_setting_int(CFG, 'General', 'queue_priority_recent', 1)
+        QUEUE_PRIORITY_OLDER = check_setting_int(CFG, 'General', 'queue_priority_older', -100)
+
         NZB_DIR = check_setting_str(CFG, 'Blackhole', 'nzb_dir', '')
         TORRENT_DIR = check_setting_str(CFG, 'Blackhole', 'torrent_dir', '')
 
@@ -496,6 +503,7 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
+        SAB_ALL_PRIORITIES  = bool(check_setting_int(CFG, 'SABnzbd', 'sab_all_priorities', 0))
 
         NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789')
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
@@ -947,6 +955,8 @@ def save_config():
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['queue_priority_recent'] = int(QUEUE_PRIORITY_RECENT)
+    new_config['General']['queue_priority_older'] = int(QUEUE_PRIORITY_OLDER)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)
     new_config['General']['flatten_folders_default'] = int(FLATTEN_FOLDERS_DEFAULT)
@@ -1026,6 +1036,7 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
+    new_config['SABnzbd']['sab_all_priorities'] = int(SAB_ALL_PRIORITIES)
 
     new_config['NZBget'] = {}
     new_config['NZBget']['nzbget_password'] = NZBGET_PASSWORD

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -254,3 +254,27 @@ countryList = {'Australia': 'AU',
                'USA': 'US'
                }
 
+class QueuePriority:
+    DEFAULT = -100
+    PAUSED = -2
+    LOW = -1
+    NORMAL = 0
+    HIGH = 1
+    FORCE = 2
+    
+    queuePriorityStrings = {DEFAULT: "Default",
+                            HIGH: "High"}
+    
+    queuePriorityStringsAllSAB = {DEFAULT: "Default",
+                                  HIGH: "High",
+                                  NORMAL: "Normal",
+                                  LOW: "Low",
+                                  PAUSED: "Paused",
+                                  FORCE: "Force"}
+    @staticmethod
+    def getQueuePriorities(all_sab=False):
+        if all_sab:
+            return QueuePriority.queuePriorityStringsAllSAB
+        else:
+            return QueuePriority.queuePriorityStrings
+    

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -63,7 +63,7 @@ class InitialSchema (db.SchemaUpgrade):
 
     def execute(self):
         queries = [
-            "CREATE TABLE tv_shows (show_id INTEGER PRIMARY KEY, location TEXT, show_name TEXT, tvdb_id NUMERIC, network TEXT, genre TEXT, runtime NUMERIC, quality NUMERIC, airs TEXT, status TEXT, seasonfolders NUMERIC, paused NUMERIC, startyear NUMERIC);",
+            "CREATE TABLE tv_shows (show_id INTEGER PRIMARY KEY, location TEXT, show_name TEXT, tvdb_id NUMERIC, network TEXT, genre TEXT, runtime NUMERIC, quality NUMERIC, airs TEXT, status TEXT, seasonfolders NUMERIC, paused NUMERIC, startyear NUMERIC, priority_recent NUMERIC, priority_older NUMERIC);",
             "CREATE TABLE tv_episodes (episode_id INTEGER PRIMARY KEY, showid NUMERIC, tvdbid NUMERIC, name TEXT, season NUMERIC, episode NUMERIC, description TEXT, airdate NUMERIC, hasnfo NUMERIC, hastbn NUMERIC, status NUMERIC, location TEXT);",
             "CREATE TABLE info (last_backlog NUMERIC, last_tvdb NUMERIC);",
             "CREATE TABLE history (action NUMERIC, date NUMERIC, showid NUMERIC, season NUMERIC, episode NUMERIC, quality NUMERIC, resource TEXT, provider NUMERIC);"
@@ -500,3 +500,17 @@ class RenameSeasonFolders(AddSizeAndSceneNameFields):
         self.connection.action("DROP TABLE tmp_tv_shows")
 
         self.incDBVersion()
+
+class QueuePriorityRecent (RenameSeasonFolders):
+    def test(self):
+        return self.hasColumn("tv_shows", "priority_recent")
+
+    def execute(self):
+        self.addColumn("tv_shows", "priority_recent", "NUMERIC", sickbeard.QUEUE_PRIORITY_RECENT)
+
+class QueuePriorityOlder (QueuePriorityRecent):
+    def test(self):
+        return self.hasColumn("tv_shows", "priority_older")
+
+    def execute(self):
+        self.addColumn("tv_shows", "priority_older", "NUMERIC", sickbeard.QUEUE_PRIORITY_OLDER)

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -59,10 +59,12 @@ def sendNZB(nzb):
             logger.log(u"Protocol Error: " + e.errmsg, logger.ERROR)
         return False
 
-    # if it aired recently make it high priority
+    # check if aired recently and assign appropriate queue priority
     for curEp in nzb.episodes:
         if datetime.date.today() - curEp.airdate <= datetime.timedelta(days=7):
-            addToTop = True
+            addToTop = (curEp.show.priority_recent > 0)
+        else:
+            addToTop = (curEp.show.priority_older > 0)
 
     # if it's a normal result need to download the NZB content
     if nzb.resultType == "nzb":
@@ -85,4 +87,4 @@ def sendNZB(nzb):
         return True
     else:
         logger.log(u"NZBget could not add %s to the queue" % (nzb.name + ".nzb"), logger.ERROR)
-        return False
+        return False

--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -32,7 +32,7 @@ class WombleProvider(generic.NZBProvider):
 
         self.cache = WombleCache(self)
 
-        self.url = 'http://nzb.isasecret.com/'
+        self.url = 'http://newshost.co.za/'
 
     def isEnabled(self):
         return sickbeard.WOMBLE

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -52,10 +52,12 @@ def sendNZB(nzb):
     if sickbeard.SAB_CATEGORY != None:
         params['cat'] = sickbeard.SAB_CATEGORY
 
-    # if it aired recently make it high priority
+    # check if aired recently and assign appropriate queue priority
     for curEp in nzb.episodes:
         if datetime.date.today() - curEp.airdate <= datetime.timedelta(days=7):
-            params['priority'] = 1
+            params['priority'] = curEp.show.priority_recent
+        else:
+            params['priority'] = curEp.show.priority_older
 
     # if it's a normal result we just pass SAB the URL
     if nzb.resultType == "nzb":

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -115,8 +115,8 @@ class ShowQueue(generic_queue.GenericQueue):
 
         return queueItemObj
 
-    def addShow(self, tvdb_id, showDir, default_status=None, quality=None, flatten_folders=None, lang="en"):
-        queueItemObj = QueueItemAdd(tvdb_id, showDir, default_status, quality, flatten_folders, lang)
+    def addShow(self, tvdb_id, showDir, default_status=None, quality=None, flatten_folders=None, lang="en", priority_recent=None, priority_older=None):
+        queueItemObj = QueueItemAdd(tvdb_id, showDir, default_status, quality, flatten_folders, lang, priority_recent, priority_older)
         
         self.add_item(queueItemObj)
 
@@ -165,7 +165,7 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 
 class QueueItemAdd(ShowQueueItem):
-    def __init__(self, tvdb_id, showDir, default_status, quality, flatten_folders, lang):
+    def __init__(self, tvdb_id, showDir, default_status, quality, flatten_folders, lang, priority_recent, priority_older):
 
         self.tvdb_id = tvdb_id
         self.showDir = showDir
@@ -173,6 +173,8 @@ class QueueItemAdd(ShowQueueItem):
         self.quality = quality
         self.flatten_folders = flatten_folders
         self.lang = lang
+        self.priority_recent = priority_recent
+        self.priority_older = priority_older
 
         self.show = None
 
@@ -244,6 +246,8 @@ class QueueItemAdd(ShowQueueItem):
             self.show.quality = self.quality if self.quality else sickbeard.QUALITY_DEFAULT
             self.show.flatten_folders = self.flatten_folders if self.flatten_folders != None else sickbeard.FLATTEN_FOLDERS_DEFAULT
             self.show.paused = False
+            self.show.priority_recent = self.priority_recent if self.priority_recent != None else sickbeard.QUEUE_PRIORITY_RECENT
+            self.show.priority_older = self.priority_older if self.priority_older != None else sickbeard.QUEUE_PRIORITY_OLDER
             
             # be smartish about this
             if self.show.genre and "talk show" in self.show.genre.lower():

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -67,6 +67,8 @@ class TVShow(object):
         self.paused = 0
         self.air_by_date = 0
         self.lang = lang
+        self.priority_older = int(sickbeard.QUEUE_PRIORITY_OLDER)
+        self.priority_recent = int(sickbeard.QUEUE_PRIORITY_RECENT)
 
         self.lock = threading.Lock()
         self._isDirGood = False
@@ -589,6 +591,8 @@ class TVShow(object):
             if self.lang == "":
                 self.lang = sqlResults[0]["lang"]
 
+            self.priority_recent = int(sqlResults[0]["priority_recent"])
+            self.priority_older = int(sqlResults[0]["priority_older"])
 
     def loadFromTVDB(self, cache=True, tvapi=None, cachedSeason=None):
 
@@ -799,7 +803,9 @@ class TVShow(object):
                         "air_by_date": self.air_by_date,
                         "startyear": self.startyear,
                         "tvr_name": self.tvrname,
-                        "lang": self.lang
+                        "lang": self.lang,
+                        "priority_recent": self.priority_recent,
+                        "priority_older": self.priority_older
                         }
 
         myDB.upsert("tv_shows", newValueDict, controlValueDict)


### PR DESCRIPTION
config.ini option "display_queue_priorities = 1" in order to display queue priority controls/info.
Download queue priorities can be defined for both recent episodes and
older episodes The priorities available for NZBGet are "Default" and "High".
The "Default" priority causes the NZB to be added
to the bottom of the download queue, while the High priority will cause the 
NZB to be added to the top of the queue. All of SABnzb's priorities are
available. Using the "Default" priority will cause SABnzb to assign the 
NZB with the priority for the Category of that NZB.

Sick-Beard defaults to assigning recent episodes a priority of
High, and older episodes a priority of Default. It is possible to
set different priorities when adding a new show, as well as change the
Sick-Beard defaults. The priorities for an existing show can be changed
within that show's edit page.

Priorities are valid only for shows being downloaded using
SABnzbd or NZBGet. They have no effect on torrent downloads or when
sending NZBs to a black hole. All options and info regarding priorities
will be hidden if neither SABnzbd or NZBGet is configured as the
download method even if "display_queue_priorities = 1" .
