### PR TITLE
rootDirs.js cleanup

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -9,13 +9,13 @@ browser.css
   margin: 0;
 }
 #fileBrowserDialog ul li {
-  padding: 4px 0;
-  margin: 2px;
+  margin: 2px 0;
   list-style-type: none;
   cursor: pointer;
 }
 #fileBrowserDialog ul li a {
   display: block;
+  padding: 4px 0;
 }
 #fileBrowserDialog ul li a:hover {
   color: #00f;
@@ -358,7 +358,7 @@ home.tmpl
 /* =======================================================================
 home_postprocess.tmpl
 ========================================================================== */
-#episodeDir {
+#episodeDir, #newRootDir {
   margin-right: 6px;
 }
 
@@ -444,11 +444,6 @@ ul#rootDirStaticList li {
   margin: 2px;
   list-style: none outside none;
   cursor: pointer;
-}
-/* for tabs: manage directories */
-#rootDirs, #rootDirsControls {
-  width: 50%;
-  min-width: 400px;
 }
 /* for tabs: customize options */
 #tabs div.field-pair,

--- a/data/interfaces/default/inc_rootDirs.tmpl
+++ b/data/interfaces/default/inc_rootDirs.tmpl
@@ -3,7 +3,7 @@
 
 #if $sickbeard.ROOT_DIRS:
 #set $backend_pieces = $sickbeard.ROOT_DIRS.split('|')
-#set $backend_default = 'rd-'+$backend_pieces[0]
+#set $backend_default = 'rd-' + $backend_pieces[0]
 #set $backend_dirs = $backend_pieces[1:]
 #else:
 #set $backend_default = ''
@@ -11,14 +11,14 @@
 #end if
 
 <input type="hidden" id="whichDefaultRootDir" value="$backend_default" />
-<div style="padding-bottom: 5px; padding-top: 10px;">
-    <select name="rootDir" id="rootDirs" size="6" style="min-width: 400px;">
+<div style="padding: 10px 0 5px;">
+    <select name="rootDir" id="rootDirs" size="6" style="min-width: 500px;">
     #for $cur_dir in $backend_dirs:
         <option value="$cur_dir">$cur_dir</option>
     #end for
     </select>
 </div>
-<div id="rootDirsControls" style="text-align: center;">
+<div id="rootDirsControls" style="text-align: center; width: 500px;">
     <input class="btn" type="button" id="addRootDir" value="New" />
     <input class="btn" type="button" id="editRootDir" value="Edit" />
     <input class="btn" type="button" id="deleteRootDir" value="Delete" />

