### PR TITLE
qualityChooser cleanup

### DIFF
--- a/data/interfaces/default/home_addExistingShow.tmpl
+++ b/data/interfaces/default/home_addExistingShow.tmpl
@@ -1,5 +1,4 @@
 #import os.path
-#import urllib
 #import sickbeard
 #from sickbeard.common import *
 #set global $title="Existing Show"
@@ -13,6 +12,7 @@
 
 <form id="addShowForm" method="post" action="$sbRoot/home/addShows/addNewShow" accept-charset="utf-8">
 
+<script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/addExistingShow.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/rootDirs.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/addShowOptions.js?$sbPID"></script> 

--- a/data/interfaces/default/home_newShow.tmpl
+++ b/data/interfaces/default/home_newShow.tmpl
@@ -1,5 +1,4 @@
 #import os.path
-#import urllib
 #import sickbeard
 #set global $title="New Show"
 
@@ -14,8 +13,8 @@
 <script type="text/javascript" src="$sbRoot/js/lib/formwizard.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
 <script type="text/javascript" src="$sbRoot/js/newShow.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/addShowOptions.js?$sbPID"></script> 
-   
+<script type="text/javascript" src="$sbRoot/js/addShowOptions.js?$sbPID"></script>
+
 <div id="displayText">aoeu</div>
 <br />
 
@@ -40,7 +39,7 @@
             <b>*</b> This will only affect the language of the retrieved metadata file contents and episode filenames.<br />
             This <b>DOES NOT</b> allow Sick Beard to download non-english TV episodes!<br />
             <br />
-            <div id="searchResults" style="max-height: 225px; overflow: auto;"></div>
+            <div id="searchResults" style="max-height: 225px; overflow: auto;"><br/></div>
         #end if
     </div>
 </fieldset>

--- a/data/interfaces/default/inc_qualityChooser.tmpl
+++ b/data/interfaces/default/inc_qualityChooser.tmpl
@@ -1,8 +1,6 @@
 #import sickbeard
 #from sickbeard.common import Quality, qualityPresets, qualityPresetStrings
 
-<script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
-
 <div class="field-pair">
     <label for="qualityPreset" class="nocheck clearfix">
 #set $overall_quality = $Quality.combineQualities($anyQualities, $bestQualities)
@@ -21,11 +19,10 @@
 </div>
 
 <div id="customQualityWrapper">
-
-<div id="customQuality">
-    <div class="component-group-desc">
-        <p>One of the <b>Initial</b> quality selections must be obtained before Sick Beard will attempt to process the <b>Archive</b> selections.</p>
-    </div>
+    <div id="customQuality">
+        <div class="component-group-desc">
+            <p>One of the <b>Initial</b> quality selections must be obtained before Sick Beard will attempt to process the <b>Archive</b> selections.</p>
+        </div>
 
         <div style="padding-right: 40px; text-align: center;" class="float-left">
             <h4>Initial</h4>

--- a/data/js/qualityChooser.js
+++ b/data/js/qualityChooser.js
@@ -1,29 +1,36 @@
-$(document).ready(function(){
+$(document).ready(function() {
     function setFromPresets (preset) {
         if (preset == 0) {
-          $('#customQuality').show();
-          return
-        } else
-          $('#customQuality').hide();
-    
+            $('#customQuality').show();
+            return;
+        } else {
+            $('#customQuality').hide();
+        }
+
         $('#anyQualities option').each(function(i) {
-            var result = preset & $(this).val()
-            if (result > 0) $(this).attr('selected', 'selected');
-            else $(this).attr('selected', false);
+            var result = preset & $(this).val();
+            if (result > 0) {
+                $(this).attr('selected', 'selected');
+            } else {
+                $(this).attr('selected', false);
+            }
         });
-    
+
         $('#bestQualities option').each(function(i) {
-            var result = preset & ($(this).val() << 16)
-            if (result > 0) $(this).attr('selected', 'selected');
-            else $(this).attr('selected', false);
+            var result = preset & ($(this).val() << 16);
+            if (result > 0) {
+                $(this).attr('selected', 'selected');
+            } else {
+                $(this).attr('selected', false);
+            }
         });
-    
-        return
+
+        return;
     }
-    
-    $('#qualityPreset').change(function(){
-          setFromPresets($('#qualityPreset :selected').val());
+
+    $('#qualityPreset').change(function() {
+        setFromPresets($('#qualityPreset :selected').val());
     });
-    
-    setFromPresets($('#qualityPreset :selected').val())
+
+    setFromPresets($('#qualityPreset :selected').val());
 });


### PR DESCRIPTION
- cleaned up the qualityChooser.js for readability and make jsHint a bit happier
- Removed unused import, cleaned up some misc whitespace and added some padding for the searching animation on the tvdb search (new show).
- We were importing qualityChooser.js in the inc_qualityChooser.tmpl and also in the newShow tmpl which resulted in a double loading the file..
  
  >  We should have a standard rule that we do not put javascript includes in the `inc_*.tmpl` files as it limits flexibility (not every page may need that .js let alone would be happy with its placement) and makes it harder to track down issues.
