### PR TITLE
On home page show number of days remaining till next episode airs

### DIFF
--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -144,10 +144,21 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
   #set $nom = 0
   #set $den = 1
 #end if
+#if len($curEp) != 0:
+  #set $airDateDelta = $curEp[0].airdate - datetime.date.today()
+  #if $airDateDelta.days > 1
+    #set $daysStr = 's'
+  #else
+    #set $daysStr = ''
+  #end if
+  #set $nextEp = str($airDateDelta.days) + ' day' + $daysStr + ' (' + str($curEp[0].airdate) + ')'
+#else
+  #set $nextEp = ''
+#end if
 
 
   <tr>
-    <td align="center" class="nowrap">#if len($curEp) != 0 then $curEp[0].airdate else ""#</td>
+    <td align="center" class="nowrap">$nextEp</td>
     <td class="tvShow"><a href="$sbRoot/home/displayShow?show=$curShow.tvdbid">$curShow.name</a></td>
     <td>$curShow.network</td>
 #if $curShow.quality in $qualityPresets:


### PR DESCRIPTION
Changed the "Next Episode" column to display the number of days until the next episode, in addition to the date itself.

Code might require cleanup as this is the first time I ever do anything in Python.
Esp. the "if $airDateDelta.days > 1" part, which I would have done inline as (if foo > 1 ? 's' : '') in any other language, but found out Python doesn't support that Syntax.

Also the string formatting is debatable as it's no longer nicely centered.

But the intention of this patch is that the number of days remaining until the next episode airs is more meaningful than the air date itself where the brain has to do the calculation of the delta.
