### PR TITLE
Add update once option to xbmc notifier

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -66,6 +66,13 @@
                                 </label>
                             </div>
                             <div class="field-pair">
+                                <input type="checkbox" name="xbmc_update_once" id="xbmc_update_once" #if $sickbeard.XBMC_UPDATE_ONCE then "checked=\"checked\"" else ""# />
+                                <label class="clearfix" for="xbmc_update_once">
+                                    <span class="component-title">Update Only One Host</span>
+                                    <span class="component-desc">Update only one host in the list? (Useful for shared databases)</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
                                 <label class="nocheck clearfix">
                                     <span class="component-title">XBMC IP:Port</span>
                                     <input type="text" name="xbmc_host" id="xbmc_host" value="$sickbeard.XBMC_HOST" size="35" />

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -203,6 +203,7 @@ XBMC_NOTIFY_ONSNATCH = False
 XBMC_NOTIFY_ONDOWNLOAD = False
 XBMC_UPDATE_LIBRARY = False
 XBMC_UPDATE_FULL = False
+XBMC_UPDATE_ONCE = False
 XBMC_HOST = ''
 XBMC_USERNAME = None
 XBMC_PASSWORD = None
@@ -309,7 +310,7 @@ def initialize(consoleLogging=True):
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
-                XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
+                XBMC_UPDATE_LIBRARY, XBMC_UPDATE_ONCE, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
                 USE_TRAKT, TRAKT_USERNAME, TRAKT_PASSWORD, TRAKT_API, \
                 USE_PLEX, PLEX_NOTIFY_ONSNATCH, PLEX_NOTIFY_ONDOWNLOAD, PLEX_UPDATE_LIBRARY, \
                 PLEX_SERVER_HOST, PLEX_HOST, PLEX_USERNAME, PLEX_PASSWORD, \
@@ -504,6 +505,7 @@ def initialize(consoleLogging=True):
         XBMC_NOTIFY_ONDOWNLOAD = bool(check_setting_int(CFG, 'XBMC', 'xbmc_notify_ondownload', 0))
         XBMC_UPDATE_LIBRARY = bool(check_setting_int(CFG, 'XBMC', 'xbmc_update_library', 0))
         XBMC_UPDATE_FULL = bool(check_setting_int(CFG, 'XBMC', 'xbmc_update_full', 0))
+        XBMC_UPDATE_ONCE = bool(check_setting_int(CFG, 'XBMC', 'xbmc_update_once', 0))
         XBMC_HOST = check_setting_str(CFG, 'XBMC', 'xbmc_host', '')
         XBMC_USERNAME = check_setting_str(CFG, 'XBMC', 'xbmc_username', '')
         XBMC_PASSWORD = check_setting_str(CFG, 'XBMC', 'xbmc_password', '')
@@ -1036,6 +1038,7 @@ def save_config():
     new_config['XBMC']['xbmc_notify_ondownload'] = int(XBMC_NOTIFY_ONDOWNLOAD)
     new_config['XBMC']['xbmc_update_library'] = int(XBMC_UPDATE_LIBRARY)
     new_config['XBMC']['xbmc_update_full'] = int(XBMC_UPDATE_FULL)
+    new_config['XBMC']['xbmc_update_once'] = int(XBMC_UPDATE_ONCE)
     new_config['XBMC']['xbmc_host'] = XBMC_HOST
     new_config['XBMC']['xbmc_username'] = XBMC_USERNAME
     new_config['XBMC']['xbmc_password'] = XBMC_PASSWORD

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -49,11 +49,16 @@ class XBMCNotifier:
 
     def update_library(self, show_name):
         if sickbeard.XBMC_UPDATE_LIBRARY:
+            updated = False
             for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
                 # do a per-show update first, if possible
-                if not self._update_library(curHost, showName=show_name) and sickbeard.XBMC_UPDATE_FULL:
+                updated = self._update_library(curHost, showName=show_name)
+                if not updated and sickbeard.XBMC_UPDATE_FULL:
                     # do a full update if requested
-                    self._update_library(curHost)
+                    updated = self._update_library(curHost)
+                if updated and sickbeard.XBMC_UPDATE_ONCE:
+                    logger.log(u"Stopped updating xbmc hosts becuase %s host updated" % curHost, logger.DEBUG)
+                    break
 
     def _username(self):
         return sickbeard.XBMC_USERNAME

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1137,7 +1137,7 @@ class ConfigNotifications:
 
     @cherrypy.expose
     def saveNotifications(self, use_xbmc=None, xbmc_notify_onsnatch=None, xbmc_notify_ondownload=None,
-                          xbmc_update_library=None, xbmc_update_full=None, xbmc_host=None, xbmc_username=None, xbmc_password=None,
+                          xbmc_update_library=None, xbmc_update_full=None, xbmc_update_once=None, xbmc_host=None, xbmc_username=None, xbmc_password=None,
                           use_plex=None, plex_notify_onsnatch=None, plex_notify_ondownload=None, plex_update_library=None,
                           plex_server_host=None, plex_host=None, plex_username=None, plex_password=None,
                           use_growl=None, growl_notify_onsnatch=None, growl_notify_ondownload=None, growl_host=None, growl_password=None, 
@@ -1174,6 +1174,11 @@ class ConfigNotifications:
             xbmc_update_full = 1
         else:
             xbmc_update_full = 0
+
+        if xbmc_update_once == "on":
+            xbmc_update_once = 1
+        else:
+            xbmc_update_once = 0
 
         if use_xbmc == "on":
             use_xbmc = 1
@@ -1340,6 +1345,7 @@ class ConfigNotifications:
         sickbeard.XBMC_NOTIFY_ONDOWNLOAD = xbmc_notify_ondownload
         sickbeard.XBMC_UPDATE_LIBRARY = xbmc_update_library
         sickbeard.XBMC_UPDATE_FULL = xbmc_update_full
+        sickbeard.XBMC_UPDATE_ONCE = xbmc_update_once
         sickbeard.XBMC_HOST = xbmc_host
         sickbeard.XBMC_USERNAME = xbmc_username
         sickbeard.XBMC_PASSWORD = xbmc_password


### PR DESCRIPTION
Adds option to stop sending update commands to xbmc hosts once it has successfully updated once. If using a mysql database that has several clients, this is really useful.
