### PR TITLE
Patch to remove some special Characters from filenames to circumvent errors

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1452,5 +1452,7 @@ class TVEpisode(object):
         if naming_use_periods:
             finalName = re.sub("\s+", ".", finalName)
 
+        finalName = ''.join(i for i in finalName if i not in r'\/:*?"<>|')
+
         return finalName
 


### PR DESCRIPTION
On my Windows machine with NTFS partitions Sick-Beard somehow managed to put several files onto it with special characters in it like : , ", ? and so on.

This pr fixes this by removing such characters from the to be renamed filename
