### PR TITLE
Fix the display of multi-line log entries in the viewlog page

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1890,7 +1890,7 @@ class ErrorLogs:
         finalData = []
 
         numLines = 0
-        lastLine = False
+        setAsideLines = []
         numToShow = min(maxLines, len(data))
 
         for x in reversed(data):
@@ -1900,19 +1900,19 @@ class ErrorLogs:
 
             if match:
                 level = match.group(6)
-                if level not in logger.reverseNames:
-                    lastLine = False
+                if level not in logger.reverseNames or logger.reverseNames[level] < minLevel:
+                    setAsideLines = []
                     continue
 
-                if logger.reverseNames[level] >= minLevel:
-                    lastLine = True
-                    finalData.append(x)
-                else:
-                    lastLine = False
-                    continue
+                finalData.append(x)
+                for y in setAsideLines:
+                    finalData.append(y)
+                
+                setAsideLines = []
 
-            elif lastLine:
-                finalData.append("AA"+x)
+            else:
+                setAsideLines.append(x)
+                continue
 
             numLines += 1
 


### PR DESCRIPTION
Multi-line log entries are currently displayed incorrectly in the viewlog page when specifying a minimum level above Debug.

In particular, right now if a multi-line debug entry is logged right before an info entry, the viewlog with minlevel=info will display the info entry, followed by all the debug entry lines except the first one prepended by 'AA', causing confusion when checking the log from the web page.

(I hope this time I made the request correctly, first time git user here..)
