### PR TITLE
Fix update via tarball for GITHUB recent url changes

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -459,7 +459,7 @@ class SourceUpdateManager(GitUpdateManager):
             logger.log(u"Unable to retrieve new version from "+tar_download_url+", can't update", logger.ERROR)
             return False
 
-        download_name = data.geturl().split('/')[-1]
+        download_name = data.geturl().split('/')[-1].split('?')[0]
 
         tar_download_path = os.path.join(sickbeard.PROG_DIR, download_name)
 


### PR DESCRIPTION
Github have changed something in tarball url adding some parameter like expiration date. The changes broke updating features via Tarball. This pull request fix the error during update process.