--- a/data/js/rootDirs.js
+++ b/data/js/rootDirs.js
@@ -1,27 +1,34 @@
 $(document).ready(function(){
 
-    function logMsg(msg) {
-        if (window.console && window.logMsg)
-            console.log(msg)
-    }
+    // usage: log('inside coolFunc', this, arguments);
+    // paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
+    window.log = function(){
+        log.history = log.history || []; // store logs to an array for reference
+        log.history.push(arguments);
+        if(this.console){
+            console.log( Array.prototype.slice.call(arguments) );
+        }
+    };
 
     function addRootDir(path){
         // check if it's the first one
         var is_default = false;
-        if (!$('#whichDefaultRootDir').val().length)
+        if (!$('#whichDefaultRootDir').val().length) {
             is_default = true;
+        }
 
         $('#rootDirs').append('<option value="'+path+'">'+path+'</option>');
-        
+
         syncOptionIDs();
         
-        if (is_default)
+        if (is_default) {
             setDefault($('#rootDirs option').attr('id'));
+        }
 
         refreshRootDirs();
-    
-        $.get(sbRoot+'/config/general/saveRootDirs', { rootDirString: $('#rootDirText').val() });
-    
+
+        $.get(sbRoot + '/config/general/saveRootDirs', { rootDirString: $('#rootDirText').val() });
+
     }
 
     function editRootDir(path) {
@@ -29,10 +36,11 @@ $(document).ready(function(){
         if ($("#rootDirs option:selected").length) {
 
             // update the selected one with the provided path
-            if ($("#rootDirs option:selected").attr('id') == $("#whichDefaultRootDir").val())
-                $("#rootDirs option:selected").text('*'+path);
-            else
-                $("#rootDirs option:selected").text('*'+path);
+            if ($("#rootDirs option:selected").attr('id') == $("#whichDefaultRootDir").val()) {
+                $("#rootDirs option:selected").text('*' + path);
+            } else {
+                $("#rootDirs option:selected").text('*' + path);
+            }
             $("#rootDirs option:selected").val(path);
         }
 
@@ -40,10 +48,10 @@ $(document).ready(function(){
         $.get(sbRoot+'/config/general/saveRootDirs', {rootDirString: $('#rootDirText').val()});
     }
     
-    $('#addRootDir').click(function(){$(this).nFileBrowser(addRootDir)});
-    $('#editRootDir').click(function(){$(this).nFileBrowser(editRootDir, {initialDir: $("#rootDirs option:selected").val()})});
+    $('#addRootDir').click(function(){$(this).nFileBrowser(addRootDir);});
+    $('#editRootDir').click(function(){$(this).nFileBrowser(editRootDir, {initialDir: $("#rootDirs option:selected").val()});});
 
-    $('#deleteRootDir').click(function(){
+    $('#deleteRootDir').click(function() {
         if ($("#rootDirs option:selected").length) {
 
             var toDelete = $("#rootDirs option:selected");
@@ -56,53 +64,59 @@ $(document).ready(function(){
 
             if (newDefault) {
 
-                logMsg('new default when deleting')
-                
+                log('new default when deleting');
+
                 // we deleted the default so this isn't valid anymore
                 $("#whichDefaultRootDir").val('');
 
                 // if we're deleting the default and there are options left then pick a new default
-                if ($("#rootDirs option").length)
+                if ($("#rootDirs option").length) {
                     setDefault($('#rootDirs option').attr('id'));
-            
+                }
+
             } else if ($("#whichDefaultRootDir").val().length) {
                 var old_default_num = $("#whichDefaultRootDir").val().substr(3);
-                if (old_default_num > deleted_num)
-                    $("#whichDefaultRootDir").val('rd-'+(old_default_num-1))
+                if (old_default_num > deleted_num) {
+                    $("#whichDefaultRootDir").val('rd-' + (old_default_num-1));
+                }
             }
 
         }
         refreshRootDirs();
-        $.get(sbRoot+'/config/general/saveRootDirs', {rootDirString: $('#rootDirText').val()});
+        $.get(sbRoot + '/config/general/saveRootDirs', {rootDirString: $('#rootDirText').val()});
     });
 
     $('#defaultRootDir').click(function(){
-        if ($("#rootDirs option:selected").length)
+        if ($("#rootDirs option:selected").length) {
             setDefault($("#rootDirs option:selected").attr('id'));
+        }
         refreshRootDirs();
-        $.get(sbRoot+'/config/general/saveRootDirs', 'rootDirString='+$('#rootDirText').val());
+        $.get(sbRoot + '/config/general/saveRootDirs', 'rootDirString=' + $('#rootDirText').val());
     });
 
     function setDefault(which, force){
 
-        logMsg('setting default to '+which)
+        log('setting default to ' + which);
 
-        if (which != undefined && !which.length)
-            return
+        if (which != undefined && !which.length) {
+            return;
+        }
 
-        if ($('#whichDefaultRootDir').val() == which && force != true)
-            return
+        if ($('#whichDefaultRootDir').val() == which && force != true) {
+            return;
+        }
 
         // put an asterisk on the text
-        if ($('#'+which).text().charAt(0) != '*')
-            $('#'+which).text('*'+$('#'+which).text());
+        if ($('#' + which).text().charAt(0) != '*') {
+            $('#' + which).text('*' + $('#'+which).text());
+        }
 
         // if there's an existing one then take the asterisk off
         if ($('#whichDefaultRootDir').val() && force != true) {
             var old_default = $('#'+$('#whichDefaultRootDir').val());
             old_default.text(old_default.text().substring(1));
         }
-        
+
         $('#whichDefaultRootDir').val(which);
     }
 
@@ -116,17 +130,19 @@ $(document).ready(function(){
 
     function refreshRootDirs() {
 
-        if (!$("#rootDirs").length)
-            return
-        
+        if (!$("#rootDirs").length) {
+            return;
+        }
+
         var do_disable = 'true';
 
         // re-sync option ids
         syncOptionIDs();
 
         // if nothing's selected then select the default
-        if (!$("#rootDirs option:selected").length && $('#whichDefaultRootDir').val().length)
-            $('#'+$('#whichDefaultRootDir').val()).prop("selected", true)
+        if (!$("#rootDirs option:selected").length && $('#whichDefaultRootDir').val().length) {
+            $('#' + $('#whichDefaultRootDir').val()).prop("selected", true);
+        }
 
         // if something's selected then we have some behavior to figure out
         if ($("#rootDirs option:selected").length) {
@@ -140,26 +156,28 @@ $(document).ready(function(){
 
         var log_str = '';
         var dir_text = '';
-        if ($('#whichDefaultRootDir').val().length >= 4)
-            var dir_text = $('#whichDefaultRootDir').val().substr(3);
+        if ($('#whichDefaultRootDir').val().length >= 4) {
+            dir_text = $('#whichDefaultRootDir').val().substr(3);
+        }
         $('#rootDirs option').each(function() {
-            log_str += $(this).val()+'='+$(this).text()+'->'+$(this).attr('id')+'\n';
-            if (dir_text.length)
-                dir_text += '|' + $(this).val()
+            log_str += $(this).val() + '=' + $(this).text() + '->' + $(this).attr('id') + '\n';
+            if (dir_text.length) {
+                dir_text += '|' + $(this).val();
+            }
         });
         log_str += 'def: '+ $('#whichDefaultRootDir').val();
-        logMsg(log_str)
-        
+        log(log_str);
+
         $('#rootDirText').val(dir_text);
         $('#rootDirText').change();
-        logMsg('rootDirText: '+$('#rootDirText').val())
+        log('rootDirText: ' + $('#rootDirText').val());
     }
 
     $('#rootDirs').click(refreshRootDirs);
 
     // set up buttons on page load
     syncOptionIDs();
-    setDefault($('#whichDefaultRootDir').val(), true)
+    setDefault($('#whichDefaultRootDir').val(), true);
     refreshRootDirs();
 
 });

--- a/data/js/rootDirs.js
+++ b/data/js/rootDirs.js
@@ -1,26 +1,26 @@
-$(document).ready(function(){
+$(document).ready(function() {
 
     // usage: log('inside coolFunc', this, arguments);
     // paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
-    window.log = function(){
+    window.log = function() {
         log.history = log.history || []; // store logs to an array for reference
         log.history.push(arguments);
-        if(this.console){
-            console.log( Array.prototype.slice.call(arguments) );
+        if (this.console) {
+            console.log(Array.prototype.slice.call(arguments));
         }
     };
 
-    function addRootDir(path){
+    function addRootDir(path) {
         // check if it's the first one
         var is_default = false;
         if (!$('#whichDefaultRootDir').val().length) {
             is_default = true;
         }
 
-        $('#rootDirs').append('<option value="'+path+'">'+path+'</option>');
+        $('#rootDirs').append('<option value="' + path + '">' + path + '</option>');
 
         syncOptionIDs();
-        
+
         if (is_default) {
             setDefault($('#rootDirs option').attr('id'));
         }
@@ -45,11 +45,16 @@ $(document).ready(function(){
         }
 
         refreshRootDirs();
-        $.get(sbRoot+'/config/general/saveRootDirs', {rootDirString: $('#rootDirText').val()});
+        $.get(sbRoot + '/config/general/saveRootDirs', {rootDirString: $('#rootDirText').val()});
     }
-    
-    $('#addRootDir').click(function(){$(this).nFileBrowser(addRootDir);});
-    $('#editRootDir').click(function(){$(this).nFileBrowser(editRootDir, {initialDir: $("#rootDirs option:selected").val()});});
+
+    $('#addRootDir').click(function() {
+        $(this).nFileBrowser(addRootDir);
+    });
+
+    $('#editRootDir').click(function() {
+        $(this).nFileBrowser(editRootDir, {initialDir: $("#rootDirs option:selected").val()});
+    });
 
     $('#deleteRootDir').click(function() {
         if ($("#rootDirs option:selected").length) {
@@ -77,7 +82,7 @@ $(document).ready(function(){
             } else if ($("#whichDefaultRootDir").val().length) {
                 var old_default_num = $("#whichDefaultRootDir").val().substr(3);
                 if (old_default_num > deleted_num) {
-                    $("#whichDefaultRootDir").val('rd-' + (old_default_num-1));
+                    $("#whichDefaultRootDir").val('rd-' + (old_default_num - 1));
                 }
             }
 
@@ -86,7 +91,7 @@ $(document).ready(function(){
         $.get(sbRoot + '/config/general/saveRootDirs', {rootDirString: $('#rootDirText').val()});
     });
 
-    $('#defaultRootDir').click(function(){
+    $('#defaultRootDir').click(function() {
         if ($("#rootDirs option:selected").length) {
             setDefault($("#rootDirs option:selected").attr('id'));
         }
@@ -94,9 +99,12 @@ $(document).ready(function(){
         $.get(sbRoot + '/config/general/saveRootDirs', 'rootDirString=' + $('#rootDirText').val());
     });
 
-    function setDefault(which, force){
-
-        log('setting default to ' + which);
+    function setDefault(which, force) {
+        if (!force) {
+            log('setting default to ' + which);
+        } else {
+            log('initalized setting default to ' + which);
+        }
 
         if (which != undefined && !which.length) {
             return;
@@ -108,12 +116,12 @@ $(document).ready(function(){
 
         // put an asterisk on the text
         if ($('#' + which).text().charAt(0) != '*') {
-            $('#' + which).text('*' + $('#'+which).text());
+            $('#' + which).text('*' + $('#' + which).text());
         }
 
         // if there's an existing one then take the asterisk off
         if ($('#whichDefaultRootDir').val() && force != true) {
-            var old_default = $('#'+$('#whichDefaultRootDir').val());
+            var old_default = $('#' + $('#whichDefaultRootDir').val());
             old_default.text(old_default.text().substring(1));
         }
 
@@ -124,12 +132,11 @@ $(document).ready(function(){
         // re-sync option ids
         var i = 0;
         $('#rootDirs option').each(function() {
-            $(this).attr('id', 'rd-'+(i++));
+            $(this).attr('id', 'rd-' + (i++));
         });
     }
 
     function refreshRootDirs() {
-
         if (!$("#rootDirs").length) {
             return;
         }
@@ -154,19 +161,17 @@ $(document).ready(function(){
         $('#defaultRootDir').prop('disabled', do_disable);
         $('#editRootDir').prop('disabled', do_disable);
 
-        var log_str = '';
         var dir_text = '';
         if ($('#whichDefaultRootDir').val().length >= 4) {
             dir_text = $('#whichDefaultRootDir').val().substr(3);
         }
         $('#rootDirs option').each(function() {
-            log_str += $(this).val() + '=' + $(this).text() + '->' + $(this).attr('id') + '\n';
+            log($(this).val(), $(this).text(), $(this).attr('id'));
             if (dir_text.length) {
                 dir_text += '|' + $(this).val();
             }
         });
-        log_str += 'def: '+ $('#whichDefaultRootDir').val();
-        log(log_str);
+        // log('def: ' + $('#whichDefaultRootDir').val());
 
         $('#rootDirText').val(dir_text);
         $('#rootDirText').change();

--- a/sickbeard/browser.py
+++ b/sickbeard/browser.py
@@ -47,7 +47,7 @@ def getWinDrives():
     return drives
 
 
-def foldersAtPath(path, includeParent = False):
+def foldersAtPath(path, includeParent=False):
     """ Returns a list of dictionaries with the folders contained at the given path
         Give the empty string as the path to list the contents of the root path
         under Unix this means "/", on Windows this will be a list of drive letters)
@@ -81,6 +81,12 @@ def foldersAtPath(path, includeParent = False):
 
     fileList = [{ 'name': filename, 'path': ek.ek(os.path.join, path, filename) } for filename in ek.ek(os.listdir, path)]
     fileList = filter(lambda entry: ek.ek(os.path.isdir, entry['path']), fileList)
+
+    # prune out directories to proect the user from doing stupid things (already lower case the dir to reduce calls)
+    hideList = ["boot", "bootmgr", "cache", "msocache", "recovery", "$recycle.bin", "recycler", "system volume information", "temporary internet files"] # windows specific
+    hideList += [".fseventd", ".spotlight", ".trashes", ".vol", "cachedmessages", "caches", "trash"] # osx specific
+    fileList = filter(lambda entry: entry['name'].lower() not in hideList, fileList)
+
     fileList = sorted(fileList, lambda x, y: cmp(os.path.basename(x['name']).lower(), os.path.basename(y['path']).lower()))
 
     entries = [{'current_path': path}]
@@ -89,6 +95,7 @@ def foldersAtPath(path, includeParent = False):
     entries.extend(fileList)
 
     return entries
+
 
 class WebFileBrowser:
 


### PR DESCRIPTION
- Cleaned up the rootDir.js with regards to JSHint/JSLint.
- Replaced the console.log routine with one that is a bit better and only a few lines.
  
  > If we plan to use the console.log on other pages and want to support legacy IE I'd recommend that we go with: http://patik.com/blog/complete-cross-browser-console-log/
- Tweaked our browser/autocomplete routine so it prunes out known win and osx directories that serve no purpose to be used within sb (and would just result in issues)
