### PR TITLE
Womble - Change RSS section from 'TV' to 'TV-x264'

### DIFF
--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -17,21 +17,17 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import sickbeard
+import generic
 
 from sickbeard import logger
-
 from sickbeard import tvcache
 
-import generic
 
 class WombleProvider(generic.NZBProvider):
 
     def __init__(self):
-
         generic.NZBProvider.__init__(self, "Womble's Index")
-
         self.cache = WombleCache(self)
-
         self.url = 'http://nzb.isasecret.com/'
 
     def isEnabled(self):
@@ -41,21 +37,14 @@ class WombleProvider(generic.NZBProvider):
 class WombleCache(tvcache.TVCache):
 
     def __init__(self, provider):
-
         tvcache.TVCache.__init__(self, provider)
-
         # only poll Womble's Index every 15 minutes max
         self.minTime = 15
 
-
     def _getRSSData(self):
-
-        url = self.provider.url + 'rss/?sec=TV&fr=false'
-
-        logger.log(u"Womble's Index cache update URL: "+ url, logger.DEBUG)
-
+        url = self.provider.url + 'rss/?sec=TV-x264&fr=false'
+        logger.log(u"Womble's Index cache update URL: " + url, logger.DEBUG)
         data = self.provider.getURL(url)
-
         return data
 
     def _checkAuth(self, data):


### PR DESCRIPTION
Switch from TV section to TV-x264. As 'TV' has not had any new content since Nov of 2011. Some minor pep8 cleanup as well.
