### PR TITLE
Added the ability to override resizing the images served up from the cache if PIL is installed.

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -162,9 +162,9 @@ def main():
     threading.currentThread().name = "MAIN"
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "qfdp::", ['quiet', 'forceupdate', 'daemon', 'port=', 'pidfile=', 'nolaunch', 'config=', 'datadir='])  # @UnusedVariable
+        opts, args = getopt.getopt(sys.argv[1:], "qfdp::", ['quiet', 'forceupdate', 'port=', 'daemon', 'noresize', 'pidfile=', 'nolaunch', 'config=', 'datadir='])  # @UnusedVariable
     except getopt.GetoptError:
-        print "Available Options: --quiet, --forceupdate, --port, --daemon, --pidfile, --config, --datadir"
+        print "Available Options: --quiet, --forceupdate, --port, --daemon, --noresize, --pidfile, --nolaunch, --config, --datadir"
         sys.exit()
 
     forceUpdate = False
@@ -197,6 +197,10 @@ def main():
             else:
                 consoleLogging = False
                 sickbeard.DAEMON = True
+
+        # Prevent resizing of the banner/posters even if PIL is installed
+        if o in ('--noresize',):
+            sickbeard.NO_RESIZE = True
 
         # Specify folder to load the config file from
         if o in ('--config',):

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -66,6 +66,7 @@ CREATEPID = False
 PIDFILE = ''
 
 DAEMON = None
+NO_RESIZE = False
 
 backlogSearchScheduler = None
 currentSearchScheduler = None

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -54,7 +54,10 @@ try:
 except ImportError:
     from lib import simplejson as json
 
-import xml.etree.cElementTree as etree
+try:
+    import xml.etree.cElementTree as etree
+except ImportError:
+    import xml.etree.ElementTree as etree
 
 from sickbeard import browser
 
@@ -2690,7 +2693,7 @@ class UI:
 
         return json.dumps(messages)
 
-   
+
 class WebInterface:
 
     @cherrypy.expose
@@ -2716,7 +2719,7 @@ class WebInterface:
             return cherrypy.lib.static.serve_file(default_image_path, content_type="image/png")
 
         cache_obj = image_cache.ImageCache()
-        
+
         if which == 'poster':
             image_file_name = cache_obj.poster_path(showObj.tvdbid)
         # this is for 'banner' but also the default case
@@ -2724,6 +2727,9 @@ class WebInterface:
             image_file_name = cache_obj.banner_path(showObj.tvdbid)
 
         if ek.ek(os.path.isfile, image_file_name):
+            # use startup argument to prevent using PIL even if installed
+            if sickbeard.NO_RESIZE:
+                return cherrypy.lib.static.serve_file(image_file_name, content_type="image/jpeg")
             try:
                 from PIL import Image
                 from cStringIO import StringIO
@@ -2740,10 +2746,10 @@ class WebInterface:
                 else:
                     return cherrypy.lib.static.serve_file(image_file_name, content_type="image/jpeg")
                 im = im.resize(size, Image.ANTIALIAS)
-                buffer = StringIO()
-                im.save(buffer, 'JPEG', quality=85)
+                imgbuffer = StringIO()
+                im.save(imgbuffer, 'JPEG', quality=85)
                 cherrypy.response.headers['Content-Type'] = 'image/jpeg'
-                return buffer.getvalue()
+                return imgbuffer.getvalue()
         else:
             return cherrypy.lib.static.serve_file(default_image_path, content_type="image/png")
 


### PR DESCRIPTION
- Add `--noresize` to command line argument so that the user could disable the use of PIL on resizing the poster/banner cached images. (ex: they need PIL for another python app but don't want PIL to be used for sb..)
- Corrected the etree import so it mimics how tvdb_api does (will try cElementTree first then fall back to the slower non-C ElementTree)
