### PR TITLE
Adding help and checks to the new ubuntu init and cosmetic fixes

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -16,8 +16,7 @@
 if [ -f /etc/default/sickbeard ]; then
         . /etc/default/sickbeard
 else
-	echo "Please create config in /etc/default/sickbeard";
-	exit 1
+	echo "/etc/default/sickbeard not found using default settings.";
 fi
 
 

--- a/init.ubuntu
+++ b/init.ubuntu
@@ -15,49 +15,53 @@
 # Source SickBeard configuration
 if [ -f /etc/default/sickbeard ]; then
         . /etc/default/sickbeard
+else
+	echo "Please create config in /etc/default/sickbeard";
+	exit 1
 fi
 
-# script name
+
+# Script name
 NAME=sickbeard
 
-# app name
+# App name
 DESC=SickBeard
 
 ## Don't edit this file
 ## Edit user configuation in /etc/default/sickbeard to change
 ##
-## SB_USER=
-## SB_HOME=
-## SB_DATA=
-## SB_PIDFILE=
-## PYTHON_BIN=
-## SB_OPTS=
-## SSD_OPTS=
+## SB_USER=				#$RUN_AS, username to run sickbeard under, the default is sickbeard 
+## SB_HOME=				#$APP_PATH, the location of SickBeard.py, the default is /opt/sickbeard
+## SB_DATA=				#$DATA_DIR, the location of sickbeard.db, cache, logs, the default is /opt/sickbeard
+## SB_PIDFILE=			#$PID_FILE, the location of sickbeard.pid, the default is /var/run/sickbeard/sickbeard.pid
+## PYTHON_BIN=			#$DAEMON, the location of the python binary, the default is /usr/bin/python
+## SB_OPTS=				#$EXTRA_DAEMON_OPTS, extra cli option for sickbeard, i.e. " --config=/home/sickbeard/config.ini"
+## SSD_OPTS=			#$EXTRA_SSD_OPTS, extra start-stop-daemon option like " --group=users"
 ##
 ## EXAMPLE if want to run as different user
 ## add SB_USER=username to /etc/default/sickbeard
 ## otherwise default sickbeard is used
 
-## the defaults
+## The defaults
 # Run as username 
 RUN_AS=${SB_USER-sickbeard}
 
-# path to app SB_APP=path_to_app_SickBeard.py
+# Path to app SB_HOME=path_to_app_SickBeard.py
 APP_PATH=${SB_HOME-/opt/sickbeard}
 
-# data directory where sickbeard.db, cache and logs are stored
+# Data directory where sickbeard.db, cache and logs are stored
 DATA_DIR=${SB_DATA-/opt/sickbeard}
 
 # Path to store PID file
 PID_FILE=${SB_PIDFILE-/var/run/sickbeard/sickbeard.pid}
 
-# path to python bin
+# Path to python bin
 DAEMON=${PYTHON_BIN-/usr/bin/python}
 
-# extra daemon option like: SB_OPTS=" --config=/home/sickbeard/config.ini"
+# Extra daemon option like: SB_OPTS=" --config=/home/sickbeard/config.ini"
 EXTRA_DAEMON_OPTS=${SB_OPTS-}
 
-# extra start-stop-daemon option like START_OPTS=" --group=users"
+# Extra start-stop-daemon option like START_OPTS=" --group=users"
 EXTRA_SSD_OPTS=${SSD_OPTS-}
 ##
 
@@ -70,7 +74,7 @@ test -x $DAEMON || exit 0
 
 set -e
 
-# create PID directory if not exist and ensure the SickBeard user can write to it
+# Create PID directory if not exist and ensure the SickBeard user can write to it
 if [ ! -d $PID_PATH ]; then
     mkdir -p $PID_PATH
     chown $RUN_AS $PID_PATH


### PR DESCRIPTION
- Extended the if statement checking for the new config to fail
  obviously if the config doesn't exist, instead of starting with
  defaults. This can cause headaches if folks use the source install
  which can update itself from GitHub, as it fails silently after a long
  while.
- The new defaults file setup changes the variable names and they can
  confuse some, added comments to clarify.
- added cosmetic changes to the comments so capitalization is now the
  same everywhere
