### PR TITLE
Hotfix for parsing XXIV to an episode number

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -178,6 +178,7 @@ class NameParser(object):
         if number.lower() == 'xiii': return 13
         if number.lower() == 'xiv': return 14
         if number.lower() == 'xv': return 15
+        if number.lower() == 'xxiv': return 24
 
         return int(number)
 


### PR DESCRIPTION
An item in some (all?) newsnab feeds: "imagine-nation - UNCHAIN BLADES
EXXIV 1080i HDTV MPA1.0 H.264-TrollHD" causes `_convert_number()` to throw a ValueError when it tries to convert XXIV to an int. The search for that provider bails out there, so if a user only has one provider, then they get the "No providers set up etc" error. 

A proper fix would require some ep_regexes wizardry, I think. The TV show is imagine-nation, an NHK World show from Japan. UNCHAIN BLADES EXXIV is the name of a game featured on the show. So if possible, the regex shouldn't take EXXIV as the ep_num.

Addresses issue [2201](http://code.google.com/p/sickbeard/issues/detail?id=2201).

I only added 24 as I'm not sure this is the right way to fix. Happy to add more, or add a proper conversion function.
