### PR TITLE
TVDB update and fixes

### DIFF
--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -57,11 +57,14 @@
 
         var nums = match[1].split(" / ");
 
+        if (parseInt(nums[0]) === 0)
+            return parseInt(nums[1]);
+
         var finalNum = parseInt((nums[0]/nums[1])*1000)*100;
         if (finalNum > 0)
             finalNum += parseInt(nums[0]);
 
-        return finalNum
+        return finalNum;
     },
     type: 'numeric'
 });

--- a/lib/tvdb_api/setup.py
+++ b/lib/tvdb_api/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
 name = 'tvdb_api',
-version='1.7.2',
+version='1.8.2',
 
 author='dbr/Ben',
 description='Interface to thetvdb.com',

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -15,11 +15,13 @@ Example usage:
 u'Cabin Fever'
 """
 __author__ = "dbr/Ben"
-__version__ = "1.7.2"
+__version__ = "1.8.2"
 
-import os, time
+import os
+import time
 import urllib
 import urllib2
+import getpass
 import StringIO
 import tempfile
 import warnings
@@ -269,10 +271,12 @@ class Episode(dict):
         #end for cur_key, cur_value
 
 
+
 class Actors(list):
     """Holds all Actor instances for a show
     """
     pass
+
 
 
 class Actor(dict):
@@ -494,9 +498,16 @@ class Tvdb:
     #end __init__
 
     def _getTempDir(self):
-        """Returns the [system temp dir]/tvdb_api
+        """Returns the [system temp dir]/tvdb_api-u501 (or
+        tvdb_api-myuser)
         """
-        return os.path.join(tempfile.gettempdir(), "tvdb_api")
+        if hasattr(os, 'getuid'):
+            uid = "u%d" % (os.getuid())
+        else:
+            # For Windows
+            uid = getpass.getuser()
+
+        return os.path.join(tempfile.gettempdir(), "tvdb_api-%s" % (uid))
 
     def _loadUrl(self, url, recache = False, language=None):
         global lastTimeout

--- a/lib/tvdb_api/tvdb_cache.py
+++ b/lib/tvdb_api/tvdb_cache.py
@@ -12,7 +12,7 @@ Modified from http://code.activestate.com/recipes/491261/
 from __future__ import with_statement
 
 __author__ = "dbr/Ben"
-__version__ = "1.7.2"
+__version__ = "1.8.2"
 
 import os
 import time

--- a/lib/tvdb_api/tvdb_exceptions.py
+++ b/lib/tvdb_api/tvdb_exceptions.py
@@ -9,7 +9,7 @@
 """
 
 __author__ = "dbr/Ben"
-__version__ = "1.7.2"
+__version__ = "1.8.2"
 
 __all__ = ["tvdb_error", "tvdb_userabort", "tvdb_shownotfound",
 "tvdb_seasonnotfound", "tvdb_episodenotfound", "tvdb_attributenotfound"]

--- a/lib/tvdb_api/tvdb_ui.py
+++ b/lib/tvdb_api/tvdb_ui.py
@@ -43,7 +43,7 @@ Then to use it..
 """
 
 __author__ = "dbr/Ben"
-__version__ = "1.7.2"
+__version__ = "1.8.2"
 
 import logging
 import warnings

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -219,10 +219,16 @@ class QueueItemAdd(ShowQueueItem):
                 t = tvdb_api.Tvdb(**ltvdb_api_parms)
                 s = t[self.tvdb_id]
 
-                # this usually only happens if they have an NFO in their show dir which gave us a TVDB ID that has no
-                # proper english version of the show
-                if not s or not s['seriesname']:
-                    ui.notifications.error("Unable to add show", "Show in "+self.showDir+" has no name on TVDB, probably the wrong language. Delete .nfo and add manually in the correct language.")
+                # this usually only happens if they have an NFO in their show dir which gave us a TVDB ID that has no proper english version of the show
+                if not s['seriesname']:
+                    logger.log(u"Show in " + self.showDir + " has no name on TVDB, probably the wrong language used to search with.", logger.ERROR)
+                    ui.notifications.error("Unable to add show", "Show in " + self.showDir + " has no name on TVDB, probably the wrong language. Delete .nfo and add manually in the correct language.")
+                    self._finishEarly()
+                    return
+                # if the show has no episodes/seasons
+                if not s:
+                    logger.log(u"Show " + str(s['seriesname']) + " is on TVDB but contains no season/episode data.", logger.ERROR)
+                    ui.notifications.error("Unable to add show", "Show " + str(s['seriesname']) + " is on TVDB but contains no season/episode data.")
                     self._finishEarly()
                     return
             except tvdb_exceptions.tvdb_exception, e:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1137,7 +1137,7 @@ class TVEpisode(object):
             return
 
 
