### PR TITLE
Bugfix :: Metatdata Season Thumbnail : Fixes bug that attempted retrieval of non-existent season 0 (Special) and skipped last season when a show lacks a season 0.

### DIFF
--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -569,9 +569,6 @@ class GenericMetadata():
             logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
             return result
     
-        #  How many seasons?
-        num_seasons = len(tvdb_show_obj)
-    
         # if we have no season banners then just finish
         if 'season' not in tvdb_show_obj['_banners'] or 'season' not in tvdb_show_obj['_banners']['season']:
             return result
@@ -582,7 +579,7 @@ class GenericMetadata():
         # Returns a nested dictionary of season art with the season
         # number as primary key. It's really overkill but gives the option
         # to present to user via ui to pick down the road.
-        for cur_season in range(num_seasons):
+        for cur_season in tvdb_show_obj:
 
             result[cur_season] = {}
             


### PR DESCRIPTION
This bug was discovered by luxmoggy; see [forum post](http://www.sickbeard.com/forums/viewtopic.php?f=4&t=6572).

Some show are missing thumbnails for the last season. This is because when retrieving the thumbnails a list of seasons is created using number of seasons and a range(0..n) (e.g. [0, 1, 2, 3, 4, 5]. When a show lacks a season 0, it will still create the list using the same range  starting point; Thereby creating a list containing a non-existent season 0 and missing the last season ([0, 1, 2, 3, 4]).

This patch drops creating a new list in favor of using the already existing list.
