### PR TITLE
NMJv2 Notifier - Improved

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -262,6 +262,92 @@
 
                     </fieldset>
                 </div><!-- /nmj component-group //-->
+				
+				<div class="component-group clearfix">
+                    <div class="component-group-desc">
+						<img class="notifier-icon" src="$sbRoot/images/notifiers/nmj.png" alt="" title="Networked Media Jukebox V2" />
+                        <h3><a href="http://www.popcornhour.com/" onclick="window.open(this.href, '_blank'); return false;">NMJv2</a></h3>
+                        <p>The Networked Media Jukebox, or NMJv2, is the official media jukebox interface made available for the Popcorn Hour 300 & 400-series.</p>
+                    </div>
+                    <fieldset class="component-group-list">
+                        <div class="field-pair">
+                            <input type="checkbox" class="enabler" name="use_nmjv2" id="use_nmjv2" #if $sickbeard.USE_NMJv2 then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="use_nmjv2">
+                                <span class="component-title">Enable</span>
+                                <span class="component-desc">Should Sick Beard send update commands to NMJv2?</span>
+                            </label>
+                        </div>
+
+                        <div id="content_use_nmjv2">
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Popcorn IP address</span>
+                                    <input type="text" name="nmjv2_host" id="nmjv2_host" value="$sickbeard.NMJv2_HOST" size="35" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">IP of Popcorn 300/400-series (eg. 192.168.1.100)</span>
+                                </label>
+                            </div>
+							<div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Database Location</span>
+									<span class="component-desc">
+										<INPUT TYPE="radio" NAME="nmjv2_dbloc" VALUE="local" class="radio" id="NMJV2_DBLOC_A" #if $sickbeard.NMJv2_DBLOC=="local" then "checked=\"checked\"" else ""# />PCH Local Media<br />
+									</span>
+                                </label>
+								    <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">
+										<INPUT TYPE="radio" NAME="nmjv2_dbloc" VALUE="network" class="radio" id="NMJV2_DBLOC_B" #if $sickbeard.NMJv2_DBLOC=="network" then "checked=\"checked\"" else ""#/>PCH Network Media
+									</span>
+                                </label>
+								</label>
+								<label class="nocheck clearfix">
+                                    <span class="component-title">Database Instance</span>
+                                    <span class="component-desc">
+									<select id="NMJv2db_instance">
+										<option value="0">#1 </option>
+										<option value="1">#2 </option>
+										<option value="2">#3 </option>
+										<option value="3">#4 </option>
+										<option value="4">#5 </option>
+										<option value="5">#6 </option>
+										<option value="6">#7 </option>
+									</select>
+									</span>
+                                </label>
+								<label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Adjust this value if the wrong database is selected.</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Find Database</span>
+									<input type="button" value="Find Database" id="settingsNMJv2" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">The Popcorn Hour device must be powered on.</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                <span class="component-title">NMJv2 Database</span>
+                                <input type="text" name="nmjv2_database" id="nmjv2_database" value="$sickbeard.NMJv2_DATABASE" size="35" #if $sickbeard.NMJv2_DATABASE then "readonly=\"readonly\"" else ""# /></label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Automatically filled via the 'Find Database' buttons.</span>
+                                </label>
+                            </div>
+						<div class="testNotification" id="testNMJv2-result">Click below to test.</div>
+						<input type="button" value="Test NMJv2" id="testNMJv2" />
+						<input type="submit" class="config_submitter" value="Save Changes" />
+                        </div><!-- /content_use_nmjv2 //-->
+
+                    </fieldset>
+                </div><!-- /nmjv2 component-group //-->
 
 
                 <div class="component-group clearfix">

--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -125,6 +125,48 @@ $(document).ready(function(){
         function (data){ $('#testNMJ-result').html(data); });
     });
 
