### PR TITLE
Season and episode offsets

### DIFF
--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -87,6 +87,8 @@ replace with: <b><%=", ".join([Quality.qualityStrings[x] for x in bestQualities]
     </td></tr>
     <tr><td class="showLegend">Language:</td><td><img src="$sbRoot/images/flags/${show.lang}.png" width="16" height="11" alt="" /> $show.lang</td></tr>
     <tr><td class="showLegend">Flatten Folders: </td><td><img src="$sbRoot/images/#if $show.flatten_folders == 1 or $sickbeard.NAMING_FORCE_FOLDERS then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
+    <tr><td class="showLegend">Season Offset: </td><td>$show.seasonoffset</td></tr>
+    <tr><td class="showLegend">Episode Offset: </td><td>$show.episodeoffset</td></tr>
     <tr><td class="showLegend">Paused: </td><td><img src="$sbRoot/images/#if int($show.paused) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Air-by-Date: </td><td><img src="$sbRoot/images/#if int($show.air_by_date) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
 </table>

--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -66,6 +66,13 @@ This <b>DOES NOT</b> allow Sick Beard to download non-english TV episodes!<br />
 <br />
 <br />
 Flatten files (no folders): <input type="checkbox" name="flatten_folders" #if $show.flatten_folders == 1 and not $sickbeard.NAMING_FORCE_FOLDERS then "checked=\"checked\"" else ""# #if $sickbeard.NAMING_FORCE_FOLDERS then "disabled=\"disabled\"" else ""#/><br /><br />
+
+Season Offset: <input type="text" name="seasonoffset" id="seasonoffset" value="$show.seasonoffset" size="5" /><br />
+Episode Offset: <input type="text" name="episodeoffset" id="episodeoffset" value="$show.episodeoffset" size="5" /><br />
+Use these values to correct any differences in the numbering between 'the scene' and thetvdb.org. <br />
+<b>Example:</b> Having season offset set to -1 and episode offset set to 2, results in SickBeard searching for an episode with number S07E12, while SickBeard is looking for S08E10.<br />
+When using the SickBeard post processor, the values are corrected again. So you'll end up with the correct values and names for episodes.<br /><br />
+
 Paused: <input type="checkbox" name="paused" #if $show.paused == 1 then "checked=\"checked\"" else ""# /><br /><br />
 
 Air by date: 

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -536,3 +536,16 @@ class RenameSeasonFolders(AddSizeAndSceneNameFields):
         self.connection.action("DROP TABLE tmp_tv_shows")
 
         self.incDBVersion()
+
+class AddSeasonAndEpisodeOffset(RenameSeasonFolders):
+
+    def test(self):
+        return self.checkDBVersion() >= 12
+
+    def execute(self):
+
+        if self.hasColumn("tv_shows", "seasonoffset") is not True:
+            self.addColumn("tv_shows", "seasonoffset")
+            self.addColumn("tv_shows", "episodeoffset")
+
+        self.incDBVersion()

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -545,6 +545,15 @@ class PostProcessor(object):
                     season = 1
             
             if tvdb_id and season != None and episodes:
+                try:
+                    showObj = helpers.findCertainShow(sickbeard.showList, tvdb_id)
+                    if(showObj != None):
+                        season -= showObj.seasonoffset
+                        for curEp in episodes:
+                            curEp -= showObj.episodeoffset
+                except exceptions.MultipleShowObjectsException:
+                    raise #TODO: later I'll just log this, for now I want to know about it ASAP
+
                 return (tvdb_id, season, episodes)
     
         return (tvdb_id, season, episodes)

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Author: Daniël Heimans
+# Author: DaniÃ«l Heimans
 # URL: http://code.google.com/p/sickbeard
 #
 # This file is part of Sick Beard.
@@ -232,7 +232,7 @@ class BTNProvider(generic.TorrentProvider):
 
         else:
             # Do a general name search for the episode, formatted like SXXEYY
-            search_params['name'] = "S%02dE%02d" % (ep_obj.season,ep_obj.episode)
+            search_params['name'] = "S%02dE%02d" % (ep_obj.sceneseason,ep_obj.sceneepisode)
 
         to_return = [search_params]
 

--- a/sickbeard/providers/ezrss.py
+++ b/sickbeard/providers/ezrss.py
@@ -94,8 +94,8 @@ class EZRSSProvider(generic.TorrentProvider):
         if ep_obj.show.air_by_date:
             params['date'] = str(ep_obj.airdate)
         else:
-            params['season'] = ep_obj.season
-            params['episode'] = ep_obj.episode
+            params['season'] = ep_obj.sceneseason
+            params['episode'] = ep_obj.sceneepisode
     
         return [params]
 

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -255,7 +255,7 @@ class GenericProvider:
                 if parse_result.air_date != episode.airdate:
                     logger.log("Episode "+title+" didn't air on "+str(episode.airdate)+", skipping it", logger.DEBUG)
                     continue
-            elif parse_result.season_number != episode.season or episode.episode not in parse_result.episode_numbers:
+            elif parse_result.season_number != episode.sceneseason or episode.sceneepisode not in parse_result.episode_numbers:
                 logger.log("Episode "+title+" isn't "+str(episode.season)+"x"+str(episode.episode)+", skipping it", logger.DEBUG)
                 continue
 

--- a/sickbeard/providers/newzbin.py
+++ b/sickbeard/providers/newzbin.py
@@ -265,7 +265,7 @@ class NewzbinProvider(generic.NZBProvider):
 
         nameList = set(show_name_helpers.allPossibleShowNames(ep_obj.show))
         if not ep_obj.show.air_by_date:
-            searchStr = " OR ".join(['^"'+x+' - %dx%02d"'%(ep_obj.season, ep_obj.episode) for x in nameList])
+            searchStr = " OR ".join(['^"'+x+' - %dx%02d"'%(ep_obj.sceneseason, ep_obj.sceneepisode) for x in nameList])
         else:
             searchStr = " OR ".join(['^"'+x+' - '+str(ep_obj.airdate)+'"' for x in nameList])
         return [searchStr]

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -125,8 +125,8 @@ class NewznabProvider(generic.NZBProvider):
             params['season'] = date_str.partition('-')[0]
             params['ep'] = date_str.partition('-')[2].replace('-', '/')
         else:
-            params['season'] = ep_obj.season
-            params['ep'] = ep_obj.episode
+            params['season'] = ep_obj.sceneseason
+            params['ep'] = ep_obj.sceneepisode
 
         to_return = [params]
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -321,7 +321,7 @@ def findSeason(show, season):
             continue
 
         try:
-            curResults = curProvider.findSeasonResults(show, season)
+            curResults = curProvider.findSeasonResults(show, season + show.seasonoffset)
 
             # make a list of all the results for this provider
             for curEp in curResults:

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -179,8 +179,8 @@ def makeSceneSearchString (episode):
     if episode.show.air_by_date and episode.airdate != datetime.date.fromordinal(1):
         epStrings = [str(episode.airdate)]
     else:
-        epStrings = ["S%02iE%02i" % (int(episode.season), int(episode.episode)),
-                    "%ix%02i" % (int(episode.season), int(episode.episode))]
+        epStrings = ["S%02iE%02i" % (int(episode.sceneseason), int(episode.sceneepisode)),
+                    "%ix%02i" % (int(episode.sceneseason), int(episode.sceneepisode))]
 
     # for single-season shows just search for the show name
     if numseasons == 1:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -58,6 +58,8 @@ class TVShow(object):
         self.network = ""
         self.genre = ""
         self.runtime = 0
+        self.seasonoffset = 0
+        self.episodeoffset = 0
         self.quality = int(sickbeard.QUALITY_DEFAULT)
         self.flatten_folders = int(sickbeard.FLATTEN_FOLDERS_DEFAULT)
 
@@ -602,6 +604,8 @@ class TVShow(object):
             if self.air_by_date == None:
                 self.air_by_date = 0
 
+            self.seasonoffset = int(sqlResults[0]["seasonoffset"])
+            self.episodeoffset = int(sqlResults[0]["episodeoffset"])
             self.quality = int(sqlResults[0]["quality"])
             self.flatten_folders = int(sqlResults[0]["flatten_folders"])
             self.paused = int(sqlResults[0]["paused"])
@@ -819,6 +823,8 @@ class TVShow(object):
                         "quality": self.quality,
                         "airs": self.airs,
                         "status": self.status,
+                        "seasonoffset": self.seasonoffset,
+                        "episodeoffset": self.episodeoffset,
                         "flatten_folders": self.flatten_folders,
                         "paused": self.paused,
                         "air_by_date": self.air_by_date,
@@ -845,6 +851,8 @@ class TVShow(object):
         toReturn += "genre: " + self.genre + "\n"
         toReturn += "runtime: " + str(self.runtime) + "\n"
         toReturn += "quality: " + str(self.quality) + "\n"
+        toReturn += "seasonoffset: " + str(self.seasonoffset) + "\n"
+        toReturn += "episodeoffset: " + str(self.episodeoffset) + "\n"
         return toReturn
 
 
@@ -957,6 +965,9 @@ class TVEpisode(object):
         self.show = show
         self._location = file
 
+        self.sceneseason  = max(season  + show.seasonoffset , 0)
+        self.sceneepisode = max(episode + show.episodeoffset, 1)
+
         self.lock = threading.Lock()
 
         self.specifyEpisode(self.season, self.episode)
@@ -1066,6 +1077,8 @@ class TVEpisode(object):
                 self.name = sqlResults[0]["name"]
             self.season = season
             self.episode = episode
+            self.sceneseason  = max(season  + self.show.seasonoffset , 0)
+            self.sceneepisode = max(episode + self.show.episodeoffset, 1)
             self.description = sqlResults[0]["description"]
             if self.description == None:
                 self.description = ""

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -340,7 +340,7 @@ class TVCache():
         if not episode:
             sqlResults = myDB.select("SELECT * FROM "+self.providerID)
         else:
-            sqlResults = myDB.select("SELECT * FROM "+self.providerID+" WHERE tvdbid = ? AND season = ? AND episodes LIKE ?", [episode.show.tvdbid, episode.season, "%|"+str(episode.episode)+"|%"])
+            sqlResults = myDB.select("SELECT * FROM "+self.providerID+" WHERE tvdbid = ? AND season = ? AND episodes LIKE ?", [episode.show.tvdbid, episode.sceneseason, "%|"+str(episode.sceneepisode)+"|%"])
 
         # for each cache entry
         for curResult in sqlResults:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2267,7 +2267,7 @@ class Home:
         return result['description'] if result else 'Episode not found.'
 
     @cherrypy.expose
-    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, directCall=False, air_by_date=None, tvdbLang=None):
+    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], seasonoffset=None, episodeoffset=None, flatten_folders=None, paused=None, directCall=False, air_by_date=None, tvdbLang=None):
 
         if show == None:
             errString = "Invalid show ID: "+str(show)
