### PR TITLE
Added JSON fallback functions for XBMC, in case HTTP API fails or is non...

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2057,7 +2057,7 @@ class Home:
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
         result = notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(host), username, password)
-        if len(result.split(":")) > 2 and 'OK' in result.split(":")[2]:
+        if result:
             return "Test notice sent successfully to "+urllib.unquote_plus(host)
         else:
             return "Test notice failed to "+urllib.unquote_plus(host)


### PR DESCRIPTION
...-existent

This is a new set of functions in the XBMC notification code for using the XBMC JSON API to do communications.  Recently, XBMC has pulled out the HTTP API in their development code, so anyone running nightlies/.git builds of XBMC hasn't been able to get SickBeard to automatically update libraries.

The code is written so that it will try the HTTP API first, then go to JSON if the HTTP API fails.  This way, people that aren't on XBMC nightlies will continue to use the same code they always have.

There was one tweak I made that affected the HTTP API code... The XBMC Test Notification code didn't return a True/False like the rest of the notiifiers; it returned the http that came back, and then the calling code parsed it out.  I just moved the parsing of the return string into the notifier code so it could return True/False, and updated webserve.py to expect a True/False out of it.

In doing all this, I did find a bug in the development code of XBMC that actually makes this somewhat useless at the moment... http://forum.xbmc.org/showthread.php?tid=143740 which led to http://trac.xbmc.org/ticket/13462 ... Until they get this bug resolved, you still need to run the auto-clean.  Oh well, not much I can do about that.

All I can say is that the JSON code works on the ubuntu nightly ppa XBMC.  Anything else probably shouldn't matter, due to JSON being used only if HTTP API fails.