+	$('#settingsNMJv2').click(function(){
+        if (!$('#nmjv2_host').val()) {
+            alert('Please fill in the Popcorn IP address');
+            $('#nmjv2_host').focus();
+            return;
+        }
+        $('#testNMJv2-result').html(loading);
+        var nmjv2_host = $('#nmjv2_host').val();
+		var nmjv2_dbloc;
+		var radios = document.getElementsByName("nmjv2_dbloc");
+		for (var i = 0; i < radios.length; i++){
+			if (radios[i].checked) {
+				nmjv2_dbloc=radios[i].value;
+				break;
+			}
+		}
+		
+        var nmjv2_dbinstance=$('#NMJv2db_instance').val();
+        $.get(sbRoot+"/home/settingsNMJv2", {'host': nmjv2_host,'dbloc': nmjv2_dbloc,'instance': nmjv2_dbinstance}, 
+        function (data){
+            if (data == null) {
+                $('#nmjv2_database').removeAttr('readonly');
+            }
+            var JSONData = $.parseJSON(data);
+            $('#testNMJv2-result').html(JSONData.message);
+            $('#nmjv2_database').val(JSONData.database);
+            
+            if (JSONData.database)
+                $('#nmjv2_database').attr('readonly', true);
+            else
+                $('#nmjv2_database').removeAttr('readonly');
+        });
+    });
+	
+    $('#testNMJv2').click(function(){
+        $('#testNMJv2-result').html(loading);
+        var nmjv2_host = $("#nmjv2_host").val();
+        
+        $.get(sbRoot+"/home/testNMJv2", {'host': nmjv2_host}, 
+        function (data){ $('#testNMJv2-result').html(data); });
+    });
+	
     $('#testTrakt').click(function(){
         $('#testTrakt-result').html(loading);
         var trakt_api = $("#trakt_api").val();

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -269,6 +269,11 @@ NMJ_MOUNT = None
 
 USE_SYNOINDEX = False
 
+USE_NMJv2 = False
+NMJv2_HOST = None
+NMJv2_DATABASE = None
+NMJv2_DBLOC = None
+
 USE_TRAKT = False
 TRAKT_USERNAME = None
 TRAKT_PASSWORD = None
@@ -338,7 +343,7 @@ def initialize(consoleLogging=True):
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
-                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
+                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, USE_SYNOINDEX, \
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
@@ -648,6 +653,12 @@ def initialize(consoleLogging=True):
         NMJ_HOST = check_setting_str(CFG, 'NMJ', 'nmj_host', '')
         NMJ_DATABASE = check_setting_str(CFG, 'NMJ', 'nmj_database', '')
         NMJ_MOUNT = check_setting_str(CFG, 'NMJ', 'nmj_mount', '')
+
+        CheckSection(CFG, 'NMJv2')
+        USE_NMJv2 = bool(check_setting_int(CFG, 'NMJv2', 'use_nmjv2', 0))
+        NMJv2_HOST = check_setting_str(CFG, 'NMJv2', 'nmjv2_host', '')
+        NMJv2_DATABASE = check_setting_str(CFG, 'NMJv2', 'nmjv2_database', '')
+        NMJ_DBLOC = check_setting_str(CFG, 'NMJv2', 'nmjv2_dbloc', '')
 
         CheckSection(CFG, 'Synology')
         USE_SYNOINDEX = bool(check_setting_int(CFG, 'Synology', 'use_synoindex', 0))
@@ -1128,6 +1139,12 @@ def save_config():
 
     new_config['Synology'] = {}
     new_config['Synology']['use_synoindex'] = int(USE_SYNOINDEX)
+
+    new_config['NMJv2'] = {}
+    new_config['NMJv2']['use_nmjv2'] = int(USE_NMJv2)
+    new_config['NMJv2']['nmjv2_host'] = NMJv2_HOST
+    new_config['NMJv2']['nmjv2_database'] = NMJv2_DATABASE
+    new_config['NMJv2']['nmjv2_dbloc'] = NMJv2_DBLOC
 
     new_config['Trakt'] = {}
     new_config['Trakt']['use_trakt'] = int(USE_TRAKT)

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -21,6 +21,7 @@ import sickbeard
 import xbmc
 import plex
 import nmj
+import nmjv2
 import synoindex
 import pytivo
 
@@ -42,6 +43,7 @@ xbmc_notifier = xbmc.XBMCNotifier()
 plex_notifier = plex.PLEXNotifier()
 nmj_notifier = nmj.NMJNotifier()
 synoindex_notifier = synoindex.synoIndexNotifier()
+nmjv2_notifier = nmjv2.NMJv2Notifier()
 pytivo_notifier = pytivo.pyTivoNotifier()
 # devices
 growl_notifier = growl.GrowlNotifier()
@@ -60,6 +62,7 @@ notifiers = [
     xbmc_notifier,
     plex_notifier,
     nmj_notifier,
+    nmjv2_notifier,
     synoindex_notifier,
     pytivo_notifier,
     growl_notifier,

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -1,0 +1,172 @@
+# Author: Jasper Lanting
+# Based on nmj.py by Nico Berlee: http://nico.berlee.nl/
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import urllib, urllib2,xml.dom.minidom
+from xml.dom.minidom import parseString
+import sickbeard
+import telnetlib
+import re
+import time
+
+from sickbeard import logger
+
+try:
+    import xml.etree.cElementTree as etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+
+
+class NMJv2Notifier:
+    
+    def notify_snatch(self, ep_name):
+        return False
+        #Not implemented: Start the scanner when snatched does not make any sense
+
+    def notify_download(self, ep_name):
+        self._notifyNMJ()
+
+    def test_notify(self, host):
+        return self._sendNMJ(host)
+
+    def notify_settings(self, host, dbloc, instance):
+        """
+        Retrieves the NMJv2 database location from Popcorn hour
+        
+        host: The hostname/IP of the Popcorn Hour server
+        dbloc: 'local' for PCH internal harddrive. 'network' for PCH network shares
+        instance: Allows for selection of different DB in case of multiple databases
+        
+        Returns: True if the settings were retrieved successfully, False otherwise
+        """
+        try:
+            url_loc = "http://" + host + ":8008/file_operation?arg0=list_user_storage_file&arg1=&arg2="+instance+"&arg3=20&arg4=true&arg5=true&arg6=true&arg7=all&arg8=name_asc&arg9=false&arg10=false"
+            req = urllib2.Request(url_loc)
+            handle1 = urllib2.urlopen(req)
+            response1 = handle1.read()
+            xml = parseString(response1)
+            time.sleep (300.0 / 1000.0)
+            for node in xml.getElementsByTagName('path'):
+                xmlTag=node.toxml();
+                xmlData=xmlTag.replace('<path>','').replace('</path>','').replace('[=]','')
+                url_db = "http://" + host + ":8008/metadata_database?arg0=check_database&arg1="+ xmlData
+                reqdb = urllib2.Request(url_db)
+                handledb = urllib2.urlopen(reqdb)
+                responsedb = handledb.read()
+                xmldb = parseString(responsedb)
+                returnvalue=xmldb.getElementsByTagName('returnValue')[0].toxml().replace('<returnValue>','').replace('</returnValue>','')
+                if returnvalue=="0":
+                    DB_path=xmldb.getElementsByTagName('database_path')[0].toxml().replace('<database_path>','').replace('</database_path>','').replace('[=]','')
+                    if dbloc=="local" and DB_path.find("localhost")>-1:
+                        sickbeard.NMJv2_HOST=host
+                        sickbeard.NMJv2_DATABASE=DB_path
+                        return True
+                    if dbloc=="network" and DB_path.find("://")>-1:
+                        sickbeard.NMJv2_HOST=host
+                        sickbeard.NMJv2_DATABASE=DB_path
+                        return True
+                        
+        except IOError, e:
+            logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))
+            return False
+        return False
+
+    def _sendNMJ(self, host):
+        """
+        Sends a NMJ update command to the specified machine
+        
+        host: The hostname/IP to send the request to (no port)
+        database: The database to send the requst to
+        mount: The mount URL to use (optional)
+        
+        Returns: True if the request succeeded, False otherwise
+        """
+        
+        #if a host is provided then attempt to open a handle to that URL
+        try:
+            url_scandir = "http://" + host + ":8008/metadata_database?arg0=update_scandir&arg1="+ sickbeard.NMJv2_DATABASE +"&arg2=&arg3=update_all"
+            logger.log(u"NMJ scan update command send to host: %s" % (host))
+            url_updatedb = "http://" + host + ":8008/metadata_database?arg0=scanner_start&arg1="+ sickbeard.NMJv2_DATABASE +"&arg2=background&arg3="
+            logger.log(u"Try to mount network drive via url: %s" % (host), logger.DEBUG)
+            prereq = urllib2.Request(url_scandir)
+            req = urllib2.Request(url_updatedb)
+            handle1 = urllib2.urlopen(prereq)
+            response1 = handle1.read()
+            time.sleep (300.0 / 1000.0)
+            handle2 = urllib2.urlopen(req)
+            response2 = handle2.read()
+        except IOError, e:
+            logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))
+            return False
+        try:            
+            et = etree.fromstring(response1)
+            result1 = et.findtext("returnValue")
+        except SyntaxError, e:
+             logger.log(u"Unable to parse XML returned from the Popcorn Hour: update_scandir, %s" % (e), logger.ERROR)
+             return False
+        try:            
+            et = etree.fromstring(response2)
+            result2 = et.findtext("returnValue")
+        except SyntaxError, e:
+            logger.log(u"Unable to parse XML returned from the Popcorn Hour: scanner_start, %s" % (e), logger.ERROR)
+            return False
+                
+        # if the result was a number then consider that an error
+        error_codes=["8","11","22","49","50","51","60"]
+        error_messages=["Invalid parameter(s)/argument(s)",
+                        "Invalid database path",
+                        "Insufficient size",
+                        "Database write error",
+                        "Database read error",
+                        "Open fifo pipe failed",
+                        "Read only file system"]
+        if int(result1) > 0:
+            index=error_codes.index(result1)
+            logger.log(u"Popcorn Hour returned an error: %s" % (error_messages[index]))
+            return False
+        else:
+            if int(result2) > 0:
+                index=error_codes.index(result2)
+                logger.log(u"Popcorn Hour returned an error: %s" % (error_messages[index]))
+                return False
+            else:
+                logger.log(u"NMJv2 started background scan")
+                return True
+
+    def _notifyNMJ(self, host=None, force=False):
+        """
+        Sends a NMJ update command based on the SB config settings
+        
+        host: The host to send the command to (optional, defaults to the host in the config)
+        database: The database to use (optional, defaults to the database in the config)
+        mount: The mount URL (optional, defaults to the mount URL in the config)
+        force: If True then the notification will be sent even if NMJ is disabled in the config
+        """
+        if not sickbeard.USE_NMJv2 and not force:
+            logger.log("Notification for NMJ scan update not enabled, skipping this notification", logger.DEBUG)
+            return False
+
+        # fill in omitted parameters
+        if not host:
+            host = sickbeard.NMJv2_HOST
+
+        logger.log(u"Sending scan command for NMJ ", logger.DEBUG)
+
+        return self._sendNMJ(host)
+
+notifier = NMJv2Notifier

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1150,6 +1150,7 @@ class ConfigNotifications:
                           use_pushover=None, pushover_notify_onsnatch=None, pushover_notify_ondownload=None, pushover_userkey=None,
                           use_libnotify=None, libnotify_notify_onsnatch=None, libnotify_notify_ondownload=None,
                           use_nmj=None, nmj_host=None, nmj_database=None, nmj_mount=None, use_synoindex=None,
