### PR TITLE
Use FQDN for thetvdb url

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1467,7 +1467,7 @@ class CMD_SickBeardSearchTVDB(ApiCall):
     def run(self):
         """ search for show at tvdb with a given string and language """
         if self.name and not self.tvdbid: # only name was given
-            baseURL = "http://thetvdb.com/api/GetSeries.php?"
+            baseURL = "http://www.thetvdb.com/api/GetSeries.php?"
             params = {"seriesname": str(self.name).encode('utf-8'), 'language': self.lang}
             finalURL = baseURL + urllib.urlencode(params)
             urlData = sickbeard.helpers.getURL(finalURL)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1497,7 +1497,7 @@ class NewHomeAddShows:
         if 'en' in result:
             del result[result.index('en')]
         result.sort()
-        result.insert(0,'en')
+        result.insert(0, 'en')
 
         return json.dumps({'results': result})
 
@@ -1510,7 +1510,7 @@ class NewHomeAddShows:
         if not lang or lang == 'null':
                 lang = "en"
 
-        baseURL = "http://thetvdb.com/api/GetSeries.php?"
+        baseURL = "http://www.thetvdb.com/api/GetSeries.php?"
         nameUTF8 = name.encode('utf-8')
 
         logger.log(u"Trying to find Show on thetvdb.com with: " + nameUTF8.decode('utf-8'), logger.DEBUG)
@@ -1532,7 +1532,7 @@ class NewHomeAddShows:
 
             finalURL = baseURL + urllib.urlencode(params)
 
-            logger.log(u"Searching for Show with searchterm: \'" + searchTerm.decode('utf-8')+ u"\' on URL " + finalURL, logger.DEBUG)
+            logger.log(u"Searching for Show with searchterm: \'" + searchTerm.decode('utf-8') + u"\' on URL " + finalURL, logger.DEBUG)
             urlData = helpers.getURL(finalURL)
 
             if urlData is None:
@@ -1546,7 +1546,7 @@ class NewHomeAddShows:
 
                 except Exception, e:
                     # use finalURL in log, because urlData can be too much information
-                    logger.log(u"Unable to parse XML for some reason: "+ex(e)+" from XML: "+finalURL, logger.ERROR)
+                    logger.log(u"Unable to parse XML for some reason: " + ex(e) + " from XML: " + finalURL, logger.ERROR)
                     series = ''
 
                 # add each result to our list


### PR DESCRIPTION
We should use the fully qualified domain name to prevent CDN/dns issues people have reported that http://thetvdb.com doesn't work for them while http://www.thetvdb.com does. Plus we already use www for other calls and as the 'base'. So these were just two oddball entries that weren't.

See: http://www.sickbeard.com/forums/viewtopic.php?f=3&t=6055&p=28691
