### PR TITLE
XBMC Streaming using Pneumatic addon

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -86,8 +86,8 @@
                                 <span class="component-title jumbo">NZB Method:</span>
                                 <span class="component-desc">
                                     <select name="nzb_method" id="nzb_method" class="input-medium" >
-                                    #set $nzb_method_text = {'blackhole': "Black Hole", 'sabnzbd': "SABnzbd", 'nzbget': "NZBget"}
-                                    #for $curAction in ('sabnzbd', 'blackhole', 'nzbget'):
+                                    #set $nzb_method_text = {'blackhole': "Black Hole", 'sabnzbd': "SABnzbd", 'nzbget': "NZBget", 'strm': "XBMC STRM"}
+                                    #for $curAction in ('sabnzbd', 'blackhole', 'nzbget', 'strm': "XBMC STRM"):
                                       #if $sickbeard.NZB_METHOD == $curAction:
                                         #set $nzb_method = "selected=\"selected\""
                                       #else

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -87,7 +87,7 @@
                                 <span class="component-desc">
                                     <select name="nzb_method" id="nzb_method" class="input-medium" >
                                     #set $nzb_method_text = {'blackhole': "Black Hole", 'sabnzbd': "SABnzbd", 'nzbget': "NZBget", 'strm': "XBMC STRM"}
-                                    #for $curAction in ('sabnzbd', 'blackhole', 'nzbget', 'strm': "XBMC STRM"):
+                                    #for $curAction in ('sabnzbd', 'blackhole', 'nzbget', 'strm'):
                                       #if $sickbeard.NZB_METHOD == $curAction:
                                         #set $nzb_method = "selected=\"selected\""
                                       #else
@@ -109,6 +109,19 @@
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
                                     <span class="component-desc">The directory where Sick Beard should store your <i>NZB</i> files.</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div id="strm_settings">
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Pneumatic NZB Location</span>
+                                    <input type="text" name="pneu_nzb_dir" id="pneu_nzb_dir" value="$sickbeard.PNEU_NZB_DIR" size="45" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">The directory where Pneumatic looks for your <i>NZB</i> files.</span>
                                 </label>
                             </div>
                         </div>

--- a/data/js/configSearch.js
+++ b/data/js/configSearch.js
@@ -18,24 +18,28 @@ $(document).ready(function(){
             $('#testSABnzbd').hide();
             $('#testSABnzbd-result').hide();
             $('#nzbget_settings').hide();
+            $('#strm_settings').hide();
         } else if (selectedProvider == "nzbget") {
             $('#blackhole_settings').hide();
             $('#sabnzbd_settings').hide();
             $('#testSABnzbd').hide();
             $('#testSABnzbd-result').hide();
             $('#nzbget_settings').show();
+            $('#strm_settings').hide();
         } else if (selectedProvider == "strm") {
             $('#blackhole_settings').show();
             $('#sabnzbd_settings').hide();
             $('#testSABnzbd').hide();
             $('#testSABnzbd-result').hide();
             $('#nzbget_settings').hide();
+            $('#strm_settings').show();
         } else {
             $('#blackhole_settings').hide();
             $('#sabnzbd_settings').show();
             $('#testSABnzbd').show();
             $('#testSABnzbd-result').show();
             $('#nzbget_settings').hide();
+            $('#strm_settings').hide();
         }
 
     }

