### PR TITLE
quality chooser / newShow tweaks

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -122,10 +122,6 @@ div.formpaginate .prev, div.formpaginate .next {
   overflow: hidden;
   clear: both;
 }
-.stepDiv > #customQualityWrapper {
-  height: 190px;
-  overflow: auto;
-}
 #customQualityWrapper div.component-group-desc {
   float:left;
   width:165px;

--- a/data/interfaces/default/home_newShow.tmpl
+++ b/data/interfaces/default/home_newShow.tmpl
@@ -40,7 +40,7 @@
             <b>*</b> This will only affect the language of the retrieved metadata file contents and episode filenames.<br />
             This <b>DOES NOT</b> allow Sick Beard to download non-english TV episodes!<br />
             <br />
-            <div id="searchResults" style="height: 225px; overflow: auto;"></div>
+            <div id="searchResults" style="max-height: 225px; overflow: auto;"></div>
         #end if
 
     </div>

--- a/data/js/lib/formwizard.js
+++ b/data/js/lib/formwizard.js
@@ -39,7 +39,7 @@ formtowizard.prototype={
 		}	
 		var i=(rawi=="prev")? this.currentsection-1 : (rawi=="next")? this.currentsection+1 : parseInt(rawi) //get index of next section to show
 		i=(i<0)? this.sections.count-1 : (i>this.sections.count-1)? 0 : i //make sure i doesn't exceed min/max limit
