### PR TITLE
Added NMJv2 Notifier

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -258,6 +258,57 @@
                     </fieldset>
                 </div><!-- /nmj component-group //-->
 
+				<div class="component-group clearfix">
+                    <div class="component-group-desc">
+                        <h3><a href="http://www.popcornhour.com/" onclick="window.open(this.href, '_blank'); return false;"><img src="$sbRoot/images/notifiers/nmj.gif" alt="" title="Networked Media Jukebox" width="16" height="16" /> NMJv2 </a></h3>
+                        <p>The Networked Media Jukebox, or NMJv2, is the official media jukebox interface made available for the Popcorn Hour 300-series.</p>
+                    </div>
+                    <fieldset class="component-group-list">
+                        <div class="field-pair">
+                            <input type="checkbox" class="enabler" name="use_nmjv2" id="use_nmjv2" #if $sickbeard.USE_NMJv2 then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="use_nmjv2">
+                                <span class="component-title">Enable</span>
+                                <span class="component-desc">Should Sick Beard send update commands to NMJv2?</span>
+                            </label>
+                        </div>
+
+                        <div id="content_use_nmjv2">
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Popcorn IP address</span>
+                                    <input type="text" name="nmjv2_host" id="nmjv2_host" value="$sickbeard.NMJv2_HOST" size="35" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">IP of Popcorn 300-series (eg. 192.168.1.100)</span>
+                                </label>
+                            </div>
+                              <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Find Database</span>
+                                  <input type="button" value="Find Database" id="settingsNMJv2" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">The Popcorn Hour device must be powered on.</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                <span class="component-title">NMJv2 Database</span>
+                                <input type="text" name="nmjv2_database" id="nmjv2_database" value="$sickbeard.NMJv2_DATABASE" size="35" #if $sickbeard.NMJv2_DATABASE then "readonly=\"readonly\"" else ""# /></label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Automatically filled via the 'Find Database' button.</span>
+                                </label>
+                            </div>
+						<div class="testNotification" id="testNMJv2-result">Click below to test.</div>
+						<input type="button" value="Test NMJv2" id="testNMJv2" />
+						<input type="submit" class="config_submitter" value="Save Changes" />
+                        </div><!-- /content_use_nmjv2 //-->
+
+                    </fieldset>
+                </div><!-- /nmjv2 component-group //-->
 
                 <div class="component-group clearfix">
                     <div class="component-group-desc">

--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -125,6 +125,39 @@ $(document).ready(function(){
         function (data){ $('#testNMJ-result').html(data); });
     });
 
