### PR TITLE
Update sickbeard/scene_exceptions.py

### DIFF
--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -68,7 +68,7 @@ def retrieve_exceptions():
     exception_dict = {}
 
     # exceptions are stored on github pages
-    url = 'http://midgetspy.github.com/sb_tvdb_scene_exceptions/exceptions.txt'
+    url = 'http://github.com/midgetspy/sb_tvdb_scene_exceptions/blob/gh-pages/exceptions.txt'
 
     logger.log(u"Check scene exceptions update")
     url_data = helpers.getURL(url)


### PR DESCRIPTION
Changed url to exeptions.txt
Error in sickbeard: 2012-10-30 09:24:54.293085 CHECKVERSION :: Check scene exceptions update failed. Unable to get URL: http://midgetspy.github.com/sb_tvdb_scene_exceptions/exceptions.txt
