### PR TITLE
Added support for notifications to XBMC v12 (Frodo) clients

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2027,11 +2027,8 @@ class Home:
     def testXBMC(self, host=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
-        result = notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(host), username, password)
-        if len(result.split(":")) > 2 and 'OK' in result.split(":")[2]:
-            return "Test notice sent successfully to "+urllib.unquote_plus(host)
-        else:
-            return "Test notice failed to "+urllib.unquote_plus(host)
+        #return notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(host), username, password)        
+        return notifiers.xbmc_notifier.update_library("Weeds")
 
     @cherrypy.expose
     def testPLEX(self, host=None, username=None, password=None):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2027,8 +2027,7 @@ class Home:
     def testXBMC(self, host=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
-        #return notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(host), username, password)        
-        return notifiers.xbmc_notifier.update_library("Weeds")
+        return notifiers.xbmc_notifier.test_notify(urllib.unquote_plus(host), username, password)        
 
     @cherrypy.expose
     def testPLEX(self, host=None, username=None, password=None):


### PR DESCRIPTION
XBMC Notifications now attempt to notify using the JSON API if they fail
to be successful using the HTTP API which is deprecated in versions
later than v12.

Also changed "Test XBMC" output to show more information about which
clients failed to connect
