### PR TITLE
Update Xbmc notifier to use JSON for new Xbmc versions(>=frodo)

### DIFF
--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -34,26 +34,55 @@ try:
 except ImportError:
     import xml.etree.ElementTree as etree
 
-class XBMCNotifier:
+try:
+    import lib.simplejson as json
+except:
+    import json
 
+class XBMCNotifier:
+    
+    apiversion = 0
+    
     def notify_snatch(self, ep_name):
         if sickbeard.XBMC_NOTIFY_ONSNATCH:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+            if (self._jsonapiversion() <= 4):
+                logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
+                self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+            else:
+                logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
+                self._notifyXBMC_json(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
 
     def notify_download(self, ep_name):
         if sickbeard.XBMC_NOTIFY_ONDOWNLOAD:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            if (self._jsonapiversion() <= 4):
+                self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            else:
+                self._notifyXBMC_json(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def test_notify(self, host, username, password):
-        return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+        if (self._jsonapiversion() <= 4):
+            logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
+            return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+        else:
+            logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
+            return self._notifyXBMC_json("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
 
-    def update_library(self, show_name):
+    def update_library(self, host, showName=None):
         if sickbeard.XBMC_UPDATE_LIBRARY:
-            for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-                # do a per-show update first, if possible
-                if not self._update_library(curHost, showName=show_name) and sickbeard.XBMC_UPDATE_FULL:
+            if (self._jsonapiversion() <= 4):
+                if not self._update_library(host, showName) and sickbeard.XBMC_UPDATE_FULL:
                     # do a full update if requested
-                    self._update_library(curHost)
+                    return self._update_library(host)
+                else:
+                    return True
+
+            else:
+                if not self._update_library_json(host, showName) and sickbeard.XBMC_UPDATE_FULL:
+                    # do a full update if requested
+                    logger.log("Single show update failed, running full update", logger.ERROR)
+                    return self._update_library_json(host)
+                else:
+                    return True
 
     def _username(self):
         return sickbeard.XBMC_USERNAME
@@ -66,6 +95,12 @@ class XBMCNotifier:
 
     def _hostname(self):
         return sickbeard.XBMC_HOST
+    
+    def _jsonapiversion(self):
+        # buffer the api version, so we don't hammer the server with useless requests
+        if (self.apiversion == 0):
+            self.apiversion = self._checkJSON_version()
+        return self.apiversion
 
     def _sendToXBMC(self, command, host, username=None, password=None):
         '''
@@ -113,7 +148,7 @@ class XBMCNotifier:
     def _notifyXBMC(self, input, title="Sick Beard", host=None, username=None, password=None, force=False):
     
         if not self._use_me() and not force:
-            logger.log("Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
+            logger.log(u"Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
             return False
     
         if not host:
@@ -139,15 +174,15 @@ class XBMCNotifier:
         return result
 
     def _update_library(self, host, showName=None):
-    
+        
         if not self._use_me():
-            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
+            logger.log(u"Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
             return False
     
         logger.log(u"Updating library in XBMC", logger.DEBUG)
     
         if not host:
-            logger.log('No host specified, no updates done', logger.DEBUG)
+            logger.log(u'No host specified, no updates done', logger.DEBUG)
             return False
     
         # if we're doing per-show
@@ -212,6 +247,161 @@ class XBMCNotifier:
                 return False
     
         return True
+
+    def _checkJSON_version(self):
+        '''
+        returns XBMC JSONRPC Api version
+        4 = Xbmc Eden(11), 5 = Xbmc Frodo(12)
+        '''
+        host = self._hostname()
+        username = self._username()
+        password = self._password()
+            
+        checkCommand = '{"id":1,"jsonrpc":"2.0","method":"JSONRPC.Version"}'
+        result = self._sendToXBMC_json(checkCommand, host, username, password)
+        if result:
+            return result["result"]["version"]
+        else:
+            return False
+        
+    def _sendToXBMC_json(self, command, host, username=None, password=None):
+        '''
+        Handles communication with XBMC servers via JSONRPC 
+    
+        command - JSON request passed to http://host/jsonrpc
+        returns: dict or False on error
+    
+        host - host/ip + port (foo:8080)
+        '''
+
+        if not username:
+            username = self._username()
+        if not password:
+            password = self._password()
+    
+        command = command.encode('utf-8')
+        logger.log(u"Command is " + command, logger.DEBUG)
+        url = 'http://%s/jsonrpc' % (host)
+                    
+        try:
+            req = urllib2.Request(url, command)
+            req.add_header("Content-type", "application/json")
+            # If we have a password, use authentication
+            if password:
+                logger.log(u"Adding Password to XBMC url", logger.DEBUG)
+                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
+                authheader =  "Basic %s" % base64string
+                req.add_header("Authorization", authheader)
+    
+            logger.log(u"Contacting XBMC via url: " + url, logger.DEBUG)
+            response = urllib2.urlopen(req)
+            
+        except IOError, e:
+            logger.log(u"Warning: Couldn't contact XBMC JSON api at " + fixStupidEncodings(url) + ": " + ex(e), logger.ERROR)
+            return False
+
+        # Parse the json result
+        try:
+            result = json.load(response)
+            response.close()
+            logger.log(u"response: " + str(result), logger.DEBUG)
+            return result
+        
+        except ValueError, e:
+            logger.log(u"Unable to decode JSON: "+response, logger.ERROR)
+            return False
+        
+     
+    def _notifyXBMC_json(self, msg, title="Sick Beard", host=None, username=None, password=None, force=False):
+    
+        if not self._use_me() and not force:
+            logger.log(u"Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
+            return False
+    
+        if not host:
+            host = self._hostname()
+        if not username:
+            username = self._username()
+        if not password:
+            password = self._password()
+    
+        logger.log(u"Sending notification for " + msg, logger.DEBUG)
+    
+        result = ''
+        for curHost in [x.strip() for x in host.split(",")]:
+            command = '{"id":1,"jsonrpc":"2.0","method":"GUI.ShowNotification","params":{"title":"Sick Beard","message":"%s"}}' % msg
+            logger.log(u"Sending notification to XBMC via host: "+ curHost +" username: "+ username + " password: " + password, logger.DEBUG)
+            notifyResult = self._sendToXBMC_json(command, curHost, username, password)
+            if (notifyResult != False):
+                result += ', '+ curHost + ':' + notifyResult["result"].decode(sickbeard.SYS_ENCODING)
+        
+        return result
+
+    def _update_library_json(self, host, showName=None):
+        
+        username = self._username()
+        password = self._password()
+    
+        if not self._use_me():
+            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
+            return False
+    
+        logger.log(u"Updating library in XBMC", logger.DEBUG)
+    
+        if not host:
+            logger.log(u'No host specified, no updates done', logger.DEBUG)
+            return False
+    
+        # if we're doing per-show
+        if showName:
+            tvshowid = -1
+            
+            # get tvshowid by showName
+            showsCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows"}'
+            showsResponse = self._sendToXBMC_json(showsCommand, host)
+            if (showsResponse == False):
+                return False
+            shows = showsResponse["result"]["tvshows"] 
+            
+            for show in shows:
+                if (show["label"] == showName):
+                    tvshowid = show["tvshowid"]
+            if (tvshowid == -1):
+                # we didn't find the show, will trigger a full update if enabled
+                return False
+            
+            # this can be big, so free some memory
+            del shows
+            
+            # JSON to get the TV-Show path
+            pathCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.GetTVShowDetails","params":{"tvshowid":%d, "properties": ["file"]}}' % (tvshowid)
+            pathResponse = self._sendToXBMC_json(pathCommand, host)
+
+            path = pathResponse["result"]["tvshowdetails"]["file"]
+            logger.log(u"Received Show: " + show["label"] + " with ID: " + str(tvshowid) + " Path: " + path, logger.DEBUG)
+
+            if (len(path) < 1):
+                logger.log(u"No valid path found for " + showName + " with ID: " + str(tvshowid) + " on " + host, logger.ERROR)
+                return False
+
+            logger.log(u"XBMC Updating " + showName + " on " + host + " at " + path, logger.DEBUG)
+            updateCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":"%s"}}' % (path)
+            request = self._sendToXBMC_json(updateCommand, host)
+            if not request:
+                    logger.log(u"Update of show directory failed on " + showName + " on " + host + " at " + path, logger.ERROR)
+                    return False
+            
+        else:
+            logger.log(u"Do a full update as requested", logger.DEBUG)
+            logger.log(u"XBMC Updating " + host, logger.DEBUG)
+            updateCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.Scan"}'
+            request = self._sendToXBMC_json(updateCommand, host, username, password)
+            if not request:
+                logger.log(u"Full update failed on " + host, logger.ERROR)
+                return False
+    
+        return True
+
 
 # Wake function
 def wakeOnLan(ethernet_address):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2448,7 +2448,7 @@ class Home:
     def updateXBMC(self, showName=None):
 
         for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-            if notifiers.xbmc_notifier._update_library(curHost, showName=showName):
+            if notifiers.xbmc_notifier.update_library(curHost, showName=showName):
                 ui.notifications.message("Command sent to XBMC host " + curHost + " to update library")
             else:
                 ui.notifications.error("Unable to contact XBMC host " + curHost)


### PR DESCRIPTION
Xbmc recently dropped the old and long deprecated HTTP API, so notifications and library updates don't work anymore in xbmc nightly builds.

this PR adds methods for the JSONRPC API and uses it if a recent Xbmc version is found.
For older Xbmc builds, nothing changes.
We cannot use json for older xbmc builds, because they don't support notifications over json.
