### PR TITLE
Bugfix :: Postprocessing: nzbName and multiple videos in process folder caused files to be lost

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -94,6 +94,10 @@ def processDir (dirName, nzbName=None, recurse=False):
 
     remainingFolders = filter(lambda x: ek.ek(os.path.isdir, ek.ek(os.path.join, dirName, x)), fileList)
 
+    # If nzbName is set and there's more than one videofile in the folder, files will be lost (overwritten).
+    if nzbName != None and len(videoFiles) >= 2:
+        nzbName = None
+
     # process any files in the dir
     for cur_video_file_path in videoFiles:
 


### PR DESCRIPTION
Multiple videofiles in same folder and nzbName variable set, would lead to loss of files. All videofiles would be processed using the same parsing from the nzbName, leading to each videofile overwriting the previous one.
