### PR TITLE
AddNewShow tvdb_api languages select fixed (would only contain the fallback 'en')

### DIFF
--- a/data/js/newShow.js
+++ b/data/js/newShow.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
 
     function populateSelect() {
-        if (!$('#nameToSearch').val().length) {
+        if (!$('#nameToSearch').length) {
             return;
         }
 


### PR DESCRIPTION
A previous change caused the tvdb languages select to not be populated
anymore. This happens when adding a new show from scratch. Reverting
back the culprit line.
