### PR TITLE
Make the DB test actually delete the test database

### DIFF
--- a/tests/db_tests.py
+++ b/tests/db_tests.py
@@ -29,6 +29,10 @@ class DBBasicTests(test.SickbeardTestDBCase):
 
     def test_select(self):
         self.db.select("SELECT * FROM tv_episodes WHERE showid = ? AND location != ''", [0000])
+    
+    def tearDown(self):
+      self.db.connection.close()
+      super(DBBasicTests, self).tearDown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This test fails on Windows. We really should close the connection before deleting the db