+                          use_nmjv2=None, nmjv2_host=None, nmjv2_dbloc=None, nmjv2_database=None,
                           use_trakt=None, trakt_username=None, trakt_password=None, trakt_api=None,
                           use_pytivo=None, pytivo_notify_onsnatch=None, pytivo_notify_ondownload=None, pytivo_update_library=None,
                           pytivo_host=None, pytivo_share_name=None, pytivo_tivo_name=None,
@@ -1296,6 +1297,11 @@ class ConfigNotifications:
             use_synoindex = 1
         else:
             use_synoindex = 0
+            
+        if use_nmjv2 == "on":
+            use_nmjv2 = 1
+        else:
+            use_nmjv2 = 0
 
         if use_trakt == "on":
             use_trakt = 1
@@ -1397,6 +1403,11 @@ class ConfigNotifications:
         sickbeard.NMJ_MOUNT = nmj_mount
 
         sickbeard.USE_SYNOINDEX = use_synoindex
+
+        sickbeard.USE_NMJv2 = use_nmjv2
+        sickbeard.NMJv2_HOST = nmjv2_host
+        sickbeard.NMJv2_DATABASE = nmjv2_database
+        sickbeard.NMJv2_DBLOC = nmjv2_dbloc
 
         sickbeard.USE_TRAKT = use_trakt
         sickbeard.TRAKT_USERNAME = trakt_username
