### PR TITLE
Fixed issue with UNKNOWN status episodes being ignored

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -861,15 +861,19 @@ class TVShow(object):
             return False
 
         myDB = db.DBConnection()
-        sqlResults = myDB.select("SELECT status FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?", [self.tvdbid, season, episode])
+        sqlResults = myDB.select("SELECT status,airdate FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?", [self.tvdbid, season, episode])
 
         if not sqlResults or not len(sqlResults):
             logger.log(u"Unable to find the episode", logger.DEBUG)
             return False
 
         epStatus = int(sqlResults[0]["status"])
+        epAirDate = int(sqlResults[0]["airdate"])
+        todayDate = datetime.date.today().toordinal()
 
         logger.log(u"current episode status: "+str(epStatus), logger.DEBUG)
+        logger.log(u"current episode airdate: "+str(epAirDate), logger.DEBUG)
+        logger.log(u"current date: "+str(todayDate), logger.DEBUG)
 
         # if we know we don't want it then just say no
         if epStatus in (SKIPPED, IGNORED, ARCHIVED) and not manualSearch:
@@ -880,6 +884,9 @@ class TVShow(object):
         if quality in anyQualities + bestQualities:
             if epStatus in (WANTED, UNAIRED, SKIPPED):
                 logger.log(u"Ep is wanted/unaired/skipped, definitely get it", logger.DEBUG)
+                return True
+            elif epStatus == UNKNOWN and epAirDate <= todayDate:
+                logger.log(u"Still in UNKNOWN status for some reason, but it should have aired, so getting it", logger.DEBUG)
                 return True
             elif manualSearch:
                 logger.log(u"Usually I would ignore this ep but because you forced the search I'm overriding the default and allowing the quality", logger.DEBUG)


### PR DESCRIPTION
While this doesn't address the root cause of episode statuses showing up as UNKNOWN, it handles the condition should it arise by checking episodes of UNKNOWN status that have an airdate of today or in the past.  Please pull in these changes.
Thanks!