-        if not myEp["firstaired"]:
+        if not myEp["firstaired"] or myEp["firstaired"] == "0000-00-00":
             myEp["firstaired"] = str(datetime.date.fromordinal(1))
 
         if myEp["episodename"] == None or myEp["episodename"] == "":

--- a/sickbeard/tvrage.py
+++ b/sickbeard/tvrage.py
@@ -114,7 +114,7 @@ class TVRage:
                     ep = t[self.show.tvdbid][curSeason][1]
 
                     # make sure we have a date to compare with
-                    if ep["firstaired"] == "" or ep["firstaired"] == None:
+                    if ep["firstaired"] == "" or ep["firstaired"] == None or ep["firstaired"] == "0000-00-00":
                         continue
 
                     # get a datetime object

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1508,6 +1508,10 @@ class CMD_SickBeardSearchTVDB(ApiCall):
                 logger.log(u"API :: Unable to find show with id " + str(self.tvdbid), logger.WARNING)
                 return _responds(RESULT_SUCCESS, {"results": [], "langid": lang_id})
 
+            if not myShow.data['seriesname']:
+                logger.log(u"API :: Found show with tvdbid " + str(self.tvdbid) + ", however it contained no show name", logger.DEBUG)
+                return _responds(RESULT_FAILURE, msg="Show contains no name, invalid result")
+
             showOut = [{"tvdbid": self.tvdbid,
                        "name": unicode(myShow.data['seriesname']),
                        "first_aired": myShow.data['firstaired']}]
@@ -1698,6 +1702,8 @@ class CMD_ShowAddExisting(ApiCall):
         tvdbResult = CMD_SickBeardSearchTVDB([], {"tvdbid": self.tvdbid}).run()
 
         if tvdbResult['result'] == result_type_map[RESULT_SUCCESS]:
+            if not tvdbResult['data']['results']:
+                return _responds(RESULT_FAILURE, msg="Empty results returned, check tvdbid and try again")
             if len(tvdbResult['data']['results']) == 1 and 'name' in tvdbResult['data']['results'][0]:
                 tvdbName = tvdbResult['data']['results'][0]['name']
 
@@ -1826,6 +1832,8 @@ class CMD_ShowAddNew(ApiCall):
         tvdbResult = CMD_SickBeardSearchTVDB([], {"tvdbid": self.tvdbid}).run()
 
         if tvdbResult['result'] == result_type_map[RESULT_SUCCESS]:
+            if not tvdbResult['data']['results']:
+                return _responds(RESULT_FAILURE, msg="Empty results returned, check tvdbid and try again")
             if len(tvdbResult['data']['results']) == 1 and 'name' in tvdbResult['data']['results'][0]:
                 tvdbName = tvdbResult['data']['results'][0]['name']
 


### PR DESCRIPTION
- Treat episodes on TVDB with the airdate of `0000-00-00` the same as if it was not set to anything. 
  
  >  This resolves tv.py throwing: `Malformed air date retrieved from TVDB`
  >  This resolves tvrage.py throwing: `Error encountered while checking TVRage<->TVDB sync: year is out of range`
- Upgrade _tvdb_api_ from 1.7.2 -> 1.8.2
  
  >  Should resolve cache issues with regards to users that are unable to write to the cache, depending on how the 'tmp' permissions are set up.
- Correctly sort shows on homepage that have 0 ep downloaded. (0/# sorts lower than 1/#)
-  Fix **SB-API** `show.addnew` and `show.addexisting` when adding a show from tvdbid that contain no name.
  
  >  As this resulted in the show creation folder called `None`.
- Fix **SB-API** `sb.searchTVDB` call on returning incorrect data for a tvdbid that contains no name.
  
  >  Report the failure to add a show to sb because it has no episode/season data rather than saying it has no name and to delete the .nfo file.
