### PR TITLE
process files by size (smallest first)

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -85,7 +85,12 @@ def processDir (dirName, nzbName=None, recurse=False):
 
     # split the list into video files and folders
     folders = filter(lambda x: ek.ek(os.path.isdir, ek.ek(os.path.join, dirName, x)), fileList)
-    videoFiles = filter(helpers.isMediaFile, fileList)
+
+    # videoFiles, sorted by size
+    #  this prevents from overwriting a big file with a small one whith the same name
+    #  workaround for bad named samle files in single episod archives/dirs
+    videoFilesAndSize = [ ( videoFile, os.path.getsize( ek.ek(os.path.join, dirName, videoFile) ) ) for videoFile in filter(helpers.isMediaFile, fileList) ]
+    videoFiles = [ videoFile[0] for videoFile in sorted(videoFilesAndSize, key=lambda x: x[1]) ]
 
     # recursively process all the folders
     for curFolder in folders:


### PR DESCRIPTION
I just hat two downloads with similar problems like the one described in https://github.com/sabnzbd/sabnzbd/issues/32. Of cause I have configured Sabnzbd to not download sample files.

The downloaded archive contained two .mkv files, the episode (1.7GB) and a sample (24MB) which was not identifiable as a sample by name. 
sabToSickBeard.py first processed the episode.mkv which then got replaced by the (smaller) samle.mkv because the complete archive was marked as priority download due to it was snatched by sick-beard.

With this little change sabToSickBeard.py will process all video files sorted by their filesize (smallest first). In the described case, the samle.mkv would get overriden by episode.mkv. As far as I can say multi-ep archives are processed normally as the names of the video files do match against episode numbers.