@@ -2293,6 +2293,30 @@ class Home:
                 t.show = showObj
 
             return _munge(t)
+
+        errors = []
+        maxOffset = 10
+
+        try:
+            seasonoffset = int(seasonoffset)
+        except ValueError:
+            errors.append(seasonoffset + " is not a valid season offset value")
+            seasonoffset = showObj.seasonoffset
+
+        if seasonoffset < -maxOffset or seasonoffset > maxOffset:
+            errors.append("Season offset value should be between -10 and 10")
+            seasonoffset = showObj.seasonoffset
+
+        try:
+            episodeoffset = int(episodeoffset)
+        except ValueError:
+            errors.append(episodeoffset + " is not a valid episode offset value")
+            episodeoffset = showObj.episodeoffset
+
+        if episodeoffset < -maxOffset or episodeoffset > maxOffset:
+            errors.append("Episode offset value should be between -10 and 10")
+            episodeoffset = showObj.episodeoffset
+
 
         if flatten_folders == "on":
             flatten_folders = 1
@@ -2328,7 +2352,6 @@ class Home:
         if type(bestQualities) != list:
             bestQualities = [bestQualities]
 
-        errors = []
         with showObj.lock:
             newQuality = Quality.combineQualities(map(int, anyQualities), map(int, bestQualities))
             showObj.quality = newQuality
@@ -2342,6 +2365,8 @@ class Home:
                     errors.append("Unable to refresh this show: "+ex(e))
 
             showObj.paused = paused
+            showObj.seasonoffset = seasonoffset
+            showObj.episodeoffset = episodeoffset
             showObj.air_by_date = air_by_date
             showObj.lang = tvdb_lang
 


### PR DESCRIPTION
Implemented per-show season offset and episode offset for current search queries for differences between the 'scene' and thetvdb.org. Must be manually and personally maintained per show.

I tested with the SickBeard index and the post processor. When one does use sabnzb+ to postprocess, things could get ugly.

Furthermore, any future providers should be using the sceneseason and sceneepisode fields in the TVEpisode object in stead of the regular season and episode fields.

More information on google code:
http://code.google.com/p/sickbeard/issues/detail?id=1352

and the forum:
http://sickbeard.com/forums/viewtopic.php?f=8&t=6600
