### PR TITLE
Remove superfluous POSTPROCESSER message when disabled

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -717,7 +717,8 @@ def initialize(consoleLogging=True):
         autoPostProcesserScheduler = scheduler.Scheduler(autoPostProcesser.PostProcesser(),
                                                      cycleTime=datetime.timedelta(minutes=10),
                                                      threadName="POSTPROCESSER",
-                                                     runImmediately=True)
+                                                     runImmediately=True,
+                                                     silent=True)
 
         backlogSearchScheduler = searchBacklog.BacklogSearchScheduler(searchBacklog.BacklogSearcher(),
                                                                       cycleTime=datetime.timedelta(minutes=get_backlog_cycle_time()),

--- a/sickbeard/autoPostProcesser.py
+++ b/sickbeard/autoPostProcesser.py
@@ -30,6 +30,8 @@ class PostProcesser():
         if not sickbeard.PROCESS_AUTOMATICALLY:
             return
 
+        logger.log(u"Starting new thread: POSTPROCESSER", logger.DEBUG)
+
         if not ek.ek(os.path.isdir, sickbeard.TV_DOWNLOAD_DIR):
             logger.log(u"Automatic post-processing attempted but dir "+sickbeard.TV_DOWNLOAD_DIR+" doesn't exist", logger.ERROR)
             return


### PR DESCRIPTION
Resolves issue 2080 by only announcing the thread when process_automatically
is checked ("Scan and Process" option).
