### PR TITLE
intFromRoman helper function - used by parser.py for ep_num

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -698,3 +698,25 @@ def backupVersionedFile(oldFile, version):
         if numTries >= 10:
             logger.log(u"Unable to back up "+oldFile+", please do it manually.")
             sys.exit(1)
+
+def intFromRoman(x):
+    # Roman Numerals
+    # 2010-06-15, Eljakim Schrijvers
+    mapping = [ ('cd',4*'c'),
+                ('xl',4*'x'),
+                ('iv',4*'i'),
+                ('d',5*'c'),
+                ('l',5*'x'),
+                ('v',5*'i'),
+                ('cm',9*'c'),
+                ('xc',9*'x'),
+                ('ix',9*'i')]
+
+    bignums = [ ('m',1000), ('c',100), ('x', 10), ('i',1) ]
+
+    for (shortv, longv) in mapping: x= x.replace(shortv, longv) ## reverse order needed
+    x = '+'.join(list(x))
+    for (character, word) in bignums: x = x.replace(character, str(word))
+    if x=='': x = '0'
+    return eval(x)
+    

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -25,6 +25,7 @@ import regexes
 import sickbeard
 
 from sickbeard import logger
+from sickbeard.helpers import intFromRoman
 
 class NameParser(object):
     def __init__(self, file_name=True):
@@ -162,23 +163,13 @@ class NameParser(object):
         if type(number) == int:
             return number
 
-        # the lazy way
-        if number.lower() == 'i': return 1
-        if number.lower() == 'ii': return 2
-        if number.lower() == 'iii': return 3
-        if number.lower() == 'iv': return 4
-        if number.lower() == 'v': return 5
-        if number.lower() == 'vi': return 6
-        if number.lower() == 'vii': return 7
-        if number.lower() == 'viii': return 8
-        if number.lower() == 'ix': return 9
-        if number.lower() == 'x': return 10
-        if number.lower() == 'xi': return 11
-        if number.lower() == 'xii': return 12
-        if number.lower() == 'xiii': return 13
-        if number.lower() == 'xiv': return 14
-        if number.lower() == 'xv': return 15
+        # will throw a NameError if not a 
+        # valid Roman numeral
+        conv = intFromRoman(number.lower())
 
+        if type(conv) == int:
+            return conv
+            
         return int(number)
 
     def parse(self, name):


### PR DESCRIPTION
Not sure if you want to go this far. I tested with the dodgy RSS item from nzb.su and manually from 1-10000. Tests passed.

Previously:

```
Feb-08 01:12:11 DEBUG    SEARCHQUEUE-RSS-SEARCH :: Adding item from RSS to cache: imagine-nation - UNCHAIN BLADES EXXIV 1080i HDTV MPA1.0 H.264-TrollHD
Feb-08 01:12:11 ERROR    SEARCHQUEUE-RSS-SEARCH :: Error while searching nzb.su, skipping: invalid literal for int() with base 10: 'XXIV'
Feb-08 01:12:11 DEBUG    SEARCHQUEUE-RSS-SEARCH :: Traceback (most recent call last):
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/search.py", line 157, in searchForNeededEpisodes
    curFoundResults = curProvider.searchRSS()
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/providers/generic.py", line 179, in searchRSS
    self.cache.updateCache()
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/tvcache.py", line 128, in updateCache
    self._parseItem(item)
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/tvcache.py", line 148, in _parseItem
    self._addCacheEntry(title, url)
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/tvcache.py", line 191, in _addCacheEntry
    parse_result = myParser.parse(curName)
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/name_parser/parser.py", line 207, in parse
    file_name_result = self._parse_string(base_file_name)
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/name_parser/parser.py", line 96, in _parse_string
    ep_num = self._convert_number(match.group('ep_num'))
  File "/SaturnV/Apps/src/Sick-Beard/sickbeard/name_parser/parser.py", line 182, in _convert_number
    return int(number)
ValueError: invalid literal for int() with base 10: 'XXIV'
```

After this patch:

```
Feb-08 05:33:39 DEBUG    SEARCHQUEUE-RSS-SEARCH :: Adding item from RSS to cache: imagine-nation - UNCHAIN BLADES EXXIV 1080i HDTV MPA1.0 H.264-TrollHD
Feb-08 05:33:39 DEBUG    SEARCHQUEUE-RSS-SEARCH :: Checking the cache to see if we already know the tvdb id of imagine-nation - UNCHAIN BLADES
Feb-08 05:33:39 DEBUG    SEARCHQUEUE-RSS-SEARCH :: cache.db: SELECT * FROM scene_names WHERE name = ? with args [u'imagine-nation.UNCHAIN.BLADES']
Feb-08 05:33:39 DEBUG    SEARCHQUEUE-RSS-SEARCH :: Cache lookup found 0, using that
Feb-08 05:33:39 DEBUG    SEARCHQUEUE-RSS-SEARCH :: cache.db: INSERT INTO nzb_su (name, season, episodes, tvrid, tvdbid, url, time, quality) VALUES (?,?,?,?,?,?,?,?) with args [u'imagine-nation - UNCHAIN BLADES EXXIV 1080i HDTV MPA1.0 H.264-TrollHD', 1, '|24|', 0, 0, u'https://nzb.su/getnzb/e2ca8562ba980b8bbdac192fa674c5f4.nzb&i=88477&r=a021d179d7257c9eec4b84NOTMINE', 1360272819, 32768]
```

Thing is, for this particular RSS feed item, it wasn't an ep_num. So, this is overkill for this issue.

Anyway, the helper function is there is you want it.

Thanks
James 
