### PR TITLE
Made checks for x264, h264, h.264 more liberally matching

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -137,17 +137,17 @@ class Quality:
 
         checkName = lambda list, func: func([re.search(x, name, re.I) for x in list])
 
-        if checkName(["(pdtv|hdtv|dsr|tvrip).(xvid|x264)"], all) and not checkName(["(720|1080)[pi]"], all):
+        if checkName(["(pdtv|hdtv|dsr|tvrip).(xvid|[xh]\.?264)"], all) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDTV
-        elif checkName(["(dvdrip|bdrip)(.ws)?.(xvid|divx|x264)"], any) and not checkName(["(720|1080)[pi]"], all):
+        elif checkName(["(dvdrip|bdrip)(.ws)?.(xvid|divx|[xh]\.?264)"], any) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDDVD
-        elif checkName(["720p", "hdtv", "x264"], all) or checkName(["hr.ws.pdtv.x264"], any):
+        elif checkName(["720p", "hdtv", "[xh]\.?264"], all) or checkName(["hr.ws.pdtv.x264"], any):
             return Quality.HDTV
-        elif checkName(["720p", "web.dl"], all) or checkName(["720p", "itunes", "h.?264"], all):
+        elif checkName(["720p", "web"], all) or checkName(["720p", "itunes", "h.?264"], all):
             return Quality.HDWEBDL
-        elif checkName(["720p", "bluray", "x264"], all) or checkName(["720p", "hddvd", "x264"], all):
+        elif checkName(["720p", "bluray", "[xh]\.?264"], all) or checkName(["720p", "hddvd", "[xh]\.?264"], all):
             return Quality.HDBLURAY
-        elif checkName(["1080p", "bluray", "x264"], all) or checkName(["1080p", "hddvd", "x264"], all):
+        elif checkName(["1080p", "bluray", "[xh]\.?264"], all) or checkName(["1080p", "hddvd", "[xh]\.?264"], all):
             return Quality.FULLHDBLURAY
         else:
             return Quality.UNKNOWN


### PR DESCRIPTION
Another attempt since the last request became too messy.

Please refer to closed pull request for details.
https://github.com/midgetspy/Sick-Beard/pull/526

Hope you will incorporate these minor improvements on the regular expression matching for 
quality profiles as they tolerate more diverse NZB naming styles without increasing the probability for false positives.