--- a/data/js/configSearch.js
+++ b/data/js/configSearch.js
@@ -25,7 +25,7 @@ $(document).ready(function(){
             $('#testSABnzbd-result').hide();
             $('#nzbget_settings').show();
         } else if (selectedProvider == "strm") {
-            $('#blackhole_settings').hide();
+            $('#blackhole_settings').show();
             $('#sabnzbd_settings').hide();
             $('#testSABnzbd').hide();
             $('#testSABnzbd-result').hide();

--- a/data/js/configSearch.js
+++ b/data/js/configSearch.js
@@ -24,6 +24,12 @@ $(document).ready(function(){
             $('#testSABnzbd').hide();
             $('#testSABnzbd-result').hide();
             $('#nzbget_settings').show();
+        } else if (selectedProvider == "strm") {
+            $('#blackhole_settings').hide();
+            $('#sabnzbd_settings').hide();
+            $('#testSABnzbd').hide();
+            $('#testSABnzbd-result').hide();
+            $('#nzbget_settings').hide();
         } else {
             $('#blackhole_settings').hide();
             $('#sabnzbd_settings').show();

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -142,6 +142,7 @@ USE_TORRENTS = None
 
 NZB_METHOD = None
 NZB_DIR = None
+PNEU_NZB_DIR = None
 USENET_RETENTION = None
 DOWNLOAD_PROPERS = None
 
@@ -305,7 +306,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
+                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, PNEU_NZB_DIR, DOWNLOAD_PROPERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
@@ -450,6 +451,7 @@ def initialize(consoleLogging=True):
             SEARCH_FREQUENCY = MIN_SEARCH_FREQUENCY
 
         NZB_DIR = check_setting_str(CFG, 'Blackhole', 'nzb_dir', '')
+        PNEU_NZB_DIR = check_setting_str(CFG, 'Blackhole', 'pneu_nzb_dir', '')
         TORRENT_DIR = check_setting_str(CFG, 'Blackhole', 'torrent_dir', '')
 
         TV_DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'tv_download_dir', '')
@@ -981,6 +983,7 @@ def save_config():
 
     new_config['Blackhole'] = {}
     new_config['Blackhole']['nzb_dir'] = NZB_DIR
+    new_config['Blackhole']['pneu_nzb_dir'] = PNEU_NZB_DIR
     new_config['Blackhole']['torrent_dir'] = TORRENT_DIR
 
     new_config['EZRSS'] = {}

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -438,7 +438,7 @@ def initialize(consoleLogging=True):
         USE_TORRENTS = bool(check_setting_int(CFG, 'General', 'use_torrents', 0))
 
         NZB_METHOD = check_setting_str(CFG, 'General', 'nzb_method', 'blackhole')
-        if NZB_METHOD not in ('blackhole', 'sabnzbd', 'nzbget'):
+        if NZB_METHOD not in ('blackhole', 'sabnzbd', 'nzbget', 'strm'):
             NZB_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
@@ -756,7 +756,7 @@ def start():
 
             # start the proper finder
             autoPostProcesserScheduler.thread.start()
-            
+
             started = True
 
 def halt ():

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -28,7 +28,7 @@ mediaExtensions = ['avi', 'mkv', 'mpg', 'mpeg', 'wmv',
                    'ogm', 'mp4', 'iso', 'img', 'divx',
                    'm2ts', 'm4v', 'ts', 'flv', 'f4v',
                    'mov', 'rmvb', 'vob', 'dvr-ms', 'wtv',
-                   'ogv', '3gp']
+                   'ogv', '3gp', 'strm']
 
 ### Other constants
 MULTI_EP_RESULT = -1

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -105,6 +105,11 @@ def change_NZB_DIR(nzb_dir):
 
     return True
 
+def change_PNEU_NZB_DIR(nzb_dir):
+
+    sickbeard.PNEU_NZB_DIR = nzb_dir
+
+    return True
 
 def change_TORRENT_DIR(torrent_dir):
 

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -24,6 +24,7 @@ import shutil
 import sickbeard 
 from sickbeard import postProcessor
 from sickbeard import db, helpers, exceptions
+from sickbeard import strm
 
 from sickbeard import encodingKludge as ek
 from sickbeard.exceptions import ex
@@ -82,6 +83,15 @@ def processDir (dirName, nzbName=None, recurse=False):
             return returnStr
 
     fileList = ek.ek(os.listdir, dirName)
+    
+    # create strm and move .nzb files
+    if sickbeard.NZB_METHOD == "strm":
+        for file in fileList:
+            if os.path.splitext(file)[1] == ".nzb":
+                strm_files = strm.NZBtoSTRM(file)
+                if strm_files:
+                    helpers.moveFile(ek.ek(os.path.join, dirName, file), ek.ek(os.path.join, sickbeard.NZB_DIR, file))
+                    fileList.extend(strm_files)
 
     # split the list into video files and folders
     folders = filter(lambda x: ek.ek(os.path.isdir, ek.ek(os.path.join, dirName, x)), fileList)

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -112,10 +112,7 @@ def snatchEpisode(result, endStatus=SNATCHED):
         elif sickbeard.NZB_METHOD == "nzbget":
             dlResult = nzbget.sendNZB(result)
         elif sickbeard.NZB_METHOD == "strm":
-            dlResultSTRM = strm.saveSTRM(result)
-            dlResultNZB = _downloadResult(result)
-            if (dlResultSTRM and dlResultNZB) == True:
-                dlResult = True
+            dlResult = strm.saveSTRM(result)
         else:
             logger.log(u"Unknown NZB action specified in config: " + sickbeard.NZB_METHOD, logger.ERROR)
             dlResult = False

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -112,7 +112,10 @@ def snatchEpisode(result, endStatus=SNATCHED):
         elif sickbeard.NZB_METHOD == "nzbget":
             dlResult = nzbget.sendNZB(result)
         elif sickbeard.NZB_METHOD == "strm":
-            dlResult = strm.saveSTRM(result)
+            dlResultSTRM = strm.saveSTRM(result)
+            dlResultNZB = _downloadResult(result)
+            if (dlResultSTRM and dlResultNZB) == True:
+                dlResult = True
         else:
             logger.log(u"Unknown NZB action specified in config: " + sickbeard.NZB_METHOD, logger.ERROR)
             dlResult = False

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -28,6 +28,7 @@ from common import SNATCHED, Quality, SEASON_RESULT, MULTI_EP_RESULT
 from sickbeard import logger, db, show_name_helpers, exceptions, helpers
 from sickbeard import sab
 from sickbeard import nzbget
+from sickbeard import strm
 from sickbeard import history
 from sickbeard import notifiers
 from sickbeard import nzbSplitter
@@ -110,6 +111,8 @@ def snatchEpisode(result, endStatus=SNATCHED):
             dlResult = sab.sendNZB(result)
         elif sickbeard.NZB_METHOD == "nzbget":
             dlResult = nzbget.sendNZB(result)
+        elif sickbeard.NZB_METHOD == "strm":
+            dlResult = strm.saveSTRM(result)
         else:
             logger.log(u"Unknown NZB action specified in config: " + sickbeard.NZB_METHOD, logger.ERROR)
             dlResult = False

--- a/sickbeard/strm.py
+++ b/sickbeard/strm.py
@@ -1,0 +1,67 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+import os
+
+import sickbeard
+
+import urllib
+
+from sickbeard import logger, helpers, ui
+
+from sickbeard.exceptions import ex
+
+from sickbeard import encodingKludge as ek
+
+def saveSTRM(nzb):
+
+    newResult = False
+
+    nzbProvider = nzb.provider
+
+    if sickbeard.TV_DOWNLOAD_DIR == None:
+        logger.log(u"No TV downloader directory found in configuration. Please configure it.", logger.ERROR)
+        return False
+
+    fileContents = "plugin://plugin.program.pneumatic/?mode=strm&nzb=" + urllib.quote_plus(nzb.url) + "&nzbname=" + nzb.name
+
+    # get the final file path to the strm file
+    destinationPath = ek.ek(os.path.join, sickbeard.TV_DOWNLOAD_DIR, nzb.name)
+    helpers.makeDir(destinationPath)
+    fileName = ek.ek(os.path.join, destinationPath, nzb.name + ".strm")
+
+    logger.log(u"Saving STRM to " + fileName)
+
+    newResult = True
+
+    # save the data to disk
+    try:
+        fileOut = open(fileName, "w")
+        fileOut.write(fileContents)
+        fileOut.close()
+        helpers.chmodAsParent(fileName)
+    except IOError, e:
+        logger.log(u"Error trying to save STRM to TV downloader directory: "+ex(e), logger.ERROR)
+        newResult = False
+
+    if newResult:
+        ui.notifications.message('Episode snatched','<b>%s</b> snatched from <b>%s</b>' % (nzb.name, nzbProvider.name))
+
+    return newResult

--- a/sickbeard/strm.py
+++ b/sickbeard/strm.py
@@ -206,3 +206,11 @@ def saveSTRM(nzb):
             ui.notifications.message('Episode snatched','<b>%s</b> snatched from <b>%s</b>' % (nzb.name, nzbProvider.name))
 
     return newResult
+    
+def NZBtoSTRM(file):
+
+    nzbName = os.path.splitext(file)[0]
+    fileContents = "plugin://plugin.program.pneumatic/?mode=strm&type=add_file&nzb=" + sickbeard.PNEU_NZB_DIR + nzbName + ".nzb" + "&nzbname=" + nzbName
+    strmFile = _commitSTRM(nzbName, fileContents)
+    if strmFile:
+        return nzbName

--- a/sickbeard/strm.py
+++ b/sickbeard/strm.py
@@ -22,13 +22,143 @@ import os
 
 import sickbeard
 
-import urllib
+import urllib2
 
-from sickbeard import logger, helpers, ui, nzbSplitter
+import re
+
+import xml.etree.cElementTree as etree
+
+from name_parser.parser import NameParser, InvalidNameException
+
+from sickbeard import logger, helpers, ui, nzbSplitter, classes
 
 from sickbeard.exceptions import ex
 
 from sickbeard import encodingKludge as ek
+
+def _getSeasonNZBs(name, urlData, season, showName):
+
+    try:
+        showXML = etree.ElementTree(etree.XML(urlData))
+    except SyntaxError:
+        logger.log(u"Unable to parse the XML of "+name+", not splitting it", logger.ERROR)
+        return ({},'')
+
+    filename = name.replace(".nzb", "")
+
+    nzbElement = showXML.getroot()
+
+    #regex = '([\w\._\ ]+)[\. ]S%02d[\. ]([\w\._\-\ ]+)[\- ]([\w_\-\ ]+?)' % season
+
+    #sceneNameMatch = re.search(regex, filename, re.I)
+    #if sceneNameMatch:
+    #    showName, qualitySection, groupName = sceneNameMatch.groups() #@UnusedVariable
+    #else:
+    #    logger.log(u"Unable to parse "+name+" into a scene name. If it's a valid one log a bug.", logger.ERROR)
+    #    return ({},'')
+
+    epFiles = {}
+    xmlns = None
+
+    regex1 = '(' + re.escape(showName) + '\.S%02d(?:[E0-9]+)\.[\w\._]+\-\w+' % season + ')'
+    regex2 = '(' + re.escape(showName) + '\.%dx(?:[0-9]+)\.[\w\._]+\-\w+' % season + ')'
+    regex3 = '(' + re.escape(showName) + '\.%d(?:[0-9]+)' % season + ')'
+    regex1 = regex1.replace(' ', '.')
+    regex2 = regex2.replace(' ', '.')
+    regex3 = regex3.replace(' ', '.')
+
+    for curFile in nzbElement.getchildren():
+        xmlnsMatch = re.match("\{(http:\/\/[A-Za-z0-9_\.\/]+\/nzb)\}file", curFile.tag)
+        if not xmlnsMatch:
+            continue
+        else:
+            xmlns = xmlnsMatch.group(1)
+        tempFile = curFile.get("subject")
+        tempFile = tempFile.replace(' ', '.')
+        match = re.search(regex1, tempFile, re.I)
+        if not match:
+            match = re.search(regex2, tempFile, re.I)
+            if not match:
+                match = re.search(regex3, tempFile, re.I)
+                if not match:
+                    #print curFile.get("subject"), "doesn't match", regex
+                    continue
+        curEp = match.group(1)
+        if curEp not in epFiles:
+            epFiles[curEp] = [curFile]
+        else:
+            epFiles[curEp].append(curFile)
+
+    return (epFiles, xmlns)
+
+def _splitResult(result):
+
+    try:
+        urlData = helpers.getURL(result.url)
+    except urllib2.URLError:
+        logger.log(u"Unable to load url "+result.url+", can't download season NZB", logger.ERROR)
+        return False
+
+    # parse the season ep name
+    try:
+        np = NameParser(False)
+        parse_result = np.parse(result.name)
+    except InvalidNameException:
+        logger.log(u"Unable to parse the filename "+result.name+" into a valid episode", logger.WARNING)
+        return False
+
+    # bust it up
+    season = parse_result.season_number if parse_result.season_number != None else 1
+
+    separateNZBs, xmlns = _getSeasonNZBs(result.name, urlData, season, parse_result.series_name)
+
+    resultList = []
+
+    if len(separateNZBs) > 1:
+        for newNZB in separateNZBs:
+
+            logger.log(u"Split out "+newNZB+" from "+result.name, logger.DEBUG)
+
+            # parse the name
+            try:
+                np = NameParser(False)
+                parse_result = np.parse(newNZB)
+            except InvalidNameException:
+                logger.log(u"Unable to parse the filename "+newNZB+" into a valid episode", logger.WARNING)
+                return False
+
+            # make sure the result is sane
+            if (parse_result.season_number != None and parse_result.season_number != season) or (parse_result.season_number == None and season != 1):
+                logger.log(u"Found "+newNZB+" inside "+result.name+" but it doesn't seem to belong to the same season, ignoring it", logger.WARNING)
+                continue
+            elif len(parse_result.episode_numbers) == 0:
+                logger.log(u"Found "+newNZB+" inside "+result.name+" but it doesn't seem to be a valid episode NZB, ignoring it", logger.WARNING)
+                continue
+
+            wantEp = True
+            for epNo in parse_result.episode_numbers:
+                if not result.extraInfo[0].wantEpisode(season, epNo, result.quality):
+                    logger.log(u"Ignoring result "+newNZB+" because we don't want an episode that is "+Quality.qualityStrings[result.quality], logger.DEBUG)
+                    wantEp = False
+                    break
+            if not wantEp:
+                continue
+
+            # get all the associated episode objects
+            epObjList = []
+            for curEp in parse_result.episode_numbers:
+                epObjList.append(result.extraInfo[0].getEpisode(season, curEp))
+
+            # make a result
+            curResult = classes.NZBDataSearchResult(epObjList)
+            curResult.name = newNZB
+            curResult.provider = result.provider
+            curResult.quality = result.quality
+            curResult.extraInfo = [nzbSplitter.createNZBString(separateNZBs[newNZB], xmlns)]
+
+            resultList.append(curResult)
+
+    return resultList
 
 def _commitSTRM(strmName, strmContents):
     # get the final file path to the strm file
@@ -57,20 +187,22 @@ def saveSTRM(nzb):
 
     newResult = False
 
-    episodeList = nzbSplitter.splitResult(nzb)
-    if len(episodeList) > 0:
+    episodeList = _splitResult(nzb)
+    if len(episodeList) > 1:
         for episode in episodeList:
             sickbeard.search._downloadResult(episode)
-            fileContents = "plugin://plugin.program.pneumatic/?mode=strm&type=add_local&nzb=" + urllib.quote_plus(nzb.url) + "&nzbname=" + episode.name
+            fileContents = "plugin://plugin.program.pneumatic/?mode=strm&type=add_file&nzb=" + sickbeard.PNEU_NZB_DIR + episode.name + ".nzb" + "&nzbname=" + episode.name
             newResult = _commitSTRM(episode.name, fileContents)
+            nzbProvider = nzb.provider
+            if newResult:
+                ui.notifications.message('Episode snatched','<b>%s</b> snatched from <b>%s</b>' % (nzb.name, nzbProvider.name))
+                newResult = False
     else:
-        fileContents = "plugin://plugin.program.pneumatic/?mode=strm&type=add_local&nzb=" + urllib.quote_plus(nzb.url) + "&nzbname=" + nzb.name
+        fileContents = "plugin://plugin.program.pneumatic/?mode=strm&type=add_file&nzb=" + sickbeard.PNEU_NZB_DIR + nzb.name + ".nzb" + "&nzbname=" + nzb.name
         sickbeard.search._downloadResult(nzb)
         newResult = _commitSTRM(nzb.name, fileContents)
-
-    nzbProvider = nzb.provider
-
-    if newResult:
-        ui.notifications.message('Episode snatched','<b>%s</b> snatched from <b>%s</b>' % (nzb.name, nzbProvider.name))
+        nzbProvider = nzb.provider
+        if newResult:
+            ui.notifications.message('Episode snatched','<b>%s</b> snatched from <b>%s</b>' % (nzb.name, nzbProvider.name))
 
     return newResult

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -762,7 +762,7 @@ class ConfigSearch:
         return _munge(t)
 
     @cherrypy.expose
-    def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
+    def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, pneu_nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
                        torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None):
 
@@ -773,6 +773,8 @@ class ConfigSearch:
 
         if not config.change_TORRENT_DIR(torrent_dir):
             results += ["Unable to create directory " + os.path.normpath(torrent_dir) + ", dir not changed."]
+
+        config.change_PNEU_NZB_DIR(pneu_nzb_dir)
 
         config.change_SEARCH_FREQUENCY(search_frequency)
 


### PR DESCRIPTION
This allows having .strm file support for use in XBMC using the Pneumatic addon.  This will download the .nzb file to the directory you specify.  It will then post process (according to your settings) the .nzb by creating a .strm file pointing to the location of the .nzb downloaded.  This will allow XBMC to stream the episodes... allowing you to save space!  This would be especially useful for [Raspberry Pi](http://wiki.xbmc.org/index.php?title=Raspberry_Pi/FAQ) users, AppleTV users, and really anyone looking to save disk space.

Note:  I did not do the programming here, it was originally done by user Doonga some time ago.  I just got it up to date and submitted the pull request.

This pull request is a rebase of my earlier pull request #519.

[Pneumatic](http://forum.xbmc.org/showthread.php?tid=97657) @ XBMC Forums
[Pneumatic - Strm file support for Sickbeard](http://forum.xbmc.org/showthread.php?tid=97657&pid=1060531#pid1060531) @ XBMC Forums (post by forum member tpunder aka Doonga)
[My post on setting up this fork of Sick-Beard with Pneumatic](http://forum.xbmc.org/showthread.php?tid=97657&pid=1214376#pid1214376)
[Doonga's original fork and his work](https://github.com/Doonga/Sick-Beard/tree/xbmc_strm_file_support)
