### PR TITLE
Enhancement :: Config - Notifier - Plex : Expanded test functionality.

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -198,7 +198,7 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testPLEX-result">Click below to test.</div>
-                            <input type="button" class="btn" value="Test Plex Media Clients" id="testPLEX" />
+                            <input type="button" class="btn" value="Test Plex Media Hosts" id="testPLEX" />
                             <input type="submit" class="btn config_submitter" value="Save Changes" />
                         </div><!-- /content_use_plex -->
 

--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -32,10 +32,11 @@ $(document).ready(function () {
 
     $('#testPLEX').click(function () {
         $('#testPLEX-result').html(loading);
+        var plex_server_host = $("#plex_server_host").val();
         var plex_host = $("#plex_host").val();
         var plex_username = $("#plex_username").val();
         var plex_password = $("#plex_password").val();
-        $.get(sbRoot + "/home/testPLEX", {'host': plex_host, 'username': plex_username, 'password': plex_password},
+        $.get(sbRoot + "/home/testPLEX", {'server_host': plex_server_host, 'host': plex_host, 'username': plex_username, 'password': plex_password},
             function (data) { $('#testPLEX-result').html(data); });
     });
 

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -18,6 +18,7 @@
 
 import urllib
 import urllib2
+import socket
 import base64
 
 import sickbeard
@@ -144,6 +145,20 @@ class PLEXNotifier:
 
     def test_notify(self, host, username, password):
         return self._notify_pmc("Testing Plex notifications from Sick Beard", "Test Notification", host, username, password, force=True)
+
+    def test_server_connection(self, host):
+        logger.log(u"Testing connection to the Plex Media Server host: " + host, logger.MESSAGE)
+        url = "http://%s/library/sections" % host
+        try:
+            xml_sections = minidom.parse(urllib2.urlopen(url))
+        except (urllib2.URLError, urllib2.HTTPError, socket.timeout, socket.error, IOError), e:
+            logger.log(u"Error while trying to contact Plex Media Server: " + str(e).decode('utf-8'), logger.ERROR)
+            return False
+        sections = xml_sections.getElementsByTagName('Directory')
+        if not sections:
+            logger.log(u"Plex Media Server not running on: " + host, logger.MESSAGE)
+            return False
+        return True
 
     def update_library(self):
         """Handles updating the Plex Media Server host via HTTP API

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2098,17 +2098,31 @@ class Home:
         return finalResult
 
     @cherrypy.expose
-    def testPLEX(self, host=None, username=None, password=None):
+    def testPLEX(self, server_host=None, host=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
         finalResult = ''
-        for curHost in [x.strip() for x in host.split(",")]:
-            curResult = notifiers.plex_notifier.test_notify(urllib.unquote_plus(curHost), username, password)
-            if len(curResult.split(":")) > 2 and 'OK' in curResult.split(":")[2]:
-                finalResult += "Test Plex notice sent successfully to " + urllib.unquote_plus(curHost)
+
+        if server_host:
+            if notifiers.plex_notifier.test_server_connection(urllib.unquote_plus(server_host)):
+                finalResult += "Server: Successfully connected to " + urllib.unquote_plus(server_host)
             else:
-                finalResult += "Test Plex notice failed to " + urllib.unquote_plus(curHost)
-            finalResult += "<br />\n"
+                finalResult += "Server: Failed connecting to " + urllib.unquote_plus(server_host)
+        else:
+            finalResult += "No Plex Media Server IP:Port set, skipping..."
+
+        finalResult += "<br />\n"
+
+        if host:
+            for curHost in [x.strip() for x in host.split(",")]:
+                curResult = notifiers.plex_notifier.test_notify(urllib.unquote_plus(curHost), username, password)
+                if len(curResult.split(":")) > 2 and 'OK' in curResult.split(":")[2]:
+                    finalResult += "Client: Test Plex notice sent successfully to " + urllib.unquote_plus(curHost)
+                else:
+                    finalResult += "Client: Test Plex notice failed to " + urllib.unquote_plus(curHost)
+                finalResult += "<br />\n"
+        else:
+            finalResult += "No Plex Client IP:Port set, skipping.<br />\n"
 
         return finalResult
 


### PR DESCRIPTION
If someone wishes to update the Plex library, but don't want notifications, they only need server host; In which case the test button will error since it only tests client host connection.

This patch adds test function for server host and allows for empty client host value (or server host).

I've tested all failed connection scenarios, but not successful ones since I don't have a Plex installation to test with.
