### PR TITLE
Fix NewzNab providers that use sphinx

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -86,7 +86,7 @@ class NewznabProvider(generic.NZBProvider):
                 cur_params['rid'] = show.tvrid
             # if we can't then fall back on a very basic name search
             else:
-                cur_params['q'] = helpers.sanitizeSceneName(cur_exception).replace('.', '_')
+                cur_params['q'] = helpers.sanitizeSceneName(cur_exception)
 
             if season != None:
                 # air-by-date means &season=2010&q=2010.03, no other way to do it atm
@@ -117,7 +117,7 @@ class NewznabProvider(generic.NZBProvider):
             params['rid'] = ep_obj.show.tvrid
         # if we can't then fall back on a very basic name search
         else:
-            params['q'] = helpers.sanitizeSceneName(ep_obj.show.name).replace('.', '_')
+            params['q'] = helpers.sanitizeSceneName(ep_obj.show.name)
 
         if ep_obj.show.air_by_date:
             date_str = str(ep_obj.airdate)
@@ -142,7 +142,7 @@ class NewznabProvider(generic.NZBProvider):
                     continue
 
                 cur_return = params.copy()
-                cur_return['q'] = helpers.sanitizeSceneName(cur_exception).replace('.', '_')
+                cur_return['q'] = helpers.sanitizeSceneName(cur_exception)
                 to_return.append(cur_return)
 
         return to_return


### PR DESCRIPTION
Fix for Newznab providers when searching for a show without a tvrage id, as we use the name of the show. If the show name is more than one word we are using a `_` as our delimiter which works fine unless the NN provider uses sphinx.. as the underscore then is used as part of the show name.. thus we always get back no results. We should just use `.` as it works for both sphinx and non sphinx servers. Tested this out on nzbs.org / nzb.su (sphinx) / sbi (non sphinx).
