### PR TITLE
XBMC 12 (Frodo) brings a new file naming convention

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -117,6 +117,7 @@ ROOT_DIRS = None
 USE_BANNER = None
 USE_LISTVIEW = None
 METADATA_XBMC = None
+METADATA_XBMCFRODO = None
 METADATA_MEDIABROWSER = None
 METADATA_PS3 = None
 METADATA_WDTV = None
@@ -352,7 +353,7 @@ def initialize(consoleLogging=True):
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, USE_SYNOINDEX, \
-                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
+                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_XBMCFRODO, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
                 ADD_SHOWS_WO_DIR
@@ -482,6 +483,8 @@ def initialize(consoleLogging=True):
 
             if METADATA_TYPE == 'xbmc':
                 old_metadata_class = metadata.xbmc.metadata_class
+            elif METADATA_TYPE == 'xbmcfrodo':
+                old_metadata_class = metadata.xbmcfrodo.metadata_class
             elif METADATA_TYPE == 'mediabrowser':
                 old_metadata_class = metadata.mediabrowser.metadata_class
             elif METADATA_TYPE == 'ps3':
@@ -509,6 +512,7 @@ def initialize(consoleLogging=True):
         # this is the normal codepath for metadata config
         else:
             METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0')
+            METADATA_XBMCFRODO = check_setting_str(CFG, 'General', 'metadata_xbmcfrodo', '0|0|0|0|0|0')
             METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0')
             METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0')
             METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0')
@@ -516,6 +520,7 @@ def initialize(consoleLogging=True):
             METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0')
 
             for cur_metadata_tuple in [(METADATA_XBMC, metadata.xbmc),
+                                       (METADATA_XBMCFRODO, metadata.xbmcfrodo),
                                        (METADATA_MEDIABROWSER, metadata.mediabrowser),
                                        (METADATA_PS3, metadata.ps3),
                                        (METADATA_WDTV, metadata.wdtv),
@@ -1008,6 +1013,7 @@ def save_config():
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()
+    new_config['General']['metadata_xbmcfrodo'] = metadata_provider_dict['XBMC (Frodo)'].get_config()
     new_config['General']['metadata_mediabrowser'] = metadata_provider_dict['MediaBrowser'].get_config()
     new_config['General']['metadata_ps3'] = metadata_provider_dict['Sony PS3'].get_config()
     new_config['General']['metadata_wdtv'] = metadata_provider_dict['WDTV'].get_config()

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['generic', 'helpers', 'xbmc', 'mediabrowser', 'synology', 'ps3', 'wdtv', 'tivo']
+__all__ = ['generic', 'helpers', 'xbmc', 'xbmcfrodo', 'mediabrowser', 'synology', 'ps3', 'wdtv', 'tivo']
 
 import sys
-import xbmc, mediabrowser, synology, ps3, wdtv, tivo
+import xbmc, xbmcfrodo, mediabrowser, synology, ps3, wdtv, tivo
 
 def available_generators():
     return filter(lambda x: x not in ('generic', 'helpers'), __all__)

--- a/sickbeard/metadata/xbmcfrodo.py
+++ b/sickbeard/metadata/xbmcfrodo.py
@@ -1,0 +1,102 @@
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+import sickbeard
+
+import generic
+import xbmc
+
+import os
+
+from sickbeard.common import XML_NSMAP
+from sickbeard import logger, exceptions, helpers
+from sickbeard.exceptions import ex
+from sickbeard import encodingKludge as ek
+
+from lib.tvdb_api import tvdb_api, tvdb_exceptions
+
+import xml.etree.cElementTree as etree
+
+class XBMCFrodoMetadata(xbmc.XBMCMetadata):
+    
+    def __init__(self,
+                 show_metadata=False,
+                 episode_metadata=False,
+                 poster=False,
+                 fanart=False,
+                 episode_thumbnails=False,
+                 season_thumbnails=False):
+
+        generic.GenericMetadata.__init__(self,
+                                         show_metadata,
+                                         episode_metadata,
+                                         poster,
+                                         fanart,
+                                         episode_thumbnails,
+                                         season_thumbnails)
+        
+        self.name = 'XBMC (Frodo)'
+
+        self.poster_name = "poster.jpg"
+        self.fanart_name = "fanart.jpg"
+
+        self.eg_show_metadata = "tvshow.nfo"
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
+        self.eg_fanart = "fanart.jpg"
+        self.eg_poster = "poster.jpg"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>-thumb.jpg"
+        self.eg_season_thumbnails = "season##-poster.jpg"
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. 
+		
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = ep_obj.location.rpartition(".")
+            if tbn_filename[0] == "":
+                tbn_filename = ep_obj.location + "-thumb.jpg"
+            else:
+                tbn_filename = tbn_filename[0] + "-thumb.jpg"
+        else:
+            return None
+        
+        return tbn_filename
+    
+    def get_season_thumb_path(self, show_obj, season):
+        """
+        Returns the full path to the file for a given season thumb.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_thumb_file_path = 'season-specials'
+        else:
+            season_thumb_file_path = 'season' + str(season).zfill(2)
+        
+        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path + '-poster.jpg')
+
+
+# present a standard "interface" from the module
+metadata_class = XBMCFrodoMetadata

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -847,7 +847,7 @@ class ConfigPostProcessing:
 
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
-                    xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
+                    xbmc_data=None, xbmc__frodo__data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
@@ -893,6 +893,7 @@ class ConfigPostProcessing:
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
+        sickbeard.metadata_provider_dict['XBMC (Frodo)'].set_config(xbmc__frodo__data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)
         sickbeard.metadata_provider_dict['Synology'].set_config(synology_data)
         sickbeard.metadata_provider_dict['Sony PS3'].set_config(sony_ps3_data)


### PR DESCRIPTION
XBMC 12 (Frodo) brings a new file naming convention (see http://wiki.xbmc.org/index.php?title=XBMC_v12_(Frodo)_FAQ#Local_images).

This adds basic support.
