### PR TITLE
Notifiers: XBMC / Plex - cleanup and update

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -26,6 +26,7 @@
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/xbmc.png" alt="" title="XBMC" />
                         <h3><a href="http://xbmc.org/" onclick="window.open(this.href, '_blank'); return false;">XBMC</a></h3>
                         <p>A free and open source cross-platform media center and home entertainment system software with a 10-foot user interface designed for the living-room TV.</p>
+                        <p>For SickBeard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" onclick="window.open(this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
@@ -55,14 +56,14 @@
                                 <input type="checkbox" name="xbmc_update_library" id="xbmc_update_library" #if $sickbeard.XBMC_UPDATE_LIBRARY then "checked=\"checked\"" else ""# />
                                 <label class="clearfix" for="xbmc_update_library">
                                     <span class="component-title">Update Library</span>
-                                    <span class="component-desc">Update XBMC library when we finish a download?</span>
+                                    <span class="component-desc">Update library (show's path) when we finish a download?</span>
                                 </label>
                             </div>
                             <div class="field-pair">
                                 <input type="checkbox" name="xbmc_update_full" id="xbmc_update_full" #if $sickbeard.XBMC_UPDATE_FULL then "checked=\"checked\"" else ""# />
                                 <label class="clearfix" for="xbmc_update_full">
                                     <span class="component-title">Full Library Update</span>
-                                    <span class="component-desc">Do a full library update if per-show fails?</span>
+                                    <span class="component-desc">Fall back to a full library update if per-show fails?</span>
                                 </label>
                             </div>
                             <div class="field-pair">
@@ -76,7 +77,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">(multiple host strings can be separated by commas)</span>
+                                    <span class="component-desc">(multiple host strings must be separated by commas, <br/> the library updates will only be sent to the first host listed)</span>
                                 </label>
                             </div>
                             <div class="field-pair">
@@ -164,6 +165,10 @@
                                     <span class="component-title">&nbsp;</span>
                                     <span class="component-desc">Host running Plex Client (eg. 192.168.1.100:3000)</span>
                                 </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">(multiple host strings must be separated by commas)</span>
+                                </label>
                             </div>
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
@@ -186,7 +191,7 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testPLEX-result">Click below to test.</div>
-                            <input type="button" class="btn" value="Test Plex Media Server" id="testPLEX" />
+                            <input type="button" class="btn" value="Test Plex Media Clients" id="testPLEX" />
                             <input type="submit" class="btn config_submitter" value="Save Changes" />
                         </div><!-- /content_use_plex -->
 
@@ -458,7 +463,7 @@
                             </div>
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
-                                    <span class="component-title">Prowl priority:</span>
+                                    <span class="component-title">Prowl Priority:</span>
                                    <select id="prowl_priority" name="prowl_priority">
                                         <option value="-2" #if $sickbeard.PROWL_PRIORITY == "-2" then 'selected="selected"' else ""#>Very Low</option>
                                         <option value="-1" #if $sickbeard.PROWL_PRIORITY == "-1" then 'selected="selected"' else ""#>Moderate</option>
@@ -611,7 +616,7 @@
                             </div>
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
-                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-title">Pushover User Key</span>
                                     <input type="text" name="pushover_userkey" id="pushover_userkey" value="$sickbeard.PUSHOVER_USERKEY" size="35" />
                                 </label>
                                 <label class="nocheck clearfix">
@@ -713,7 +718,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Multiple keys must be seperated by a , (comma). Up to a maximum of 5</span>
+                                    <span class="component-desc">Multiple keys (maxium of 5) must be seperated by commas</span>
                                 </label>
                             </div>
                             <div class="field-pair">

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -20,61 +20,64 @@ import sickbeard
 
 import xbmc
 import plex
-import growl
-import prowl
-import tweet
-from . import libnotify
-import notifo
-import boxcar
-import pushover
 import nmj
 import synoindex
-import trakt
 import pytivo
+
+import growl
+import prowl
+import notifo
+from . import libnotify
+import pushover
+import boxcar
 import nma
+
+import tweet
+import trakt
 
 from sickbeard.common import *
 
+# home theater
 xbmc_notifier = xbmc.XBMCNotifier()
 plex_notifier = plex.PLEXNotifier()
-growl_notifier = growl.GrowlNotifier()
-prowl_notifier = prowl.ProwlNotifier()
-twitter_notifier = tweet.TwitterNotifier()
-notifo_notifier = notifo.NotifoNotifier()
-boxcar_notifier = boxcar.BoxcarNotifier()
-pushover_notifier = pushover.PushoverNotifier()
-libnotify_notifier = libnotify.LibnotifyNotifier()
 nmj_notifier = nmj.NMJNotifier()
 synoindex_notifier = synoindex.synoIndexNotifier()
-trakt_notifier = trakt.TraktNotifier()
 pytivo_notifier = pytivo.pyTivoNotifier()
+# devices
+growl_notifier = growl.GrowlNotifier()
+prowl_notifier = prowl.ProwlNotifier()
+notifo_notifier = notifo.NotifoNotifier()
+libnotify_notifier = libnotify.LibnotifyNotifier()
+pushover_notifier = pushover.PushoverNotifier()
+boxcar_notifier = boxcar.BoxcarNotifier()
 nma_notifier = nma.NMA_Notifier()
+# online
+twitter_notifier = tweet.TwitterNotifier()
+trakt_notifier = trakt.TraktNotifier()
 
 notifiers = [
-    # Libnotify notifier goes first because it doesn't involve blocking on
-    # network activity.
-    libnotify_notifier,
+    libnotify_notifier, # Libnotify notifier goes first because it doesn't involve blocking on network activity.
     xbmc_notifier,
     plex_notifier,
-    growl_notifier,
-    prowl_notifier,
-    twitter_notifier,
     nmj_notifier,
     synoindex_notifier,
-    boxcar_notifier,
-    pushover_notifier,
-    trakt_notifier,
     pytivo_notifier,
+    growl_notifier,
+    prowl_notifier,
+    notifo_notifier,
+    pushover_notifier,
+    boxcar_notifier,
     nma_notifier,
+    twitter_notifier,
+    trakt_notifier,
 ]
+
 
 def notify_download(ep_name):
     for n in notifiers:
         n.notify_download(ep_name)
-    notifo_notifier.notify_download(ep_name)
+
 
 def notify_snatch(ep_name):
     for n in notifiers:
         n.notify_snatch(ep_name)
-    notifo_notifier.notify_snatch(ep_name)
-

--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -88,7 +88,8 @@ class NMJNotifier:
         #Not implemented: Start the scanner when snatched does not make any sense
 
     def notify_download(self, ep_name):
-        self._notifyNMJ()
+        if sickbeard.USE_NMJ:
+            self._notifyNMJ()
 
     def test_notify(self, host, database, mount):
         return self._sendNMJ(host, database, mount)

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -17,76 +17,172 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib
+import urllib2
+import base64
+
 import sickbeard
 
-from sickbeard import logger, common
-from sickbeard.notifiers.xbmc import XBMCNotifier 
+from sickbeard import logger
+from sickbeard import common
 from sickbeard.exceptions import ex
+from sickbeard.encodingKludge import fixStupidEncodings
 
+# TODO: switch over to using ElementTree
 from xml.dom import minidom
 
-class PLEXNotifier(XBMCNotifier):
+
+class PLEXNotifier:
+
+    def _send_to_plex(self, command, host, username=None, password=None):
+        """Handles communication to Plex hosts via HTTP API
+
+        Args:
+            command: Dictionary of field/data pairs, encoded via urllib and passed to the legacy xbmcCmds HTTP API
+            host: Plex host:port
+            username: Plex API username
+            password: Plex API password
+
+        Returns:
+            Returns 'OK' for successful commands or False if there was an error
+
+        """
+
+        # fill in omitted parameters
+        if not username:
+            username = sickbeard.PLEX_USERNAME
+        if not password:
+            password = sickbeard.PLEX_PASSWORD
+
+        if not host:
+            logger.log(u"No Plex host specified, check your settings", logger.DEBUG)
+            return False
+
+        for key in command:
+            if type(command[key]) == unicode:
+                command[key] = command[key].encode('utf-8')
+
+        enc_command = urllib.urlencode(command)
+        logger.log(u"Plex encoded API command: " + enc_command, logger.DEBUG)
+
+        url = 'http://%s/xbmcCmds/xbmcHttp/?%s' % (host, enc_command)
+        try:
+            req = urllib2.Request(url)
+            # if we have a password, use authentication
+            if password:
+                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
+                authheader = "Basic %s" % base64string
+                req.add_header("Authorization", authheader)
+                logger.log(u"Contacting Plex (with auth header) via url: " + url, logger.DEBUG)
+            else:
+                logger.log(u"Contacting Plex via url: " + url, logger.DEBUG)
+
+            response = urllib2.urlopen(req)
+
+            result = response.read().decode(sickbeard.SYS_ENCODING)
+            response.close()
+
+            logger.log(u"Plex HTTP response: " + result.replace('\n', ''), logger.DEBUG)
+            # could return result response = re.compile('<html><li>(.+\w)</html>').findall(result)
+            return 'OK'
+
+        except (urllib2.URLError, IOError), e:
+            logger.log(u"Warning: Couldn't contact Plex at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
+            return False
+
+    def _notify_pmc(self, message, title="Sick Beard", host=None, username=None, password=None, force=False):
+        """Internal wrapper for the notify_snatch and notify_download functions
+
+        Args:
+            message: Message body of the notice to send
+            title: Title of the notice to send
+            host: Plex Media Client(s) host:port
+            username: Plex username
+            password: Plex password
+            force: Used for the Test method to override config saftey checks
+
+        Returns:
+            Returns a list results in the format of host:ip:result
+            The result will either be 'OK' or False, this is used to be parsed by the calling function.
+
+        """
+
+        # fill in omitted parameters
+        if not host:
+            host = sickbeard.PLEX_HOST
+        if not username:
+            username = sickbeard.PLEX_USERNAME
+        if not password:
+            password = sickbeard.PLEX_PASSWORD
+
+        # suppress notifications if the notifier is disabled but the notify options are checked
+        if not sickbeard.USE_PLEX and not force:
+            logger.log("Notification for Plex not enabled, skipping this notification", logger.DEBUG)
+            return False
+
+        result = ''
+        for curHost in [x.strip() for x in host.split(",")]:
+            logger.log(u"Sending Plex notification to '" + curHost + "' - " + message, logger.MESSAGE)
+
+            command = {'command': 'ExecBuiltIn', 'parameter': 'Notification(' + title.encode("utf-8") + ',' + message.encode("utf-8") + ')'}
+            notifyResult = self._send_to_plex(command, curHost, username, password)
+            if notifyResult:
+                result += curHost + ':' + str(notifyResult)
+
+        return result
+
+##############################################################################
+# Public functions
+##############################################################################
 
     def notify_snatch(self, ep_name):
         if sickbeard.PLEX_NOTIFY_ONSNATCH:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+            self._notify_pmc(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
 
     def notify_download(self, ep_name):
         if sickbeard.PLEX_NOTIFY_ONDOWNLOAD:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            self._notify_pmc(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def test_notify(self, host, username, password):
-        return self._update_library() 
-        
+        return self._notify_pmc("Testing Plex notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+
     def update_library(self):
-        if sickbeard.PLEX_UPDATE_LIBRARY:
-            self._update_library()
+        """Handles updating the Plex Media Server host via HTTP API
 
-    def _username(self):
-        return sickbeard.PLEX_USERNAME
+        Plex Media Server currently only supports updating the whole video library and not a specific path.
 
-    def _password(self):
-        return sickbeard.PLEX_PASSWORD
+        Returns:
+            Returns True or False
 
-    def _use_me(self):
-        return sickbeard.USE_PLEX
+        """
 
-    def _hostname(self):
-        return sickbeard.PLEX_HOST
+        if sickbeard.USE_PLEX and sickbeard.PLEX_UPDATE_LIBRARY:
+            if not sickbeard.PLEX_SERVER_HOST:
+                logger.log(u"No Plex Server host specified, check your settings", logger.DEBUG)
+                return False
 
+            logger.log(u"Updating library for the Plex Media Server host: " + sickbeard.PLEX_SERVER_HOST, logger.MESSAGE)
 
-    def _update_library(self):
-        if not sickbeard.USE_PLEX:
-            logger.log(u"Notifications for Plex Media Server not enabled, skipping library update", logger.DEBUG)
-            return False
+            url = "http://%s/library/sections" % sickbeard.PLEX_SERVER_HOST
+            try:
+                xml_sections = minidom.parse(urllib.urlopen(url))
+            except IOError, e:
+                logger.log(u"Error while trying to contact Plex Media Server: " + ex(e), logger.ERROR)
+                return False
 
-        logger.log(u"Updating Plex Media Server library", logger.DEBUG)
+            sections = xml_sections.getElementsByTagName('Directory')
+            if not sections:
+                logger.log(u"Plex Media Server not running on: " + sickbeard.PLEX_SERVER_HOST, logger.MESSAGE)
+                return False
 
-        if not sickbeard.PLEX_SERVER_HOST:
-            logger.log(u"No host specified, no updates done", logger.DEBUG)
-            return False
+            for s in sections:
+                if s.getAttribute('type') == "show":
+                    url = "http://%s/library/sections/%s/refresh" % (sickbeard.PLEX_SERVER_HOST, s.getAttribute('key'))
+                    try:
+                        urllib.urlopen(url)
+                    except Exception, e:
+                        logger.log(u"Error updating library section for Plex Media Server: " + ex(e), logger.ERROR)
+                        return False
 
-        logger.log(u"Plex Media Server updating " + sickbeard.PLEX_SERVER_HOST, logger.DEBUG)
-
-        url = "http://%s/library/sections" % sickbeard.PLEX_SERVER_HOST
-        try:
-            xml_sections = minidom.parse(urllib.urlopen(url))
-        except IOError, e:
-            logger.log(u"Error while trying to contact your plex server: "+ex(e), logger.ERROR)
-            return False
-
-        sections = xml_sections.getElementsByTagName('Directory')
-
-        for s in sections:
-            if s.getAttribute('type') == "show":
-                url = "http://%s/library/sections/%s/refresh" % (sickbeard.PLEX_SERVER_HOST, s.getAttribute('key'))
-
-                try:
-                    urllib.urlopen(url)
-                except Exception, e:
-                    logger.log(u"Error updating library section: "+ex(e), logger.ERROR)
-                    return False
-
-        return True
+            return True
 
 notifier = PLEXNotifier

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -34,55 +34,26 @@ try:
 except ImportError:
     import xml.etree.ElementTree as etree
 
-try:
-    import lib.simplejson as json
-except:
-    import json
-
 class XBMCNotifier:
-    
-    apiversion = 0
-    
+
     def notify_snatch(self, ep_name):
         if sickbeard.XBMC_NOTIFY_ONSNATCH:
-            if (self._jsonapiversion() <= 4):
-                logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
-                self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
-            else:
-                logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
-                self._notifyXBMC_json(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
 
     def notify_download(self, ep_name):
         if sickbeard.XBMC_NOTIFY_ONDOWNLOAD:
-            if (self._jsonapiversion() <= 4):
-                self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
-            else:
-                self._notifyXBMC_json(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def test_notify(self, host, username, password):
-        if (self._jsonapiversion() <= 4):
-            logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
-            return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
-        else:
-            logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
-            return self._notifyXBMC_json("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+        return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
 
-    def update_library(self, host, showName=None):
+    def update_library(self, show_name):
         if sickbeard.XBMC_UPDATE_LIBRARY:
-            if (self._jsonapiversion() <= 4):
-                if not self._update_library(host, showName) and sickbeard.XBMC_UPDATE_FULL:
+            for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
+                # do a per-show update first, if possible
+                if not self._update_library(curHost, showName=show_name) and sickbeard.XBMC_UPDATE_FULL:
                     # do a full update if requested
-                    return self._update_library(host)
-                else:
-                    return True
-
-            else:
-                if not self._update_library_json(host, showName) and sickbeard.XBMC_UPDATE_FULL:
-                    # do a full update if requested
-                    logger.log("Single show update failed, running full update", logger.ERROR)
-                    return self._update_library_json(host)
-                else:
-                    return True
+                    self._update_library(curHost)
 
     def _username(self):
         return sickbeard.XBMC_USERNAME
@@ -95,12 +66,6 @@ class XBMCNotifier:
 
     def _hostname(self):
         return sickbeard.XBMC_HOST
-    
-    def _jsonapiversion(self):
-        # buffer the api version, so we don't hammer the server with useless requests
-        if (self.apiversion == 0):
-            self.apiversion = self._checkJSON_version()
-        return self.apiversion
 
     def _sendToXBMC(self, command, host, username=None, password=None):
         '''
@@ -148,7 +113,7 @@ class XBMCNotifier:
     def _notifyXBMC(self, input, title="Sick Beard", host=None, username=None, password=None, force=False):
     
         if not self._use_me() and not force:
-            logger.log(u"Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
+            logger.log("Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
             return False
     
         if not host:
@@ -174,15 +139,15 @@ class XBMCNotifier:
         return result
 
     def _update_library(self, host, showName=None):
-        
+    
         if not self._use_me():
-            logger.log(u"Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
+            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
             return False
     
         logger.log(u"Updating library in XBMC", logger.DEBUG)
     
         if not host:
-            logger.log(u'No host specified, no updates done', logger.DEBUG)
+            logger.log('No host specified, no updates done', logger.DEBUG)
             return False
     
         # if we're doing per-show
@@ -247,161 +212,6 @@ class XBMCNotifier:
                 return False
     
         return True
-
-    def _checkJSON_version(self):
-        '''
-        returns XBMC JSONRPC Api version
-        4 = Xbmc Eden(11), 5 = Xbmc Frodo(12)
-        '''
-        host = self._hostname()
-        username = self._username()
-        password = self._password()
-            
-        checkCommand = '{"id":1,"jsonrpc":"2.0","method":"JSONRPC.Version"}'
-        result = self._sendToXBMC_json(checkCommand, host, username, password)
-        if result:
-            return result["result"]["version"]
-        else:
-            return False
-        
-    def _sendToXBMC_json(self, command, host, username=None, password=None):
-        '''
-        Handles communication with XBMC servers via JSONRPC 
-    
-        command - JSON request passed to http://host/jsonrpc
-        returns: dict or False on error
-    
-        host - host/ip + port (foo:8080)
-        '''
-
-        if not username:
-            username = self._username()
-        if not password:
-            password = self._password()
-    
-        command = command.encode('utf-8')
-        logger.log(u"Command is " + command, logger.DEBUG)
-        url = 'http://%s/jsonrpc' % (host)
-                    
-        try:
-            req = urllib2.Request(url, command)
-            req.add_header("Content-type", "application/json")
-            # If we have a password, use authentication
-            if password:
-                logger.log(u"Adding Password to XBMC url", logger.DEBUG)
-                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
-                authheader =  "Basic %s" % base64string
-                req.add_header("Authorization", authheader)
-    
-            logger.log(u"Contacting XBMC via url: " + url, logger.DEBUG)
-            response = urllib2.urlopen(req)
-            
-        except IOError, e:
-            logger.log(u"Warning: Couldn't contact XBMC JSON api at " + fixStupidEncodings(url) + ": " + ex(e), logger.ERROR)
-            return False
-
-        # Parse the json result
-        try:
-            result = json.load(response)
-            response.close()
-            logger.log(u"response: " + str(result), logger.DEBUG)
-            return result
-        
-        except ValueError, e:
-            logger.log(u"Unable to decode JSON: "+response, logger.ERROR)
-            return False
-        
-     
-    def _notifyXBMC_json(self, msg, title="Sick Beard", host=None, username=None, password=None, force=False):
-    
-        if not self._use_me() and not force:
-            logger.log(u"Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
-            return False
-    
-        if not host:
-            host = self._hostname()
-        if not username:
-            username = self._username()
-        if not password:
-            password = self._password()
-    
-        logger.log(u"Sending notification for " + msg, logger.DEBUG)
-    
-        result = ''
-        for curHost in [x.strip() for x in host.split(",")]:
-            command = '{"id":1,"jsonrpc":"2.0","method":"GUI.ShowNotification","params":{"title":"Sick Beard","message":"%s"}}' % msg
-            logger.log(u"Sending notification to XBMC via host: "+ curHost +" username: "+ username + " password: " + password, logger.DEBUG)
-            notifyResult = self._sendToXBMC_json(command, curHost, username, password)
-            if (notifyResult != False):
-                result += ', '+ curHost + ':' + notifyResult["result"].decode(sickbeard.SYS_ENCODING)
-        
-        return result
-
-    def _update_library_json(self, host, showName=None):
-        
-        username = self._username()
-        password = self._password()
-    
-        if not self._use_me():
-            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
-            return False
-    
-        logger.log(u"Updating library in XBMC", logger.DEBUG)
-    
-        if not host:
-            logger.log(u'No host specified, no updates done', logger.DEBUG)
-            return False
-    
-        # if we're doing per-show
-        if showName:
-            tvshowid = -1
-            
-            # get tvshowid by showName
-            showsCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows"}'
-            showsResponse = self._sendToXBMC_json(showsCommand, host)
-            if (showsResponse == False):
-                return False
-            shows = showsResponse["result"]["tvshows"] 
-            
-            for show in shows:
-                if (show["label"] == showName):
-                    tvshowid = show["tvshowid"]
-            if (tvshowid == -1):
-                # we didn't find the show, will trigger a full update if enabled
-                return False
-            
-            # this can be big, so free some memory
-            del shows
-            
-            # JSON to get the TV-Show path
-            pathCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.GetTVShowDetails","params":{"tvshowid":%d, "properties": ["file"]}}' % (tvshowid)
-            pathResponse = self._sendToXBMC_json(pathCommand, host)
-
-            path = pathResponse["result"]["tvshowdetails"]["file"]
-            logger.log(u"Received Show: " + show["label"] + " with ID: " + str(tvshowid) + " Path: " + path, logger.DEBUG)
-
-            if (len(path) < 1):
-                logger.log(u"No valid path found for " + showName + " with ID: " + str(tvshowid) + " on " + host, logger.ERROR)
-                return False
-
-            logger.log(u"XBMC Updating " + showName + " on " + host + " at " + path, logger.DEBUG)
-            updateCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":"%s"}}' % (path)
-            request = self._sendToXBMC_json(updateCommand, host)
-            if not request:
-                    logger.log(u"Update of show directory failed on " + showName + " on " + host + " at " + path, logger.ERROR)
-                    return False
-            
-        else:
-            logger.log(u"Do a full update as requested", logger.DEBUG)
-            logger.log(u"XBMC Updating " + host, logger.DEBUG)
-            updateCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.Scan"}'
-            request = self._sendToXBMC_json(updateCommand, host, username, password)
-            if not request:
-                logger.log(u"Full update failed on " + host, logger.ERROR)
-                return False
-    
-        return True
-
 
 # Wake function
 def wakeOnLan(ethernet_address):

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -327,7 +327,7 @@ class XBMCNotifier:
             try:
                 response = urllib2.urlopen(req)
             except urllib2.URLError, e:
-                logger.log(u"Error while trying to retrieve API version: " + ex(e), logger.WARNING)
+                logger.log(u"Error while trying to retrieve XBMC API version for " + host + ": " + ex(e), logger.WARNING)
                 return False
 
             # parse the json result

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -16,11 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-
-import urllib, urllib2
+import urllib
+import urllib2
 import socket
 import base64
-import time, struct
+import time
 
 import sickbeard
 
@@ -34,226 +34,460 @@ try:
 except ImportError:
     import xml.etree.ElementTree as etree
 
+try:
+    import json
+except ImportError:
+    from lib import simplejson as json
+
+
 class XBMCNotifier:
 
-    def notify_snatch(self, ep_name):
-        if sickbeard.XBMC_NOTIFY_ONSNATCH:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+    def _get_json_version(self, host, username, password):
+        """Returns XBMC JSON-RPC API version (odd # = dev, even # = stable)
 
-    def notify_download(self, ep_name):
-        if sickbeard.XBMC_NOTIFY_ONDOWNLOAD:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+        Sends a request to the XBMC host using the JSON-RPC to determine if
+        the legacy API or if the JSON-RPC API functions should be used.
 
-    def test_notify(self, host, username, password):
-        return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+        Args:
+            host: XBMC webserver host:port
+            username: XBMC webserver username
+            password: XBMC webserver password
 
-    def update_library(self, show_name):
-        if sickbeard.XBMC_UPDATE_LIBRARY:
-            for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-                # do a per-show update first, if possible
-                if not self._update_library(curHost, showName=show_name) and sickbeard.XBMC_UPDATE_FULL:
-                    # do a full update if requested
-                    self._update_library(curHost)
+        Returns:
+            Returns API number or False
 
-    def _username(self):
-        return sickbeard.XBMC_USERNAME
+            List of possible known values:
+                API | XBMC Version
+               -----+---------------
+                 2  | v10 (Dharma)
+                 3  | (pre Eden)
+                 4  | v11 (Eden)
+                 5  | (pre Frodo)
+                 6  | v12 (Frodo)
 
-    def _password(self):
-        return sickbeard.XBMC_PASSWORD
+        """
 
-    def _use_me(self):
-        return sickbeard.USE_XBMC
+        # since we need to maintain python 2.5 compatability we can not pass a timeout delay to urllib2 directly (python 2.6+)
+        # override socket timeout to reduce delay for this call alone
+        socket.setdefaulttimeout(10)
 
-    def _hostname(self):
-        return sickbeard.XBMC_HOST
+        checkCommand = '{"jsonrpc":"2.0","method":"JSONRPC.Version","id":1}'
+        result = self._send_to_xbmc_json(checkCommand, host, username, password)
 
-    def _sendToXBMC(self, command, host, username=None, password=None):
-        '''
-        Handles communication with XBMC servers
-    
-        command - Dictionary of field/data pairs, encoded via urllib.urlencode and
-        passed to /xbmcCmds/xbmcHttp
-    
-        host - host/ip + port (foo:8080)
-        '''
-    
+        # revert back to default socket timeout
+        socket.setdefaulttimeout(sickbeard.SOCKET_TIMEOUT)
+
+        if result:
+            return result["result"]["version"]
+        else:
+            return False
+
+    def _notify_xbmc(self, message, title="Sick Beard", host=None, username=None, password=None, force=False):
+        """Internal wrapper for the notify_snatch and notify_download functions
+
+        Detects JSON-RPC version then branches the logic for either the JSON-RPC or legacy HTTP API methods.
+
+        Args:
+            message: Message body of the notice to send
+            title: Title of the notice to send
+            host: XBMC webserver host:port
+            username: XBMC webserver username
+            password: XBMC webserver password
+            force: Used for the Test method to override config saftey checks
+
+        Returns:
+            Returns a list results in the format of host:ip:result
+            The result will either be 'OK' or False, this is used to be parsed by the calling function.
+
+        """
+
+        # fill in omitted parameters
+        if not host:
+            host = sickbeard.XBMC_HOST
         if not username:
-            username = self._username()
+            username = sickbeard.XBMC_USERNAME
         if not password:
-            password = self._password()
-    
-        for key in command:
-            if type(command[key]) == unicode:
-                command[key] = command[key].encode('utf-8')
-    
-        enc_command = urllib.urlencode(command)
-        logger.log(u"Encoded command is " + enc_command, logger.DEBUG)
-        # Web server doesn't like POST, GET is the way to go
-        url = 'http://%s/xbmcCmds/xbmcHttp/?%s' % (host, enc_command)
-    
-        try:
-            # If we have a password, use authentication
-            req = urllib2.Request(url)
-            if password:
-                logger.log(u"Adding Password to XBMC url", logger.DEBUG)
-                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
-                authheader =  "Basic %s" % base64string
-                req.add_header("Authorization", authheader)
-    
-            logger.log(u"Contacting XBMC via url: " + url, logger.DEBUG)
-            handle = urllib2.urlopen(req)
-            response = handle.read().decode(sickbeard.SYS_ENCODING)
-            logger.log(u"response: " + response, logger.DEBUG)
-        except IOError, e:
-            logger.log(u"Warning: Couldn't contact XBMC HTTP server at " + fixStupidEncodings(host) + ": " + ex(e))
-            response = ''
-    
-        return response
+            password = sickbeard.XBMC_PASSWORD
 
-    def _notifyXBMC(self, input, title="Sick Beard", host=None, username=None, password=None, force=False):
-    
-        if not self._use_me() and not force:
+        # suppress notifications if the notifier is disabled but the notify options are checked
+        if not sickbeard.USE_XBMC and not force:
             logger.log("Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
             return False
-    
-        if not host:
-            host = self._hostname()
-        if not username:
-            username = self._username()
-        if not password:
-            password = self._password()
-    
-        logger.log(u"Sending notification for " + input, logger.DEBUG)
-    
-        fileString = title + "," + input
-    
+
         result = ''
-    
         for curHost in [x.strip() for x in host.split(",")]:
-            command = {'command': 'ExecBuiltIn', 'parameter': 'Notification(' +fileString + ')' }
-            logger.log(u"Sending notification to XBMC via host: "+ curHost +"username: "+ username + " password: " + password, logger.DEBUG)
-            if result:
-                result += ', '
-            result += curHost + ':' + self._sendToXBMC(command, curHost, username, password)
+            logger.log(u"Sending XBMC notification to '" + curHost + "' - " + message, logger.MESSAGE)
+
+            xbmcapi = self._get_json_version(curHost, username, password)
+            if xbmcapi:
+                if (xbmcapi <= 4):
+                    logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
+                    command = {'command': 'ExecBuiltIn', 'parameter': 'Notification(' + title.encode("utf-8") + ',' + message.encode("utf-8") + ')'}
+                    notifyResult = self._send_to_xbmc(command, curHost, username, password)
+                    if notifyResult:
+                        result += curHost + ':' + str(notifyResult)
+                else:
+                    logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
+                    command = '{"jsonrpc":"2.0","method":"GUI.ShowNotification","params":{"title":"%s","message":"%s"},"id":1}' % (title.encode("utf-8"), message.encode("utf-8"))
+                    notifyResult = self._send_to_xbmc_json(command, curHost, username, password)
+                    if notifyResult:
+                        result += curHost + ':' + notifyResult["result"].decode(sickbeard.SYS_ENCODING)
+            else:
+                logger.log(u"Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.DEBUG)
 
         return result
 
-    def _update_library(self, host, showName=None):
-    
-        if not self._use_me():
-            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
-            return False
-    
-        logger.log(u"Updating library in XBMC", logger.DEBUG)
-    
+##############################################################################
+# Legacy HTTP API (pre XBMC 12) methods
+##############################################################################
+
+    def _send_to_xbmc(self, command, host=None, username=None, password=None):
+        """Handles communication to XBMC servers via HTTP API
+
+        Args:
+            command: Dictionary of field/data pairs, encoded via urllib and passed to the XBMC API via HTTP
+            host: XBMC webserver host:port
+            username: XBMC webserver username
+            password: XBMC webserver password
+
+        Returns:
+            Returns response.result for successful commands or False if there was an error
+
+        """
+
+        # fill in omitted parameters
+        if not username:
+            username = sickbeard.XBMC_USERNAME
+        if not password:
+            password = sickbeard.XBMC_PASSWORD
+
         if not host:
-            logger.log('No host specified, no updates done', logger.DEBUG)
+            logger.log(u'No XBMC host passed, aborting update', logger.DEBUG)
             return False
-    
+
+        for key in command:
+            if type(command[key]) == unicode:
+                command[key] = command[key].encode('utf-8')
+
+        enc_command = urllib.urlencode(command)
+        logger.log(u"XBMC encoded API command: " + enc_command, logger.DEBUG)
+
+        url = 'http://%s/xbmcCmds/xbmcHttp/?%s' % (host, enc_command)
+        try:
+            req = urllib2.Request(url)
+            # if we have a password, use authentication
+            if password:
+                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
+                authheader = "Basic %s" % base64string
+                req.add_header("Authorization", authheader)
+                logger.log(u"Contacting XBMC (with auth header) via url: " + fixStupidEncodings(url), logger.DEBUG)
+            else:
+                logger.log(u"Contacting XBMC via url: " + fixStupidEncodings(url), logger.DEBUG)
+
+            response = urllib2.urlopen(req)
+            result = response.read().decode(sickbeard.SYS_ENCODING)
+            response.close()
+
+            logger.log(u"XBMC HTTP response: " + result.replace('\n', ''), logger.DEBUG)
+            return result
+
+        except (urllib2.URLError, IOError), e:
+            logger.log(u"Warning: Couldn't contact XBMC HTTP at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
+            return False
+
+    def _update_library(self, host=None, showName=None):
+        """Handles updating XBMC host via HTTP API
+
+        Attempts to update the XBMC video library for a specific tv show if passed,
+        otherwise update the whole library if enabled.
+
+        Args:
+            host: XBMC webserver host:port
+            showName: Name of a TV show to specifically target the library update for
+
+        Returns:
+            Returns True or False
+
+        """
+
+        if not host:
+            logger.log(u'No XBMC host passed, aborting update', logger.DEBUG)
+            return False
+
+        logger.log(u"Updating XMBC library via HTTP method for host: " + host, logger.DEBUG)
+
         # if we're doing per-show
         if showName:
+            logger.log(u"Updating library in XBMC via HTTP method for show " + showName, logger.DEBUG)
+
             pathSql = 'select path.strPath from path, tvshow, tvshowlinkpath where ' \
                 'tvshow.c00 = "%s" and tvshowlinkpath.idShow = tvshow.idShow ' \
                 'and tvshowlinkpath.idPath = path.idPath' % (showName)
-    
-            # Use this to get xml back for the path lookups
+
+            # use this to get xml back for the path lookups
             xmlCommand = {'command': 'SetResponseFormat(webheader;false;webfooter;false;header;<xml>;footer;</xml>;opentag;<tag>;closetag;</tag>;closefinaltag;false)'}
-            # Sql used to grab path(s)
+            # sql used to grab path(s)
             sqlCommand = {'command': 'QueryVideoDatabase(%s)' % (pathSql)}
-            # Set output back to default
+            # set output back to default
             resetCommand = {'command': 'SetResponseFormat()'}
-    
-            # Set xml response format, if this fails then don't bother with the rest
-            request = self._sendToXBMC(xmlCommand, host)
+
+            # set xml response format, if this fails then don't bother with the rest
+            request = self._send_to_xbmc(xmlCommand, host)
             if not request:
                 return False
-    
-            sqlXML = self._sendToXBMC(sqlCommand, host)
-            request = self._sendToXBMC(resetCommand, host)
-    
+
+            sqlXML = self._send_to_xbmc(sqlCommand, host)
+            request = self._send_to_xbmc(resetCommand, host)
+
             if not sqlXML:
                 logger.log(u"Invalid response for " + showName + " on " + host, logger.DEBUG)
                 return False
-    
-            encSqlXML = urllib.quote(sqlXML,':\\/<>')
+
+            encSqlXML = urllib.quote(sqlXML, ':\\/<>')
             try:
                 et = etree.fromstring(encSqlXML)
             except SyntaxError, e:
-                logger.log("Unable to parse XML returned from XBMC: "+ex(e), logger.ERROR)
+                logger.log(u"Unable to parse XML returned from XBMC: " + ex(e), logger.ERROR)
                 return False
-    
+
             paths = et.findall('.//field')
-    
+
             if not paths:
                 logger.log(u"No valid paths found for " + showName + " on " + host, logger.DEBUG)
                 return False
-    
+
             for path in paths:
                 # Don't need it double-encoded, gawd this is dumb
                 unEncPath = urllib.unquote(path.text).decode(sickbeard.SYS_ENCODING)
                 logger.log(u"XBMC Updating " + showName + " on " + host + " at " + unEncPath, logger.DEBUG)
                 updateCommand = {'command': 'ExecBuiltIn', 'parameter': 'XBMC.updatelibrary(video, %s)' % (unEncPath)}
-                request = self._sendToXBMC(updateCommand, host)
+                request = self._send_to_xbmc(updateCommand, host)
                 if not request:
                     logger.log(u"Update of show directory failed on " + showName + " on " + host + " at " + unEncPath, logger.ERROR)
                     return False
-                # Sleep for a few seconds just to be sure xbmc has a chance to finish
-                # each directory
+                # sleep for a few seconds just to be sure xbmc has a chance to finish each directory
                 if len(paths) > 1:
                     time.sleep(5)
+        # do a full update if requested
         else:
-            logger.log(u"Do a full update as requested", logger.DEBUG)
-            logger.log(u"XBMC Updating " + host, logger.DEBUG)
+            logger.log(u"Doing Full Library XBMC update on host: " + host, logger.DEBUG)
             updateCommand = {'command': 'ExecBuiltIn', 'parameter': 'XBMC.updatelibrary(video)'}
-            request = self._sendToXBMC(updateCommand, host)
-    
+            request = self._send_to_xbmc(updateCommand, host)
+
             if not request:
-                logger.log(u"Full update failed on " + host, logger.ERROR)
+                logger.log(u"XBMC Full Library update failed on: " + host, logger.ERROR)
                 return False
-    
+
         return True
 
-# Wake function
-def wakeOnLan(ethernet_address):
-    addr_byte = ethernet_address.split(':')
-    hw_addr = struct.pack('BBBBBB', int(addr_byte[0], 16),
-    int(addr_byte[1], 16),
-    int(addr_byte[2], 16),
-    int(addr_byte[3], 16),
-    int(addr_byte[4], 16),
-    int(addr_byte[5], 16))
+##############################################################################
+# JSON-RPC API (XBMC 12+) methods
+##############################################################################
 
-    # Build the Wake-On-LAN "Magic Packet"...
-    msg = '\xff' * 6 + hw_addr * 16
+    def _send_to_xbmc_json(self, command, host=None, username=None, password=None):
+        """Handles communication to XBMC servers via JSONRPC
 
-    # ...and send it to the broadcast address using UDP
-    ss = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    ss.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-    ss.sendto(msg, ('<broadcast>', 9))
-    ss.close()
+        Args:
+            command: Dictionary of field/data pairs, encoded via urllib and passed to the XBMC JSON-RPC via HTTP
+            host: XBMC webserver host:port
+            username: XBMC webserver username
+            password: XBMC webserver password
 
-# Test Connection function
-def isHostUp(host,port):
+        Returns:
+            Returns response.result for successful commands or False if there was an error
 
-    (family, socktype, proto, garbage, address) = socket.getaddrinfo(host, port)[0] #@UnusedVariable
-    s = socket.socket(family, socktype, proto)
+        """
 
-    try:
-        s.connect(address)
-        return "Up"
-    except:
-        return "Down"
+        # fill in omitted parameters
+        if not username:
+            username = sickbeard.XBMC_USERNAME
+        if not password:
+            password = sickbeard.XBMC_PASSWORD
 
+        if not host:
+            logger.log(u'No XBMC host passed, aborting update', logger.DEBUG)
+            return False
 
-def checkHost(host, port):
+        command = command.encode('utf-8')
+        logger.log(u"XBMC JSON command: " + command, logger.DEBUG)
 
-    # we should try to get this programmatically from the IP
-    mac = ""
+        url = 'http://%s/jsonrpc' % (host)
+        try:
+            req = urllib2.Request(url, command)
+            req.add_header("Content-type", "application/json")
+            # if we have a password, use authentication
+            if password:
+                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
+                authheader = "Basic %s" % base64string
+                req.add_header("Authorization", authheader)
+                logger.log(u"Contacting XBMC (with auth header) via url: " + fixStupidEncodings(url), logger.DEBUG)
+            else:
+                logger.log(u"Contacting XBMC via url: " + fixStupidEncodings(url), logger.DEBUG)
 
-    i=1
-    while isHostUp(host,port)=="Down" and i<4:
-        wakeOnLan(mac)
-        time.sleep(20)
-        i=i+1
+            try:
+                response = urllib2.urlopen(req)
+            except urllib2.URLError, e:
+                logger.log(u"Error while trying to retrieve API version: " + ex(e), logger.WARNING)
+                return False
+
+            # parse the json result
+            try:
+                result = json.load(response)
+                response.close()
+                logger.log(u"XBMC JSON response: " + str(result), logger.DEBUG)
+                return result # need to return response for parsing
+            except ValueError, e:
+                logger.log(u"Unable to decode JSON: " + response, logger.WARNING)
+                return False
+
+        except IOError, e:
+            logger.log(u"Warning: Couldn't contact XBMC JSON API at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
+            return False
+
+    def _update_library_json(self, host=None, showName=None):
+        """Handles updating XBMC host via HTTP JSON-RPC
+
+        Attempts to update the XBMC video library for a specific tv show if passed,
+        otherwise update the whole library if enabled.
+
+        Args:
+            host: XBMC webserver host:port
+            showName: Name of a TV show to specifically target the library update for
+
+        Returns:
+            Returns True or False
+
+        """
+
+        if not host:
+            logger.log(u'No XBMC host passed, aborting update', logger.DEBUG)
+            return False
+
+        logger.log(u"Updating XMBC library via JSON method for host: " + host, logger.MESSAGE)
+
+        # if we're doing per-show
+        if showName:
+            tvshowid = -1
+            logger.log(u"Updating library in XBMC via JSON method for show " + showName, logger.DEBUG)
+
+            # get tvshowid by showName
+            showsCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows","id":1}'
+            showsResponse = self._send_to_xbmc_json(showsCommand, host)
+            if (showsResponse == False):
+                return False
+            shows = showsResponse["result"]["tvshows"]
+
+            for show in shows:
+                if (show["label"] == showName):
+                    tvshowid = show["tvshowid"]
+                    break # exit out of loop otherwise the label and showname will not match up
+
+            # this can be big, so free some memory
+            del shows
+
+            # we didn't find the show (exact match), thus revert to just doing a full update if enabled
+            if (tvshowid == -1):
+                logger.log(u'Exact show name not matched in XBMC TV show list', logger.DEBUG)
+                return False
+
+            # lookup tv-show path
+            pathCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.GetTVShowDetails","params":{"tvshowid":%d, "properties": ["file"]},"id":1}' % (tvshowid)
+            pathResponse = self._send_to_xbmc_json(pathCommand, host)
+
+            path = pathResponse["result"]["tvshowdetails"]["file"]
+            logger.log(u"Received Show: " + show["label"] + " with ID: " + str(tvshowid) + " Path: " + path, logger.DEBUG)
+
+            if (len(path) < 1):
+                logger.log(u"No valid path found for " + showName + " with ID: " + str(tvshowid) + " on " + host, logger.WARNING)
+                return False
+
+            logger.log(u"XBMC Updating " + showName + " on " + host + " at " + path, logger.DEBUG)
+            updateCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":%s},"id":1}' % (json.dumps(path))
+            request = self._send_to_xbmc_json(updateCommand, host)
+            if not request:
+                logger.log(u"Update of show directory failed on " + showName + " on " + host + " at " + path, logger.ERROR)
+                return False
+
+            # catch if there was an error in the returned request
+            for r in request:
+                if 'error' in r:
+                    logger.log(u"Error while attempting to update show directory for " + showName + " on " + host + " at " + path, logger.ERROR)
+                    return False
+
+        # do a full update if requested
+        else:
+            logger.log(u"Doing Full Library XBMC update on host: " + host, logger.MESSAGE)
+            updateCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.Scan","id":1}'
+            request = self._send_to_xbmc_json(updateCommand, host, sickbeard.XBMC_USERNAME, sickbeard.XBMC_PASSWORD)
+
+            if not request:
+                logger.log(u"XBMC Full Library update failed on: " + host, logger.ERROR)
+                return False
+
+        return True
+
+##############################################################################
+# Public functions which will call the JSON or Legacy HTTP API methods
+##############################################################################
+
+    def notify_snatch(self, ep_name):
+        if sickbeard.XBMC_NOTIFY_ONSNATCH:
+            self._notify_xbmc(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+
+    def notify_download(self, ep_name):
+        if sickbeard.XBMC_NOTIFY_ONDOWNLOAD:
+            self._notify_xbmc(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+
+    def test_notify(self, host, username, password):
+        return self._notify_xbmc("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+
+    def update_library(self, showName=None):
+        """Public wrapper for the update library functions to branch the logic for JSON-RPC or legacy HTTP API
+
+        Checks the XBMC API version to branch the logic to call either the legacy HTTP API or the newer JSON-RPC over HTTP methods.
+        Do the ability of accepting a list of hosts deliminated by comma, we split off the first host to send the update to.
+        This is a workaround for SQL backend users as updating multiple clients causes duplicate entries.
+        Future plan is to revist how we store the host/ip/username/pw/options so that it may be more flexible.
+
+        Args:
+            showName: Name of a TV show to specifically target the library update for
+
+        Returns:
+            Returns True or False
+
+        """
+
+        if sickbeard.USE_XBMC and sickbeard.XBMC_UPDATE_LIBRARY:
+            if not sickbeard.XBMC_HOST:
+                logger.log(u"No XBMC hosts specified, check your settings", logger.DEBUG)
+                return False
+
+            # only send update to first host in the list -- workaround for xbmc sql backend users
+            host = sickbeard.XBMC_HOST.split(",")[0].strip()
+
+            logger.log(u"Sending request to update library for XBMC host: '" + host + "'", logger.MESSAGE)
+
+            xbmcapi = self._get_json_version(host, sickbeard.XBMC_USERNAME, sickbeard.XBMC_PASSWORD)
+            if xbmcapi:
+                if (xbmcapi <= 4):
+                    # try to update for just the show, if it fails, do full update if enabled
+                    if not self._update_library(host, showName) and sickbeard.XBMC_UPDATE_FULL:
+                        logger.log(u"Single show update failed, falling back to full update", logger.WARNING)
+                        return self._update_library(host)
+                    else:
+                        return True
+                else:
+                    # try to update for just the show, if it fails, do full update if enabled
+                    if not self._update_library_json(host, showName) and sickbeard.XBMC_UPDATE_FULL:
+                        logger.log(u"Single show update failed, falling back to full update", logger.WARNING)
+                        return self._update_library_json(host)
+                    else:
+                        return True
+            else:
+                logger.log(u"Failed to detect XBMC version for '" + host + "', check configuration and try again.", logger.DEBUG)
+                return False
+
+            return True
+
 
 notifier = XBMCNotifier

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -34,26 +34,55 @@ try:
 except ImportError:
     import xml.etree.ElementTree as etree
 
-class XBMCNotifier:
+try:
+    import lib.simplejson as json
+except:
+    import json
 
+class XBMCNotifier:
+    
+    apiversion = 0
+    
     def notify_snatch(self, ep_name):
         if sickbeard.XBMC_NOTIFY_ONSNATCH:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+            if (self._jsonapiversion() <= 4):
+                logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
+                self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
+            else:
+                logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
+                self._notifyXBMC_json(ep_name, common.notifyStrings[common.NOTIFY_SNATCH])
 
     def notify_download(self, ep_name):
         if sickbeard.XBMC_NOTIFY_ONDOWNLOAD:
-            self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            if (self._jsonapiversion() <= 4):
+                self._notifyXBMC(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            else:
+                self._notifyXBMC_json(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def test_notify(self, host, username, password):
-        return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+        if (self._jsonapiversion() <= 4):
+            logger.log(u"Detected XBMC version <= 11, using XBMC HTTP API", logger.DEBUG)
+            return self._notifyXBMC("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+        else:
+            logger.log(u"Detected XBMC version >= 12, using XBMC JSON API", logger.DEBUG)
+            return self._notifyXBMC_json("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
 
-    def update_library(self, show_name):
+    def update_library(self, host, showName=None):
         if sickbeard.XBMC_UPDATE_LIBRARY:
-            for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-                # do a per-show update first, if possible
-                if not self._update_library(curHost, showName=show_name) and sickbeard.XBMC_UPDATE_FULL:
+            if (self._jsonapiversion() <= 4):
+                if not self._update_library(host, showName) and sickbeard.XBMC_UPDATE_FULL:
                     # do a full update if requested
-                    self._update_library(curHost)
+                    return self._update_library(host)
+                else:
+                    return True
+
+            else:
+                if not self._update_library_json(host, showName) and sickbeard.XBMC_UPDATE_FULL:
+                    # do a full update if requested
+                    logger.log("Single show update failed, running full update", logger.ERROR)
+                    return self._update_library_json(host)
+                else:
+                    return True
 
     def _username(self):
         return sickbeard.XBMC_USERNAME
@@ -66,6 +95,12 @@ class XBMCNotifier:
 
     def _hostname(self):
         return sickbeard.XBMC_HOST
+    
+    def _jsonapiversion(self):
+        # buffer the api version, so we don't hammer the server with useless requests
+        if (self.apiversion == 0):
+            self.apiversion = self._checkJSON_version()
+        return self.apiversion
 
     def _sendToXBMC(self, command, host, username=None, password=None):
         '''
@@ -113,7 +148,7 @@ class XBMCNotifier:
     def _notifyXBMC(self, input, title="Sick Beard", host=None, username=None, password=None, force=False):
     
         if not self._use_me() and not force:
-            logger.log("Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
+            logger.log(u"Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
             return False
     
         if not host:
@@ -139,15 +174,15 @@ class XBMCNotifier:
         return result
 
     def _update_library(self, host, showName=None):
-    
+        
         if not self._use_me():
-            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
+            logger.log(u"Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
             return False
     
         logger.log(u"Updating library in XBMC", logger.DEBUG)
     
         if not host:
-            logger.log('No host specified, no updates done', logger.DEBUG)
+            logger.log(u'No host specified, no updates done', logger.DEBUG)
             return False
     
         # if we're doing per-show
@@ -212,6 +247,161 @@ class XBMCNotifier:
                 return False
     
         return True
+
+    def _checkJSON_version(self):
+        '''
+        returns XBMC JSONRPC Api version
+        4 = Xbmc Eden(11), 5 = Xbmc Frodo(12)
+        '''
+        host = self._hostname()
+        username = self._username()
+        password = self._password()
+            
+        checkCommand = '{"id":1,"jsonrpc":"2.0","method":"JSONRPC.Version"}'
+        result = self._sendToXBMC_json(checkCommand, host, username, password)
+        if result:
+            return result["result"]["version"]
+        else:
+            return False
+        
+    def _sendToXBMC_json(self, command, host, username=None, password=None):
+        '''
+        Handles communication with XBMC servers via JSONRPC 
+    
+        command - JSON request passed to http://host/jsonrpc
+        returns: dict or False on error
+    
+        host - host/ip + port (foo:8080)
+        '''
+
+        if not username:
+            username = self._username()
+        if not password:
+            password = self._password()
+    
+        command = command.encode('utf-8')
+        logger.log(u"Command is " + command, logger.DEBUG)
+        url = 'http://%s/jsonrpc' % (host)
+                    
+        try:
+            req = urllib2.Request(url, command)
+            req.add_header("Content-type", "application/json")
+            # If we have a password, use authentication
+            if password:
+                logger.log(u"Adding Password to XBMC url", logger.DEBUG)
+                base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
+                authheader =  "Basic %s" % base64string
+                req.add_header("Authorization", authheader)
+    
+            logger.log(u"Contacting XBMC via url: " + url, logger.DEBUG)
+            response = urllib2.urlopen(req)
+            
+        except IOError, e:
+            logger.log(u"Warning: Couldn't contact XBMC JSON api at " + fixStupidEncodings(url) + ": " + ex(e), logger.ERROR)
+            return False
+
+        # Parse the json result
+        try:
+            result = json.load(response)
+            response.close()
+            logger.log(u"response: " + str(result), logger.DEBUG)
+            return result
+        
+        except ValueError, e:
+            logger.log(u"Unable to decode JSON: "+response, logger.ERROR)
+            return False
+        
+     
+    def _notifyXBMC_json(self, msg, title="Sick Beard", host=None, username=None, password=None, force=False):
+    
+        if not self._use_me() and not force:
+            logger.log(u"Notification for XBMC not enabled, skipping this notification", logger.DEBUG)
+            return False
+    
+        if not host:
+            host = self._hostname()
+        if not username:
+            username = self._username()
+        if not password:
+            password = self._password()
+    
+        logger.log(u"Sending notification for " + msg, logger.DEBUG)
+    
+        result = ''
+        for curHost in [x.strip() for x in host.split(",")]:
+            command = '{"id":1,"jsonrpc":"2.0","method":"GUI.ShowNotification","params":{"title":"Sick Beard","message":"%s"}}' % msg
+            logger.log(u"Sending notification to XBMC via host: "+ curHost +" username: "+ username + " password: " + password, logger.DEBUG)
+            notifyResult = self._sendToXBMC_json(command, curHost, username, password)
+            if (notifyResult != False):
+                result += ', '+ curHost + ':' + notifyResult["result"].decode(sickbeard.SYS_ENCODING)
+        
+        return result
+
+    def _update_library_json(self, host, showName=None):
+        
+        username = self._username()
+        password = self._password()
+    
+        if not self._use_me():
+            logger.log("Notifications for XBMC not enabled, skipping library update", logger.DEBUG)
+            return False
+    
+        logger.log(u"Updating library in XBMC", logger.DEBUG)
+    
+        if not host:
+            logger.log(u'No host specified, no updates done', logger.DEBUG)
+            return False
+    
+        # if we're doing per-show
+        if showName:
+            tvshowid = -1
+            
+            # get tvshowid by showName
+            showsCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows"}'
+            showsResponse = self._sendToXBMC_json(showsCommand, host)
+            if (showsResponse == False):
+                return False
+            shows = showsResponse["result"]["tvshows"] 
+            
+            for show in shows:
+                if (show["label"] == showName):
+                    tvshowid = show["tvshowid"]
+            if (tvshowid == -1):
+                # we didn't find the show, will trigger a full update if enabled
+                return False
+            
+            # this can be big, so free some memory
+            del shows
+            
+            # JSON to get the TV-Show path
+            pathCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.GetTVShowDetails","params":{"tvshowid":%d, "properties": ["file"]}}' % (tvshowid)
+            pathResponse = self._sendToXBMC_json(pathCommand, host)
+
+            path = pathResponse["result"]["tvshowdetails"]["file"]
+            logger.log(u"Received Show: " + show["label"] + " with ID: " + str(tvshowid) + " Path: " + path, logger.DEBUG)
+
+            if (len(path) < 1):
+                logger.log(u"No valid path found for " + showName + " with ID: " + str(tvshowid) + " on " + host, logger.ERROR)
+                return False
+
+            logger.log(u"XBMC Updating " + showName + " on " + host + " at " + path, logger.DEBUG)
+            updateCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":"%s"}}' % (path)
+            request = self._sendToXBMC_json(updateCommand, host)
+            if not request:
+                    logger.log(u"Update of show directory failed on " + showName + " on " + host + " at " + path, logger.ERROR)
+                    return False
+            
+        else:
+            logger.log(u"Do a full update as requested", logger.DEBUG)
+            logger.log(u"XBMC Updating " + host, logger.DEBUG)
+            updateCommand = '{"id":1,"jsonrpc":"2.0","method":"VideoLibrary.Scan"}'
+            request = self._sendToXBMC_json(updateCommand, host, username, password)
+            if not request:
+                logger.log(u"Full update failed on " + host, logger.ERROR)
+                return False
+    
+        return True
+
 
 # Wake function
 def wakeOnLan(ethernet_address):

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -852,20 +852,23 @@ class PostProcessor(object):
         ep_obj.createMetaFiles()
         ep_obj.saveToDB()
 
-        # do the library update
+        # do the library update for XBMC
         notifiers.xbmc_notifier.update_library(ep_obj.show.name)
 
-        # do the library update for Plex Media Server
+        # do the library update for Plex
         notifiers.plex_notifier.update_library()
 
-        # do the library update for synoindex
-        notifiers.synoindex_notifier.addFile(ep_obj.location)
+        # do the library update for NMJ
+        # nmj_notifier kicks off its library update when the notify_download is issued (inside notifiers)
 
-        # do the library update for trakt
-        notifiers.trakt_notifier.update_library(ep_obj)
+        # do the library update for Synology Indexer
+        notifiers.synoindex_notifier.addFile(ep_obj.location)
 
         # do the library update for pyTivo
         notifiers.pytivo_notifier.update_library(ep_obj)
+
+        # do the library update for Trakt
+        notifiers.trakt_notifier.update_library(ep_obj)
 
         self._run_extra_scripts(ep_obj)
 

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -108,6 +108,7 @@ class WindowsUpdateManager(UpdateManager):
 
     def __init__(self):
         self._cur_version = None
+        self._cur_commit_hash = None
         self._newest_version = None
 
         self.gc_url = 'http://code.google.com/p/sickbeard/downloads/list'

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2448,7 +2448,7 @@ class Home:
     def updateXBMC(self, showName=None):
 
         for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-            if notifiers.xbmc_notifier._update_library(curHost, showName=showName):
+            if notifiers.xbmc_notifier.update_library(curHost, showName=showName):
                 ui.notifications.message("Command sent to XBMC host " + curHost + " to update library")
             else:
                 ui.notifications.error("Unable to contact XBMC host " + curHost)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1448,10 +1448,10 @@ class Config:
     notifications = ConfigNotifications()
 
 def haveXBMC():
-    return sickbeard.XBMC_HOST
+    return sickbeard.USE_XBMC and sickbeard.XBMC_UPDATE_LIBRARY
 
 def havePLEX():
-    return sickbeard.PLEX_SERVER_HOST
+    return sickbeard.USE_PLEX and sickbeard.PLEX_UPDATE_LIBRARY
 
 def HomeMenu():
     return [
@@ -2056,21 +2056,31 @@ class Home:
     def testXBMC(self, host=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
-        result = notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(host), username, password)
-        if len(result.split(":")) > 2 and 'OK' in result.split(":")[2]:
-            return "Test notice sent successfully to "+urllib.unquote_plus(host)
-        else:
-            return "Test notice failed to "+urllib.unquote_plus(host)
+        finalResult = ''
+        for curHost in [x.strip() for x in host.split(",")]:
+            curResult = notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(curHost), username, password)
+            if len(curResult.split(":")) > 2 and 'OK' in curResult.split(":")[2]:
+                finalResult += "Test XBMC notice sent successfully to " + urllib.unquote_plus(curHost)
+            else:
+                finalResult += "Test XBMC notice failed to " + urllib.unquote_plus(curHost)
+            finalResult += "<br />\n"
+
+        return finalResult
 
     @cherrypy.expose
     def testPLEX(self, host=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
-        result = notifiers.plex_notifier.test_notify(urllib.unquote_plus(host), username, password)
-        if result:
-            return "Test notice sent successfully to "+urllib.unquote_plus(host)
-        else:
-            return "Test notice failed to "+urllib.unquote_plus(host)
+        finalResult = ''
+        for curHost in [x.strip() for x in host.split(",")]:
+            curResult = notifiers.plex_notifier.test_notify(urllib.unquote_plus(curHost), username, password)
+            if len(curResult.split(":")) > 2 and 'OK' in curResult.split(":")[2]:
+                finalResult += "Test Plex notice sent successfully to " + urllib.unquote_plus(curHost)
+            else:
+                finalResult += "Test Plex notice failed to " + urllib.unquote_plus(curHost)
+            finalResult += "<br />\n"
+
+        return finalResult
 
     @cherrypy.expose
     def testLibnotify(self):
@@ -2443,27 +2453,23 @@ class Home:
 
         redirect("/home/displayShow?show="+str(showObj.tvdbid))
 
-
     @cherrypy.expose
     def updateXBMC(self, showName=None):
-
-        for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-            if notifiers.xbmc_notifier._update_library(curHost, showName=showName):
-                ui.notifications.message("Command sent to XBMC host " + curHost + " to update library")
-            else:
-                ui.notifications.error("Unable to contact XBMC host " + curHost)
+        # TODO: configure that each host can have different options / username / pw
+        # only send update to first host in the list -- workaround for xbmc sql backend users
+        firstHost = sickbeard.XBMC_HOST.split(",")[0].strip()
+        if notifiers.xbmc_notifier.update_library(showName=showName):
+            ui.notifications.message("Library update command sent to XBMC host: " + firstHost)
+        else:
+            ui.notifications.error("Unable to contact XBMC host: " + firstHost)
         redirect('/home')
-
 
     @cherrypy.expose
     def updatePLEX(self):
-
-        if notifiers.plex_notifier._update_library():
-            ui.notifications.message("Command sent to Plex Media Server host " + sickbeard.PLEX_HOST + " to update library")
-            logger.log(u"Plex library update initiated for host " + sickbeard.PLEX_HOST, logger.DEBUG)
+        if notifiers.plex_notifier.update_library():
+            ui.notifications.message("Library update command sent to Plex Media Server host: " + sickbeard.PLEX_SERVER_HOST)
         else:
-            ui.notifications.error("Unable to contact Plex Media Server host " + sickbeard.PLEX_HOST)
-            logger.log(u"Plex library update failed for host " + sickbeard.PLEX_HOST, logger.ERROR)
+            ui.notifications.error("Unable to contact Plex Media Server host: " + sickbeard.PLEX_SERVER_HOST)
         redirect('/home')
 
     @cherrypy.expose

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2448,7 +2448,7 @@ class Home:
     def updateXBMC(self, showName=None):
 
         for curHost in [x.strip() for x in sickbeard.XBMC_HOST.split(",")]:
-            if notifiers.xbmc_notifier.update_library(curHost, showName=showName):
+            if notifiers.xbmc_notifier._update_library(curHost, showName=showName):
                 ui.notifications.message("Command sent to XBMC host " + curHost + " to update library")
             else:
                 ui.notifications.error("Unable to contact XBMC host " + curHost)


### PR DESCRIPTION
- XBMC notifier was completely redone to support both the legacy http api and the upcoming xbmc12 (frodo) json-rpc method. Using the public calls as wrappers with the detection to know which internal methods to call.
- Due to the XBMC rewrite, the Plex notifier no longer inherits xbmc's notifier as the code has diverged too much -- plus we were wrongly showing 'xbmc' log messages.
- Cleaned up many small bugs I found in the process as well as updated the config ui notification page.
- Cleaned up the notifiers page to match the web ui, which made it easier to test and for others to add notifiers in the future.