-		if (this.currentsection!=i && i<this.sections.count && doload){ //if next section to show isn't the same as the current section shown
+		if (i<this.sections.count && doload){ //if next section to show isn't the same as the current section shown
 			this.$thesteps.eq(this.currentsection).addClass('disabledstep').end().eq(i).removeClass('disabledstep') //dull current "step" text then highlight next "step" text
 			if (this.setting.revealfx[0]=="slide"){
 				this.sections.$sections.css("visibility", "visible")

--- a/data/js/newShow.js
+++ b/data/js/newShow.js
@@ -1,68 +1,73 @@
-$(document).ready(function(){
+$(document).ready(function () {
 
     function populateSelect() {
-        if (!$('#nameToSearch').length)
-            return
+        if (!$('#nameToSearch').val().length) {
+            return;
+        }
 
         if ($('#tvdbLangSelect option').length <= 1) {
-            $.getJSON(sbRoot+'/home/addShows/getTVDBLanguages', {}, function(data){
-                var resultStr = '';
-        
-                if (data.results.length == 0) {
+            $.getJSON(sbRoot + '/home/addShows/getTVDBLanguages', {}, function (data) {
+                var selected, resultStr = '';
+
+                if (data.results.length === 0) {
                     resultStr = '<option value="en" selected="selected">en</option>';
                 } else {
-                    $.each(data.results, function(index, obj){
-                        if (resultStr == '')
-                                selected = ' selected="selected"';
-                        else
-                                selected = '';
-        
+                    $.each(data.results, function (index, obj) {
+                        if (resultStr == '') {
+                            selected = ' selected="selected"';
+                        } else {
+                            selected = '';
+                        }
+
                         resultStr += '<option value="' + obj + '"' + selected + '>' + obj + '</option>';
                     });
                 }
-        
+
                 $('#tvdbLangSelect').html(resultStr);
-        
-                $('#tvdbLangSelect').change(function() { searchTvdb() });
+                $('#tvdbLangSelect').change(function () { searchTvdb(); });
             });
         }
     }
 
-    function searchTvdb(){
-        if (!$('#nameToSearch').length)
-            return
+    function searchTvdb() {
+        if (!$('#nameToSearch').val().length) {
+            return;
+        }
 
-        $('#searchResults').html('<img id="searchingAnim" src="'+sbRoot+'/images/loading32.gif" height="32" width="32" /> searching...');
+        $('#searchResults').html('<img id="searchingAnim" src="' + sbRoot + '/images/loading32.gif" height="32" width="32" /> searching...');
 
-        $.getJSON(sbRoot+'/home/addShows/searchTVDBForShowName', {'name': $('#nameToSearch').val(), 'lang': $('#tvdbLangSelect').val()}, function(data){
+        $.getJSON(sbRoot + '/home/addShows/searchTVDBForShowName', {'name': $('#nameToSearch').val(), 'lang': $('#tvdbLangSelect').val()}, function (data) {
             var firstResult = true;
             var resultStr = '<fieldset>\n<legend>Search Results:</legend>\n';
-            
-            if (data.results.length == 0) {
+            var checked = '';
+
+            if (data.results.length === 0) {
                 resultStr += '<b>No results found, try a different search.</b>';
             } else {
-            
-                $.each(data.results, function(index, obj){
+                $.each(data.results, function (index, obj) {
                     if (firstResult) {
                         checked = ' checked';
                         firstResult = false;
-                    } else
+                    } else {
                         checked = '';
+                    }
                     resultStr += '<input type="radio" id="whichSeries" name="whichSeries" value="' + obj[0] + '|' + obj[1] + '"' + checked + ' /> ';
-                    if(data.langid && data.langid != "")
-                            resultStr += '<a href="http://thetvdb.com/?tab=series&id=' + obj[0] + '&lid=' + data.langid + '" onclick=\"window.open(this.href, \'_blank\'); return false;\" ><b>' + obj[1] + '</b></a>';
-                    else
+                    if (data.langid && data.langid != "") {
+                        resultStr += '<a href="http://thetvdb.com/?tab=series&id=' + obj[0] + '&lid=' + data.langid + '" onclick=\"window.open(this.href, \'_blank\'); return false;\" ><b>' + obj[1] + '</b></a>';
+                    } else {
                         resultStr += '<a href="http://thetvdb.com/?tab=series&id=' + obj[0] + '" onclick=\"window.open(this.href, \'_blank\'); return false;\" ><b>' + obj[1] + '</b></a>';
+                    }
 
-                    if (obj[2] != null) {
+                    if (obj[2] !== null) {
                         var startDate = new Date(obj[2]);
                         var today = new Date();
-                        if (startDate>today)
-                                resultStr += ' (will debut on ' + obj[2] + ')';
-                        else
-                                resultStr += ' (started on ' + obj[2] + ')';
+                        if (startDate > today) {
+                            resultStr += ' (will debut on ' + obj[2] + ')';
+                        } else {
+                            resultStr += ' (started on ' + obj[2] + ')';
+                        }
                     }
-                    
+
                     resultStr += '<br />';
                 });
                 resultStr += '</ul>';
@@ -70,54 +75,61 @@ $(document).ready(function(){
             resultStr += '</fieldset>';
             $('#searchResults').html(resultStr);
             updateSampleText();
+            myform.loadsection(0);
         });
-    };
+    }
 
-    $('#searchName').click(function() {searchTvdb()});
+    $('#searchName').click(function () { searchTvdb(); });
 
-    if ($('#nameToSearch').length && $('#nameToSearch').val().length)
-        $('#searchName').click()
+    if ($('#nameToSearch').length && $('#nameToSearch').val().length) {
+        $('#searchName').click();
+    }
 
-    $('#addShowButton').click(function(){
-        
+    $('#addShowButton').click(function () {
         // if they haven't picked a show don't let them submit
         if (!$("input:radio[name='whichSeries']:checked").val() && !$("input:hidden[name='whichSeries']").val().length) {
             alert('You must choose a show to continue');
             return false;
         }
 
-        $('#addShowForm').submit()
-
+        $('#addShowForm').submit();
     });
-    
-    $('#skipShowButton').click(function(){
+
+    $('#skipShowButton').click(function () {
         $('#skipShow').val('1');
         $('#addShowForm').submit();
     });
-    
+
+    $('#qualityPreset').change(function () {
+        myform.loadsection(2);
+    });
+
     /***********************************************
     * jQuery Form to Form Wizard- (c) Dynamic Drive (www.dynamicdrive.com)
     * This notice MUST stay intact for legal use
     * Visit http://www.dynamicdrive.com/ for this script and 100s more.
     ***********************************************/
 
-    var myform=new formtowizard({
+    var myform = new formtowizard({
         formid: 'addShowForm',
         revealfx: ['slide', 500],
         oninit: function () {
             populateSelect();
             updateSampleText();
-            if ($('input:hidden[name=whichSeries]').length && $('#fullShowPath').length)
+            if ($('input:hidden[name=whichSeries]').length && $('#fullShowPath').length) {
                 goToStep(3);
-            if ($('#nameToSearch').length)
+            }
+            if ($('#nameToSearch').length) {
                 $('#nameToSearch').focus();
+            }
         }
     });
 
-    function goToStep(num){
-        $('.step').each(function(){
-            if ($.data(this, 'section')+1 == num)
+    function goToStep(num) {
+        $('.step').each(function () {
+            if ($.data(this, 'section') + 1 == num) {
                 $(this).click();
+            }
         });
     }
 
@@ -125,33 +137,35 @@ $(document).ready(function(){
 
     function updateSampleText() {
         // if something's selected then we have some behavior to figure out
-        
-        var show_name;
+
+        var show_name, sep_char;
         // if they've picked a radio button then use that
-        if ($('input:radio[name=whichSeries]:checked').length)
+        if ($('input:radio[name=whichSeries]:checked').length) {
             show_name = $('input:radio[name=whichSeries]:checked').val().split('|')[1];
-
-        // if we provided a show in the hidden field, use that 
-        else if ($('input:hidden[name=whichSeries]').length && $('input:hidden[name=whichSeries]').val().length)
+        }
+        // if we provided a show in the hidden field, use that
+        else if ($('input:hidden[name=whichSeries]').length && $('input:hidden[name=whichSeries]').val().length) {
             show_name = $('#providedName').val();
-
-        else
+        } else {
             show_name = '';
-        
-        var sample_text = 'Adding show <b>'+show_name+'</b> into <b>';
+        }
+
+        var sample_text = 'Adding show <b>' + show_name + '</b> into <b>';
 
         // if we have a root dir selected, figure out the path
         if ($("#rootDirs option:selected").length) {
             var root_dir_text = $('#rootDirs option:selected').val();
-            if (root_dir_text.indexOf('/') >= 0)
+            if (root_dir_text.indexOf('/') >= 0) {
                 sep_char = '/';
-            else if (root_dir_text.indexOf('\\') >= 0)
+            } else if (root_dir_text.indexOf('\\') >= 0) {
                 sep_char = '\\';
-            else
+            } else {
                 sep_char = '';
+            }
 
-            if (root_dir_text.substr(sample_text.length-1) != sep_char)
+            if (root_dir_text.substr(sample_text.length - 1) != sep_char) {
                 root_dir_text += sep_char;
+            }
             root_dir_text += '<i>||</i>' + sep_char;
 
             sample_text += root_dir_text;
@@ -160,33 +174,35 @@ $(document).ready(function(){
         } else {
             sample_text += 'unknown dir.';
         }
-        
+
         sample_text += '</b>';
 
         // if we have a show name then sanitize and use it for the dir name
         if (show_name.length) {
-            $.get(sbRoot+'/home/addShows/sanitizeFileName', {name: show_name}, function(data){
-                 $('#displayText').html(sample_text.replace('||', data));
+            $.get(sbRoot + '/home/addShows/sanitizeFileName', {name: show_name}, function (data) {
+                $('#displayText').html(sample_text.replace('||', data));
             });
-
         // if not then it's unknown
-        } else
+        } else {
             $('#displayText').html(sample_text.replace('||', '??'));
-        
+        }
+
         // also toggle the add show button
-        if (($("#rootDirs option:selected").length || ($('#fullShowPath').length && $('#fullShowPath').val().length)) && 
-            ($('input:radio[name=whichSeries]:checked').length) || ($('input:hidden[name=whichSeries]').length && $('input:hidden[name=whichSeries]').val().length))
+        if (($("#rootDirs option:selected").length || ($('#fullShowPath').length && $('#fullShowPath').val().length)) &&
+            ($('input:radio[name=whichSeries]:checked').length) || ($('input:hidden[name=whichSeries]').length && $('input:hidden[name=whichSeries]').val().length)) {
             $('#addShowButton').attr('disabled', false);
-        else
+        } else {
             $('#addShowButton').attr('disabled', true);
+        }
     }
-    
+
     $('#rootDirText').change(updateSampleText);
     $('#whichSeries').live('change', updateSampleText);
 
-    $('#nameToSearch').keyup(function(event){
-        if(event.keyCode == 13)
+    $('#nameToSearch').keyup(function (event) {
+        if (event.keyCode == 13) {
             $('#searchName').click();
+        }
     });
 
 });


### PR DESCRIPTION
 Modified it so that we could just 'reload' a page of the formwizard. This was needed as having a fixed height created a pretty ugly whitespace when switching from predefined template to 'Custom' or vice versa. (show the qualities or not). Now it will resize the outerwraper and make things look a bit nicer. Also cleaned up some JS in the newShow file to make jsHint happier.
