### PR TITLE
Try to re-register growl if send fails

### DIFF
--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -123,7 +123,13 @@ class GrowlNotifier:
             opts['port'] = pc[1]
             logger.log(u"Sending growl to "+opts['host']+":"+str(opts['port'])+": "+message)
             try:
-                return self._send_growl(opts, message)
+                if self._send_growl(opts, message):
+                    return True
+                else:
+                    if self._sendRegistration(host, password, 'Sickbeard'):
+                        return self._send_growl(opts, message)
+                    else:
+                        return False 
             except socket.error, e:
                 logger.log(u"Unable to send growl to "+opts['host']+":"+str(opts['port'])+": "+ex(e))
                 return False


### PR DESCRIPTION
Try to re-register growl if send fails.

It's needed because the message will not be shown if Sickbeard is not registered. If you use Snarl on Windows and restart it all Applications need to re-register or Notifications aren't shown. This change is to fix this issue.
