### PR TITLE
Issue-1591 When loading from TVDB mark episodes with an invalid date as ...

### DIFF
--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -145,7 +145,7 @@ class RSSSearchQueueItem(generic_queue.QueueItem):
         curDate = datetime.date.today().toordinal()
 
         myDB = db.DBConnection()
-        sqlResults = myDB.select("SELECT * FROM tv_episodes WHERE status = ? AND airdate < ?", [common.UNAIRED, curDate])
+        sqlResults = myDB.select("SELECT * FROM tv_episodes WHERE status = ? AND airdate < ? AND airdate != 1", [common.UNAIRED, curDate])
 
         for sqlEp in sqlResults:
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1167,8 +1167,8 @@ class TVEpisode(object):
                 if self.status == IGNORED:
                     logger.log(u"Episode has no air date, but it's already marked as ignored", logger.DEBUG)
                 else:
-                    logger.log(u"Episode has no air date, automatically marking it skipped", logger.DEBUG)
-                    self.status = SKIPPED
+                    logger.log(u"Episode has no air date, automatically marking it unaired", logger.DEBUG)
+                    self.status = UNAIRED 
             # if we don't have the file and the airdate is in the past
             else:
                 if self.status == UNAIRED:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1162,7 +1162,7 @@ class TVEpisode(object):
                 # and it hasn't aired yet set the status to UNAIRED
                 logger.log(u"Episode airs in the future, changing status from " + str(self.status) + " to " + str(UNAIRED), logger.DEBUG)
                 self.status = UNAIRED
-            # if there's no airdate then set it to skipped (and respect ignored)
+            # if there's no airdate then set it to unaired (and respect ignored)
             elif self.airdate == datetime.date.fromordinal(1):
                 if self.status == IGNORED:
                     logger.log(u"Episode has no air date, but it's already marked as ignored", logger.DEBUG)


### PR DESCRIPTION
If we have no aired date mark it as unaired instead of skipped. The only time an aired date should be datetime.date.fromordinal(1) is when there was no date in TVDB. Malformed dates will be caught higher up in the script by a ValueError exception.
