### PR TITLE
Add "Archival Delay" configuration option.

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -68,6 +68,17 @@
                             </label>
                         </div>
 
+                        <div class="field-pair">
+                            <label class="nocheck clearfix">
+                                <span class="component-title">Archival Delay</span>
+                                <input type="text" name="archival_delay" value="$sickbeard.ARCHIVAL_DELAY" size="5" />
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Number of days (after air date) to wait for archival quality before downloading initial quality. (eg. 2)</span>
+                            </label>
+                        </div>
+
                         <div class="clearfix"></div>
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
                         

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -151,6 +151,7 @@ USE_TORRENTS = None
 NZB_METHOD = None
 NZB_DIR = None
 USENET_RETENTION = None
+ARCHIVAL_DELAY = None
 DOWNLOAD_PROPERS = None
 
 SEARCH_FREQUENCY = None
@@ -328,7 +329,7 @@ def initialize(consoleLogging=True):
                 PLEX_SERVER_HOST, PLEX_HOST, PLEX_USERNAME, PLEX_PASSWORD, \
                 showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
                 NEWZNAB_DATA, NZBS, NZBS_UID, NZBS_HASH, EZRSS, HDBITS, HDBITS_USERNAME, HDBITS_PASSKEY, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, BTN, BTN_API_KEY, TORRENTLEECH, TORRENTLEECH_KEY, \
-                TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
+                TORRENT_DIR, USENET_RETENTION, ARCHIVAL_DELAY, SOCKET_TIMEOUT, \
                 SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
                 QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, STATUS_DEFAULT, \
                 GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
@@ -444,6 +445,8 @@ def initialize(consoleLogging=True):
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
+        ARCHIVAL_DELAY = check_setting_int(CFG, 'General', 'archival_delay', 0)
+
         SEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'search_frequency', DEFAULT_SEARCH_FREQUENCY)
         if SEARCH_FREQUENCY < MIN_SEARCH_FREQUENCY:
             SEARCH_FREQUENCY = MIN_SEARCH_FREQUENCY
@@ -976,6 +979,7 @@ def save_config():
     new_config['General']['use_torrents'] = int(USE_TORRENTS)
     new_config['General']['nzb_method'] = NZB_METHOD
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
+    new_config['General']['archival_delay'] = int(ARCHIVAL_DELAY)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -737,12 +737,17 @@ class ConfigSearch:
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None, nzbget_username=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
-                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, ignore_words=None):
+                       torrent_dir=None, nzb_method=None, archival_delay=None, usenet_retention=None, search_frequency=None, download_propers=None, ignore_words=None):
 
         results = []
 
         # Episode Search
         sickbeard.DOWNLOAD_PROPERS = config.checkbox_to_value(download_propers)
+
+        if archival_delay == None:
+            archival_delay = 0
+
+        sickbeard.ARCHIVAL_DELAY = int(archival_delay)
 
         config.change_SEARCH_FREQUENCY(search_frequency)
         sickbeard.USENET_RETENTION = config.to_int(usenet_retention, default=500)


### PR DESCRIPTION
Don't download episodes in "initial" quality within a configurable number of days from the air date, IF "archival" quality is specified for a show AND other episodes have already been downloaded in archival quality.

This prevents multiple downloads when the archival quality is frequently released a short time after the initial quality. It won't prevent immediate download of episodes in initial quality for shows that are not released in archival quality.

You should now be able to specify a single custom quality setting (e.g. initial: SD DVD, HDTV; archival: 720p WEB-DL) that works for all shows without frequent duplicate downloads, and without having to know in advance which shows are going to be released in archival quality.
