### PR TITLE
Support Plex multi-episode naming

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -58,6 +58,7 @@ NAMING_EXTEND = 2
 NAMING_DUPLICATE = 4
 NAMING_LIMITED_EXTEND = 8
 NAMING_SEPARATED_REPEAT = 16
+NAMING_LIMITED_EXTEND_E_PREFIXED = 32
 
 multiEpStrings = {}
 multiEpStrings[NAMING_REPEAT] = "Repeat"
@@ -65,6 +66,7 @@ multiEpStrings[NAMING_SEPARATED_REPEAT] = "Repeat (Separated)"
 multiEpStrings[NAMING_DUPLICATE] = "Duplicate"
 multiEpStrings[NAMING_EXTEND] = "Extend"
 multiEpStrings[NAMING_LIMITED_EXTEND] = "Extend (Limited)"
+multiEpStrings[NAMING_LIMITED_EXTEND_E_PREFIXED] = "Extend (Limited, E-prefixed)"
 
 class Quality:
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -43,7 +43,7 @@ from sickbeard import encodingKludge as ek
 
 from common import Quality, Overview
 from common import DOWNLOADED, SNATCHED, SNATCHED_PROPER, ARCHIVED, IGNORED, UNAIRED, WANTED, SKIPPED, UNKNOWN
-from common import NAMING_DUPLICATE, NAMING_EXTEND, NAMING_LIMITED_EXTEND, NAMING_SEPARATED_REPEAT
+from common import NAMING_DUPLICATE, NAMING_EXTEND, NAMING_LIMITED_EXTEND, NAMING_SEPARATED_REPEAT, NAMING_LIMITED_EXTEND_E_PREFIXED
 
 class TVShow(object):
 
@@ -1574,7 +1574,7 @@ class TVEpisode(object):
                     sep = ' '
 
                 # force 2-3-4 format if they chose to extend
-                if multi in (NAMING_EXTEND, NAMING_LIMITED_EXTEND):
+                if multi in (NAMING_EXTEND, NAMING_LIMITED_EXTEND, NAMING_LIMITED_EXTEND_E_PREFIXED):
                     ep_sep = '-'
                 
                 regex_used = season_ep_regex
@@ -1599,7 +1599,7 @@ class TVEpisode(object):
             for other_ep in self.relatedEps:
                 
                 # for limited extend we only append the last ep
-                if multi == NAMING_LIMITED_EXTEND and other_ep != self.relatedEps[-1]:
+                if multi in (NAMING_LIMITED_EXTEND, NAMING_LIMITED_EXTEND_E_PREFIXED) and other_ep != self.relatedEps[-1]:
                     continue
                 
                 elif multi == NAMING_DUPLICATE:
@@ -1611,6 +1611,10 @@ class TVEpisode(object):
 
                 # add "E04"
                 ep_string += ep_sep
+
+                if multi == NAMING_LIMITED_EXTEND_E_PREFIXED:
+                    ep_string += 'E'
+
                 ep_string += other_ep._format_string(ep_format.upper(), other_ep._replace_map())
 
             if season_ep_match:


### PR DESCRIPTION
Plex has a different idea of suitable multi-episode naming than those currently supported by Sick-Beard. Essentially it requires the format to be "S01E01-E02", which is not achievable in Sick-Beard currently. This patch makes that pattern achievable. The new multi-episode naming scheme is called "Extend (Limited, E-prefixed)" as to not be Plex-specific in case something else has a similarly limited parser. The Plex naming rules are described here: http://wiki.plexapp.com/index.php/Media_Naming_and_Organization_Guide#Multiple_Episodes_in_One_File