@@ -2112,6 +2123,26 @@ class Home:
             return '{"message": "Got settings from %(host)s", "database": "%(database)s", "mount": "%(mount)s"}' % {"host": host, "database": sickbeard.NMJ_DATABASE, "mount": sickbeard.NMJ_MOUNT}
         else:
             return '{"message": "Failed! Make sure your Popcorn is on and NMJ is running. (see Log & Errors -> Debug for detailed info)", "database": "", "mount": ""}'
+
+    @cherrypy.expose
+    def testNMJv2(self, host=None):
+        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
+        
+        result = notifiers.nmjv2_notifier.test_notify(urllib.unquote_plus(host))
+        if result:
+            return "Test notice sent successfully to "+urllib.unquote_plus(host)
+        else:
+            return "Test notice failed to "+urllib.unquote_plus(host)
+
+    @cherrypy.expose
+    def settingsNMJv2(self, host=None, dbloc=None,instance=None):
+        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
+        result = notifiers.nmjv2_notifier.notify_settings(urllib.unquote_plus(host),dbloc,instance)
+        if result:
+            return '{"message": "NMJ Database found at: %(host)s", "database": "%(database)s"}' % {"host": host, "database": sickbeard.NMJv2_DATABASE}
+        else:
+            return '{"message": "Unable to find NMJ Database at location: %(dbloc)s. Is the right location selected and PCH running?", "database": ""}' % {"dbloc": dbloc}
+
 
     @cherrypy.expose
     def testTrakt(self, api=None, username=None, password=None):


### PR DESCRIPTION
Notifier for the Networked Media Jukebox for the 300 and 400 series.
Now uses the NMJ API on the PCH to locate the database. No need to search the contents of the shares anymore.

Users need to select the DB location (local harddrive or network share), the Find Database button does the rest. For users with more then one Database: If the wrong database is selected the 'Database Instance' dropdown menu can be used to skip the first Nth DB occurences.
