### PR TITLE
filebrowser -- ignore junk folders

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -9,13 +9,13 @@ browser.css
   margin: 0;
 }
 #fileBrowserDialog ul li {
-  padding: 4px 0;
-  margin: 2px;
+  margin: 2px 0;
   list-style-type: none;
   cursor: pointer;
 }
 #fileBrowserDialog ul li a {
   display: block;
+  padding: 4px 0;
 }
 #fileBrowserDialog ul li a:hover {
   color: #00f;
@@ -356,7 +356,7 @@ home.tmpl
 /* =======================================================================
 home_postprocess.tmpl
 ========================================================================== */
-#episodeDir {
+#episodeDir, #newRootDir {
   margin-right: 6px;
 }
 
@@ -442,11 +442,6 @@ ul#rootDirStaticList li {
   margin: 2px;
   list-style: none outside none;
   cursor: pointer;
-}
-/* for tabs: manage directories */
-#rootDirs, #rootDirsControls {
-  width: 50%;
-  min-width: 400px;
 }
 /* for tabs: customize options */
 #tabs div.field-pair,

--- a/data/interfaces/default/inc_rootDirs.tmpl
+++ b/data/interfaces/default/inc_rootDirs.tmpl
@@ -3,7 +3,7 @@
 
 #if $sickbeard.ROOT_DIRS:
 #set $backend_pieces = $sickbeard.ROOT_DIRS.split('|')
-#set $backend_default = 'rd-'+$backend_pieces[0]
+#set $backend_default = 'rd-' + $backend_pieces[0]
 #set $backend_dirs = $backend_pieces[1:]
 #else:
 #set $backend_default = ''
@@ -11,14 +11,14 @@
 #end if
 
 <input type="hidden" id="whichDefaultRootDir" value="$backend_default" />
-<div style="padding-bottom: 5px; padding-top: 10px;">
-    <select name="rootDir" id="rootDirs" size="6" style="min-width: 400px;">
+<div style="padding: 10px 0 5px;">
+    <select name="rootDir" id="rootDirs" size="6" style="min-width: 500px;">
     #for $cur_dir in $backend_dirs:
         <option value="$cur_dir">$cur_dir</option>
     #end for
     </select>
 </div>
-<div id="rootDirsControls" style="text-align: center;">
+<div id="rootDirsControls" style="text-align: center; width: 500px;">
     <input class="btn" type="button" id="addRootDir" value="New" />
     <input class="btn" type="button" id="editRootDir" value="Edit" />
     <input class="btn" type="button" id="deleteRootDir" value="Delete" />

--- a/sickbeard/browser.py
+++ b/sickbeard/browser.py
@@ -47,7 +47,7 @@ def getWinDrives():
     return drives
 
 
-def foldersAtPath(path, includeParent = False):
+def foldersAtPath(path, includeParent=False):
     """ Returns a list of dictionaries with the folders contained at the given path
         Give the empty string as the path to list the contents of the root path
         under Unix this means "/", on Windows this will be a list of drive letters)
@@ -81,6 +81,12 @@ def foldersAtPath(path, includeParent = False):
 
     fileList = [{ 'name': filename, 'path': ek.ek(os.path.join, path, filename) } for filename in ek.ek(os.listdir, path)]
     fileList = filter(lambda entry: ek.ek(os.path.isdir, entry['path']), fileList)
+
+    # prune out directories to proect the user from doing stupid things (already lower case the dir to reduce calls)
+    hideList = ["boot", "bootmgr", "cache", "msocache", "recovery", "$recycle.bin", "recycler", "system volume information", "temporary internet files"] # windows specific
+    hideList += [".fseventd", ".spotlight", ".trashes", ".vol", "cachedmessages", "caches", "trash"] # osx specific
+    fileList = filter(lambda entry: entry['name'].lower() not in hideList, fileList)
+
     fileList = sorted(fileList, lambda x, y: cmp(os.path.basename(x['name']).lower(), os.path.basename(y['path']).lower()))
 
     entries = [{'current_path': path}]
@@ -89,6 +95,7 @@ def foldersAtPath(path, includeParent = False):
     entries.extend(fileList)
 
     return entries
+
 
 class WebFileBrowser:
 


### PR DESCRIPTION
- Tweaked our browser/autocomplete routine so it prunes out known win and osx directories that serve no purpose to be used within sb (and would just result in issues)
- Tweaked rootdir CSS slightly and fixed the accessibility outline on the filebrowser to look a bit nicer.