+	$('#settingsNMJv2').click(function(){
+        if (!$('#nmjv2_host').val()) {
+            alert('Please fill in the Popcorn IP address');
+            $('#nmjv2_host').focus();
+            return;
+    }
+    $('#testNMJv2-result').html(loading);
+        var nmjv2_host = $('#nmjv2_host').val();
+        
+        $.get(sbRoot+"/home/settingsNMJv2", {'host': nmjv2_host}, 
+        function (data){
+            if (data == null) {
+                $('#nmjv2_database').removeAttr('readonly');
+            }
+            var JSONData = $.parseJSON(data);
+            $('#testNMJv2-result').html(JSONData.message);
+            $('#nmjv2_database').val(JSONData.database);
+            
+            if (JSONData.database)
+                $('#nmjv2_database').attr('readonly', true);
+            else
+                $('#nmjv2_database').removeAttr('readonly');
+        });
+    });
+	
+    $('#testNMJv2').click(function(){
+        $('#testNMJv2-result').html(loading);
+        var nmjv2_host = $("#nmjv2_host").val();
+        
+        $.get(sbRoot+"/home/testNMJv2", {'host': nmjv2_host}, 
+        function (data){ $('#testNMJv2-result').html(data); });
+    });
+	
     $('#testTrakt').click(function(){
         $('#testTrakt-result').html(loading);
         var trakt_api = $("#trakt_api").val();

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -263,6 +263,10 @@ NMJ_HOST = None
 NMJ_DATABASE = None
 NMJ_MOUNT = None
 
+USE_NMJv2 = False
+NMJv2_HOST = None
+NMJv2_DATABASE = None
+
 USE_SYNOINDEX = False
 
 USE_TRAKT = False
@@ -331,7 +335,7 @@ def initialize(consoleLogging=True):
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
-                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
+                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
@@ -353,6 +357,7 @@ def initialize(consoleLogging=True):
         CheckSection(CFG, 'Prowl')
         CheckSection(CFG, 'Twitter')
         CheckSection(CFG, 'NMJ')
+        CheckSection(CFG, 'NMJv2')
         CheckSection(CFG, 'Synology')
         CheckSection(CFG, 'pyTivo')
         CheckSection(CFG, 'NMA')
@@ -562,6 +567,10 @@ def initialize(consoleLogging=True):
         NMJ_HOST = check_setting_str(CFG, 'NMJ', 'nmj_host', '')
         NMJ_DATABASE = check_setting_str(CFG, 'NMJ', 'nmj_database', '')
         NMJ_MOUNT = check_setting_str(CFG, 'NMJ', 'nmj_mount', '')
+
+        USE_NMJv2 = bool(check_setting_int(CFG, 'NMJv2', 'use_nmjv2', 0))
+        NMJv2_HOST = check_setting_str(CFG, 'NMJv2', 'nmjv2_host', '')
+        NMJv2_DATABASE = check_setting_str(CFG, 'NMJv2', 'nmjv2_database', '')
 
         USE_SYNOINDEX = bool(check_setting_int(CFG, 'Synology', 'use_synoindex', 0))
 
@@ -1103,6 +1112,11 @@ def save_config():
     new_config['NMJ']['nmj_host'] = NMJ_HOST
     new_config['NMJ']['nmj_database'] = NMJ_DATABASE
     new_config['NMJ']['nmj_mount'] = NMJ_MOUNT
+
+    new_config['NMJv2'] = {}
+    new_config['NMJv2']['use_nmjv2'] = int(USE_NMJv2)
+    new_config['NMJv2']['nmjv2_host'] = NMJv2_HOST
+    new_config['NMJv2']['nmjv2_database'] = NMJv2_DATABASE
 
     new_config['Synology'] = {}
     new_config['Synology']['use_synoindex'] = int(USE_SYNOINDEX)

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -28,6 +28,7 @@ import notifo
 import boxcar
 import pushover
 import nmj
+import nmjv2
 import synoindex
 import trakt
 import pytivo
@@ -45,6 +46,7 @@ boxcar_notifier = boxcar.BoxcarNotifier()
 pushover_notifier = pushover.PushoverNotifier()
 libnotify_notifier = libnotify.LibnotifyNotifier()
 nmj_notifier = nmj.NMJNotifier()
+nmjv2_notifier = nmjv2.NMJv2Notifier()
 synoindex_notifier = synoindex.synoIndexNotifier()
 trakt_notifier = trakt.TraktNotifier()
 pytivo_notifier = pytivo.pyTivoNotifier()
@@ -60,6 +62,7 @@ notifiers = [
     prowl_notifier,
     twitter_notifier,
     nmj_notifier,
+    nmjv2_notifier,
     synoindex_notifier,
     boxcar_notifier,
     pushover_notifier,

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -1,0 +1,139 @@
+# Author: Jasper Lanting
+# Based on nmj.py by Nico Berlee: http://nico.berlee.nl/
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import urllib, urllib2
+import sickbeard
+import telnetlib
+import re
+import time
+
+from sickbeard import logger
+
+try:
+    import xml.etree.cElementTree as etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+
+
+class NMJv2Notifier:
+    
+    def notify_snatch(self, ep_name):
+        return False
+        #Not implemented: Start the scanner when snatched does not make any sense
+
+    def notify_download(self, ep_name):
+        self._notifyNMJ()
+
+    def test_notify(self, host):
+        return self._sendNMJ(host)
+
+    def notify_settings(self, host):
+        """
+        Retrieves the NMJv2 database location from Popcorn hour
+        
+        host: The hostname/IP of the Popcorn Hour server
+        
+        Returns: True if the settings were retrieved successfully, False otherwise
+        """
+        
+        # establish a terminal session to the PC
+        terminal = False
+        try:
+            terminal = telnetlib.Telnet(host)
+        except Exception:
+            logger.log(u"Warning: unable to get a telnet session to %s" % (host), logger.ERROR)
+            return False
+
+        # tell the terminal to output the necessary info to the screen so we can search it later
+        logger.log(u"Connected to %s via telnet" % (host), logger.DEBUG)
+        terminal.read_until("sh-3.00# ")
+        terminal.write("cd opt\n")
+        terminal.write("cd sybhttpd\n")
+        terminal.write("cd localhost.drives\n")
+        terminal.write("find . -type f | grep -i \"/nmj_database/.*\.db$\"\n")
+        terminal.write("exit\n")
+        terminal.read_until(".db$")
+        tnoutput = terminal.read_all()
+        if tnoutput.find("media.db") > 0:
+            tnoutput_split=tnoutput.split('\r\n')
+            tnoutput_split[1] = tnoutput_split[1][1:]
+            sickbeard.NMJv2_HOST=host
+            sickbeard.NMJv2_DATABASE="/opt/sybhttpd/localhost.drives"+tnoutput_split[1]
+        else:
+            return False
+        return True
+
+    def _sendNMJ(self, host):
+        """
+        Sends a NMJ update command to the specified machine
+        
+        host: The hostname/IP to send the request to (no port)
+        database: The database to send the requst to
+        mount: The mount URL to use (optional)
+        
+        Returns: True if the request succeeded, False otherwise
+        """
+        
+        # if a mount URL is provided then attempt to open a handle to that URL
+        if host:
+            try:
+                url_scandir = "http://" + host + ":8008/metadata_database?arg0=update_scandir&arg1="+ sickbeard.NMJv2_DATABASE +"&arg2=&arg3=update_all"
+                logger.log(u"NMJ scan update command send to host: %s" % (host))
+                url_updatedb = "http://" + host + ":8008/metadata_database?arg0=scanner_start&arg1="+ sickbeard.NMJv2_DATABASE +"&arg2=background&arg3="
+                logger.log(u"Try to mount network drive via url: %s" % (host), logger.DEBUG)
+                prereq = urllib2.Request(url_scandir)
+                req = urllib2.Request(url_updatedb)
+                handle1 = urllib2.urlopen(prereq)
+                response1 = handle1.read()
+                time.sleep (300.0 / 1000.0)
+                handle2 = urllib2.urlopen(req)
+                response2 = handle2.read()
+                return1 = len(response1)
+                return2 = len(response2)
+                if return1 > 0 and return2 > 0:
+                    logger.log(u"NMJ scan update command send to host: %s" % (host))
+                    return True
+                else:
+                    logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))
+                    return False
+            except:
+                pass
+
+    def _notifyNMJ(self, host=None, force=False):
+        """
+        Sends a NMJ update command based on the SB config settings
+        
+        host: The host to send the command to (optional, defaults to the host in the config)
+        database: The database to use (optional, defaults to the database in the config)
+        mount: The mount URL (optional, defaults to the mount URL in the config)
+        force: If True then the notification will be sent even if NMJ is disabled in the config
+        """
+        if not sickbeard.USE_NMJv2 and not force:
+            logger.log("Notification for NMJ scan update not enabled, skipping this notification", logger.DEBUG)
+            return False
+
+        # fill in omitted parameters
+        if not host:
+            host = sickbeard.NMJv2_HOST
+
+        logger.log(u"Sending scan command for NMJ ", logger.DEBUG)
+
+        return self._sendNMJ(host)
+
+notifier = NMJv2Notifier

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -104,8 +104,9 @@ class NMJv2Notifier:
                 time.sleep (300.0 / 1000.0)
                 handle2 = urllib2.urlopen(req)
                 response2 = handle2.read()
-                return1 = len(response1)
-                return2 = len(response2)
+                # searching for string directly instead of parsing XML due to syntax error in XML response
+                return1 = response1.find("<returnValue>0</returnValue>")
+                return2 = response2.find("<returnValue>0</returnValue>")
                 if return1 > 0 and return2 > 0:
                     logger.log(u"NMJ scan update command send to host: %s" % (host))
                     return True

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1147,7 +1147,7 @@ class ConfigNotifications:
                           use_boxcar=None, boxcar_notify_onsnatch=None, boxcar_notify_ondownload=None, boxcar_username=None,
                           use_pushover=None, pushover_notify_onsnatch=None, pushover_notify_ondownload=None, pushover_userkey=None,
                           use_libnotify=None, libnotify_notify_onsnatch=None, libnotify_notify_ondownload=None,
-                          use_nmj=None, nmj_host=None, nmj_database=None, nmj_mount=None, use_synoindex=None,
+                          use_nmj=None, nmj_host=None, nmj_database=None, nmj_mount=None, use_nmjv2=None, nmjv2_host=None, nmjv2_database=None, use_synoindex=None,
                           use_trakt=None, trakt_username=None, trakt_password=None, trakt_api=None,
                           use_pytivo=None, pytivo_notify_onsnatch=None, pytivo_notify_ondownload=None, pytivo_update_library=None, 
                           pytivo_host=None, pytivo_share_name=None, pytivo_tivo_name=None,
@@ -1289,6 +1289,11 @@ class ConfigNotifications:
             use_nmj = 1
         else:
             use_nmj = 0
+            
+        if use_nmjv2 == "on":
+            use_nmjv2 = 1
+        else:
+            use_nmjv2 = 0
 
         if use_synoindex == "on":
             use_synoindex = 1
@@ -1393,6 +1398,10 @@ class ConfigNotifications:
         sickbeard.NMJ_HOST = nmj_host
         sickbeard.NMJ_DATABASE = nmj_database
         sickbeard.NMJ_MOUNT = nmj_mount
+
+        sickbeard.USE_NMJv2 = use_nmjv2
+        sickbeard.NMJv2_HOST = nmjv2_host
+        sickbeard.NMJv2_DATABASE = nmjv2_database
 
         sickbeard.USE_SYNOINDEX = use_synoindex
 
@@ -2101,6 +2110,25 @@ class Home:
         else:
             return '{"message": "Failed! Make sure your Popcorn is on and NMJ is running. (see Log & Errors -> Debug for detailed info)", "database": "", "mount": ""}'
 
+    @cherrypy.expose
+    def testNMJv2(self, host=None):
+        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
+        
+        result = notifiers.nmjv2_notifier.test_notify(urllib.unquote_plus(host))
+        if result:
+            return "Successfull started the scan update"
+        else:
+            return "Test failed to start the scan update"
+        
+    @cherrypy.expose
+    def settingsNMJv2(self, host=None):
+        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
+
+        result = notifiers.nmjv2_notifier.notify_settings(urllib.unquote_plus(host))
+        if result:
+            return '{"message": "Database found on %(host)s", "database": "%(database)s"}' % {"host": host, "database": sickbeard.NMJv2_DATABASE}
+        else:
+            return '{"message": "Failed! Make sure your Popcorn is on and NMJ is running. (see Log & Errors -> Debug for detailed info)", "database": "", "mount": ""}'
     @cherrypy.expose
     def testTrakt(self, api=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"


### PR DESCRIPTION
The already present NMJ notifier doesn't work correctly on the popcorn hour 300 series. 
On the 300 series the device no longer returns the NMJ location from the telnet commands the notifier issues.
By manually entering the URL for the API call it was able to start the scanner on the device. However after recent firmware upgrade the device now requires a second API call to specify the scan directory.

At setup the NMJv2 notifier will issue a telnet command which makes the device search every attached storage device for the directory with the name 'nmj_database'. It will stop on the first occurence and the full path to the database is returned and saved.
Next the required API calls are made and the A300/C300 will update it's NMJ database.
