### PR TITLE
Added a post-processing option that removes a TV Show year from the episode filename when relevant.

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -185,6 +185,18 @@
                         </div>
 
                         <div class="field-pair">
+                            <input type="checkbox" name="naming_strip_year" id="naming_strip_year" #if $sickbeard.NAMING_STRIP_YEAR then "checked=\"checked\"" else ""#/>
+                            <label class="clearfix" for="naming_strip_year">
+                                <span class="component-title">Strip Show Year</span>
+                                <span class="component-desc">Remove the TV show's year when renaming the file?</span>
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Only applies to shows that have their year inside parentheses</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <input type="checkbox" name="naming_ep_name" id="naming_ep_name" #if $sickbeard.NAMING_EP_NAME then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="naming_ep_name">
                                 <span class="component-title">Episode Name</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -124,6 +124,7 @@ SEASON_FOLDERS_DEFAULT = None
 PROVIDER_ORDER = []
 
 NAMING_SHOW_NAME = None
+NAMING_STRIP_YEAR = None
 NAMING_EP_NAME = None
 NAMING_EP_TYPE = None
 NAMING_MULTI_EP_TYPE = None
@@ -402,7 +403,7 @@ def initialize(consoleLogging=True):
                 NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, \
                 KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, \
-                NAMING_SHOW_NAME, NAMING_EP_TYPE, NAMING_MULTI_EP_TYPE, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
+                NAMING_SHOW_NAME, NAMING_STRIP_YEAR, NAMING_EP_TYPE, NAMING_MULTI_EP_TYPE, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
                 NAMING_EP_NAME, NAMING_SEP_TYPE, NAMING_USE_PERIODS, WOMBLE, \
                 NZBSRUS, NZBSRUS_UID, NZBSRUS_HASH, NAMING_QUALITY, providerList, newznabProviderList, \
@@ -510,6 +511,7 @@ def initialize(consoleLogging=True):
         PROVIDER_ORDER = check_setting_str(CFG, 'General', 'provider_order', '').split()
 
         NAMING_SHOW_NAME = bool(check_setting_int(CFG, 'General', 'naming_show_name', 1))
+        NAMING_STRIP_YEAR = bool(check_setting_int(CFG, 'General', 'naming_strip_year', 0))
         NAMING_EP_NAME = bool(check_setting_int(CFG, 'General', 'naming_ep_name', 1))
         NAMING_EP_TYPE = check_setting_int(CFG, 'General', 'naming_ep_type', 0)
         NAMING_MULTI_EP_TYPE = check_setting_int(CFG, 'General', 'naming_multi_ep_type', 0)
@@ -1035,6 +1037,7 @@ def save_config():
     new_config['General']['version_notify'] = int(VERSION_NOTIFY)
     new_config['General']['naming_ep_name'] = int(NAMING_EP_NAME)
     new_config['General']['naming_show_name'] = int(NAMING_SHOW_NAME)
+    new_config['General']['naming_strip_year'] = int(NAMING_STRIP_YEAR)
     new_config['General']['naming_ep_type'] = int(NAMING_EP_TYPE)
     new_config['General']['naming_multi_ep_type'] = int(NAMING_MULTI_EP_TYPE)
     new_config['General']['naming_sep_type'] = int(NAMING_SEP_TYPE)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1359,7 +1359,7 @@ class TVEpisode(object):
         return self.show.getOverview(self.status)
 
     def prettyName (self, naming_show_name=None, naming_ep_type=None, naming_multi_ep_type=None,
-                    naming_ep_name=None, naming_sep_type=None, naming_use_periods=None, naming_quality=None):
+                    naming_ep_name=None, naming_sep_type=None, naming_use_periods=None, naming_quality=None, naming_strip_year=None):
 
         regex = "(.*) \(\d\)"
 
@@ -1400,6 +1400,9 @@ class TVEpisode(object):
         if naming_show_name == None:
             naming_show_name = sickbeard.NAMING_SHOW_NAME
 
+        if naming_strip_year == None:
+            naming_strip_year = sickbeard.NAMING_STRIP_YEAR
+
         if naming_ep_name == None:
             naming_ep_name = sickbeard.NAMING_EP_NAME
 
@@ -1436,8 +1439,13 @@ class TVEpisode(object):
 
         finalName = ""
 
+        if naming_strip_year:
+            finalShowName = re.sub("\(\w+\)$", "", self.show.name).rstrip()
+        else:
+            finalShowName = self.show.name
+
         if naming_show_name:
-            finalName += self.show.name + config.naming_sep_type[naming_sep_type]
+            finalName += finalShowName + config.naming_sep_type[naming_sep_type]
 
         finalName += goodEpString
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -843,7 +843,7 @@ class ConfigPostProcessing:
     @cherrypy.expose
     def savePostProcessing(self, season_folders_format=None, naming_show_name=None, naming_ep_type=None,
                     naming_multi_ep_type=None, naming_ep_name=None, naming_use_periods=None,
-                    naming_sep_type=None, naming_quality=None, naming_dates=None,
+                    naming_sep_type=None, naming_quality=None, naming_dates=None, naming_strip_year=None,
                     xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None):
@@ -857,6 +857,11 @@ class ConfigPostProcessing:
             naming_show_name = 1
         else:
             naming_show_name = 0
+
+        if naming_strip_year == "on":
+            naming_strip_year = 1
+        else:
+            naming_strip_year = 0
 
         if naming_ep_name == "on":
             naming_ep_name = 1
@@ -918,6 +923,7 @@ class ConfigPostProcessing:
         sickbeard.SEASON_FOLDERS_FORMAT = season_folders_format
 
         sickbeard.NAMING_SHOW_NAME = naming_show_name
+        sickbeard.NAMING_STRIP_YEAR = naming_strip_year
         sickbeard.NAMING_EP_NAME = naming_ep_name
         sickbeard.NAMING_USE_PERIODS = naming_use_periods
         sickbeard.NAMING_QUALITY = naming_quality


### PR DESCRIPTION
Years in brackets are incorrectly viewed as Season-Episode by the Apple TV Media Browser parser, which retrieves erroneous metadata.

Eg. Show Name (2005) - 1x01 - Ep Name >>> Show Name - 1x01 - Ep Name
