### PR TITLE
Option to prefer single episode releases over season releases

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -144,6 +144,7 @@ NZB_METHOD = None
 NZB_DIR = None
 USENET_RETENTION = None
 DOWNLOAD_PROPERS = None
+PREFER_EPISODE_RELEASES = None
 
 SEARCH_FREQUENCY = None
 BACKLOG_SEARCH_FREQUENCY = 21
@@ -305,7 +306,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
+                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, PREFER_EPISODE_RELEASES, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
@@ -442,6 +443,8 @@ def initialize(consoleLogging=True):
             NZB_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+
+        PREFER_EPISODE_RELEASES = bool(check_setting_int(CFG, 'General', 'prefer_episode_releases', 0))
 
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
 
@@ -945,6 +948,7 @@ def save_config():
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['prefer_episode_releases'] = int(PREFER_EPISODE_RELEASES)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)
     new_config['General']['flatten_folders_default'] = int(FLATTEN_FOLDERS_DEFAULT)

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -208,7 +208,7 @@ def pickBestResult(results, quality_list=None):
         if not bestResult or bestResult.quality < cur_result.quality and cur_result.quality != Quality.UNKNOWN:
             bestResult = cur_result
         elif bestResult.quality == cur_result.quality:
-            if "proper" in cur_result.name.lower() or "repack" in cur_result.name.lower():
+            if ("proper" not in bestResult.name.lower() and "repack" not in bestResult.name.lower()) and ("proper" in cur_result.name.lower() or "repack" in cur_result.name.lower()):
                 bestResult = cur_result
             elif "internal" in bestResult.name.lower() and "internal" not in cur_result.name.lower():
                 bestResult = cur_result
@@ -383,8 +383,12 @@ def findSeason(show, season):
             else:
                 anyWanted = True
 
-        # if we need every ep in the season and there's nothing better then just download this and be done with it
-        if allWanted and bestSeasonNZB.quality == highest_quality_overall:
+        # if we need every ep in the season check if single episode releases should be preferred over season releases (missing single episode releases will be picked individually from season release)
+        preferSingleEpisodesOverSeasonReleases = sickbeard.PREFER_EPISODE_RELEASES
+        logger.log(u"Prefer single episodes over season releases: "+str(preferSingleEpisodesOverSeasonReleases), logger.DEBUG)
+
+        # if we need every ep in the season and there's nothing better then just download this and be done with it (unless single episodes are preferred)
+        if allWanted and bestSeasonNZB.quality == highest_quality_overall and not preferSingleEpisodesOverSeasonReleases:
             logger.log(u"Every ep in this season is needed, downloading the whole NZB "+bestSeasonNZB.name)
             epObjs = []
             for curEpNum in allEps:


### PR DESCRIPTION
This option is for those who prefer to get each episode nzb added to sabnzbd instead of a complete season nzb. There are multiple reasons why one would want to use this option: Getting a whole season nzb might result in one downloading 100Gb of data only to have it fail in (par) verification. The impact is much less severe when each episode is downloaded as singles. Another reason is if you, like me, prefer the original scene releases with .nfo files over some random season nzb.

As I figure this is not a main stream option it has not been added to the user interface and is currently only available in "config.ini". The default value is "False". 

Commit log:
- Added option "prefer_episode_releases" to config.ini. If a complete season of a show is added to the backlog this option will make sickbeard prefer single episode releases for that season over a comlete season release. I.e. if the complete season 1 of the show "Tv Show" is requested sickbeard will prefer "Tv.Show.S01E01...", "Tv.Show.S01E02...", e. over "Tv.Show.S01...". If not all episodes are available as singles the missing episodes will be picked individually from the season release. Though, "Proper"/"Repack" from season release will be preferred over non-"Proper"/"Repack" singles.
- Added some logic to "pickBestResult" so that if the current "bestResult" already is a "Proper"/"Repack" it will not be overridden by another "Proper"/"Repack" further down the list. This also ensures that "Proper"/"Repack" single episodes always will be preferred over "Proper"/"Repack" season releases (if the "prefer_episode_releases" option is activated).
