### PR TITLE
Enhancement :: Show listings : Enable choice of sorting show lists by articles (the, a/an).

### DIFF
--- a/data/interfaces/default/comingEpisodes.tmpl
+++ b/data/interfaces/default/comingEpisodes.tmpl
@@ -33,7 +33,11 @@
     format: function(s) {
         if (s.indexOf('Loading...') == 0)
             return s.replace('Loading...','000');
-        return (s || '').replace(/^(The|A)\s/i,'');
+        #if not $sickbeard.SORT_ARTICLE:
+        return (s || '').replace(/^(The|A|An)\s/i,'');
+        #else:
+        return (s || '');
+        #end if
     },
     type: 'text'
 });

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -52,6 +52,14 @@
                         </div>
 
                         <div class="field-pair">
+                            <input type="checkbox" name="sort_article" id="sort_article" #if $sickbeard.SORT_ARTICLE then "checked=\"checked\"" else ""#/>
+                            <label class="clearfix" for="sort_article">
+                                <span class="component-title">Sort articles</span>
+                                <span class="component-desc">Include articles (The, A, An) when sorting show lists.</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <label class="nocheck clearfix" for="log_dir">
                                 <span class="component-title">Logging Directory</span>
                                 <input type="text" name="log_dir" id="log_dir" value="$sickbeard.LOG_DIR" size="35" />

--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -28,7 +28,11 @@
     format: function(s) {
         if (s.indexOf('Loading...') == 0)
             return s.replace('Loading...','000');
-        return (s || '').replace(/^(The|A)\s/i,'');
+        #if not $sickbeard.SORT_ARTICLE:
+        return (s || '').replace(/^(The|A|An)\s/i,'');
+        #else:
+        return (s || '');
+        #end if
     },
     type: 'text'
 });

--- a/data/interfaces/default/manage.tmpl
+++ b/data/interfaces/default/manage.tmpl
@@ -16,7 +16,11 @@
         return false;
     },
     format: function(s) {
-        return (s || '').replace(/^(The|A)\s/i,'');
+        #if not $sickbeard.SORT_ARTICLE:
+        return (s || '').replace(/^(The|A|An)\s/i,'');
+        #else:
+        return (s || '');
+        #end if
     },
     type: 'text'
 });

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -110,6 +110,7 @@ HTTPS_CERT = None
 HTTPS_KEY = None
 
 LAUNCH_BROWSER = None
+SORT_ARTICLE = None
 CACHE_DIR = None
 ACTUAL_CACHE_DIR = None
 ROOT_DIRS = None
@@ -332,7 +333,7 @@ def initialize(consoleLogging=True):
                 USE_TRAKT, TRAKT_USERNAME, TRAKT_PASSWORD, TRAKT_API, \
                 USE_PLEX, PLEX_NOTIFY_ONSNATCH, PLEX_NOTIFY_ONDOWNLOAD, PLEX_UPDATE_LIBRARY, \
                 PLEX_SERVER_HOST, PLEX_HOST, PLEX_USERNAME, PLEX_PASSWORD, \
-                showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, showList, loadingShowList, \
+                showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, SORT_ARTICLE, showList, loadingShowList, \
                 NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, BTN, BTN_API_KEY, TORRENTLEECH, TORRENTLEECH_KEY, \
                 TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
                 SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
@@ -382,6 +383,7 @@ def initialize(consoleLogging=True):
         WEB_USERNAME = check_setting_str(CFG, 'General', 'web_username', '')
         WEB_PASSWORD = check_setting_str(CFG, 'General', 'web_password', '')
         LAUNCH_BROWSER = bool(check_setting_int(CFG, 'General', 'launch_browser', 1))
+        SORT_ARTICLE = bool(check_setting_int(CFG, 'General', 'sort_article', 0))
 
         USE_API = bool(check_setting_int(CFG, 'General', 'use_api', 0))
         API_KEY = check_setting_str(CFG, 'General', 'api_key', '')
@@ -1004,7 +1006,7 @@ def save_config():
     new_config['General']['naming_abd_pattern'] = NAMING_ABD_PATTERN
     new_config['General']['naming_multi_ep'] = int(NAMING_MULTI_EP)
     new_config['General']['launch_browser'] = int(LAUNCH_BROWSER)
-
+    new_config['General']['sort_article'] = int(SORT_ARTICLE)
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -126,10 +126,12 @@ class Api:
         t = webserve.PageTemplate(file="apiBuilder.tmpl")
 
         def titler(x):
-            if not x:
+            if not x or sickbeard.SORT_ARTICLE:
                 return x
             if x.lower().startswith('a '):
                 x = x[2:]
+            elif x.lower().startswith('an '):
+                x = x[3:]
             elif x.lower().startswith('the '):
                 x = x[4:]
             return x

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -685,7 +685,8 @@ class ConfigGeneral:
     @cherrypy.expose
     def saveGeneral(self, log_dir=None, web_port=None, web_log=None, web_ipv6=None,
                     launch_browser=None, web_username=None, use_api=None, api_key=None,
-                    web_password=None, version_notify=None, enable_https=None, https_cert=None, https_key=None):
+                    web_password=None, version_notify=None, enable_https=None,
+                    https_cert=None, https_key=None, sort_article=None):
 
         results = []
 
@@ -709,10 +710,16 @@ class ConfigGeneral:
         else:
             version_notify = 0
 
+        if sort_article == "on":
+            sort_article = 1
+        else:
+            sort_article = 0
+
         if not config.change_LOG_DIR(log_dir):
             results += ["Unable to create directory " + os.path.normpath(log_dir) + ", log dir not changed."]
 
         sickbeard.LAUNCH_BROWSER = launch_browser
+        sickbeard.SORT_ARTICLE = sort_article
 
         sickbeard.WEB_PORT = int(web_port)
         sickbeard.WEB_IPV6 = web_ipv6
@@ -2300,12 +2307,14 @@ class Home:
             epCounts[curEpCat] += 1
 
         def titler(x):
-            if not x:
+            if not x or sickbeard.SORT_ARTICLE:
                 return x
             if x.lower().startswith('a '):
-                    x = x[2:]
+                x = x[2:]
+            elif x.lower().startswith('an '):
+                x = x[3:]
             elif x.lower().startswith('the '):
-                    x = x[4:]
+                x = x[4:]
             return x
         t.sortedShowList = sorted(sickbeard.showList, lambda x, y: cmp(titler(x.name), titler(y.name)))
 


### PR DESCRIPTION
Cosmetic enhancement.

Adds a setting to sort TV show lists using articles (the, a/an). Default is old behavior (ie. not including the articles when sorting).

When I look for a show I keep having to rethink what exactly I'm looking for. Used to folder lists and xbmc (optional setting, don't remember what default is) sorting with the articles. This patch gives people a choice.
