### PR TITLE
Fix db upgrade when files are missing

### DIFF
--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -438,8 +438,12 @@ class AddSizeAndSceneNameFields(FixAirByDateSetting):
             
             # if there is no size yet then populate it for us
             if (not cur_ep["file_size"] or not int(cur_ep["file_size"]) and ek.ek(os.path.isfile, cur_ep["location"]):
-                cur_size = ek.ek(os.path.getsize, cur_ep["location"])
-                self.connection.action("UPDATE tv_episodes SET file_size = ? WHERE episode_id = ?", [cur_size, int(cur_ep["episode_id"])])
+                try:
+                    cur_size = ek.ek(os.path.getsize, cur_ep["location"])
+                except OSError: # File not found
+                    pass # do not write out filesize
+                else:
+                    self.connection.action("UPDATE tv_episodes SET file_size = ? WHERE episode_id = ?", [cur_size, int(cur_ep["episode_id"])])
 
         # check each snatch to see if we can use it to get a release name from
         history_results = self.connection.select("SELECT * FROM history WHERE provider != -1 ORDER BY date ASC")


### PR DESCRIPTION
DB upgrade crashes when trying to update filesize if file does not exist on disk.
