### PR TITLE
Metadata change

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -469,7 +469,6 @@
 #set $cur_id = $GenericMetadata.makeID($cur_name)
 <div class="metadataDiv clearfix" id="$cur_id">
     <div class="metadata-options-wrapper">
-                <!-- IRC: TO BE DONE: Edit new metadata opsions here-->
         <h4>Create:</h4>
         <div class="metadata-options">
             <label for="${cur_id}_show_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_metadata" #if $cur_metadata_inst.show_metadata then "checked=\"checked\"" else ""#/>&nbsp;Show Metadata</label>

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -472,22 +472,34 @@
         <h4>Create:</h4>
         <div class="metadata-options">
             <label for="${cur_id}_show_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_metadata" #if $cur_metadata_inst.show_metadata then "checked=\"checked\"" else ""#/>&nbsp;Show Metadata</label>
+            <label for="${cur_id}_show_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_fanart" #if $cur_metadata_inst.show_fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
+            <label for="${cur_id}_show_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_poster" #if $cur_metadata_inst.show_poster then "checked=\"checked\"" else ""#/>&nbsp;Show Poster Image</label>
+            <label for="${cur_id}_show_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_banner" #if $cur_metadata_inst.show_banner then "checked=\"checked\"" else ""#/>&nbsp;Show Banner Image</label>
+            <label for="${cur_id}_season_all_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_fanart" #if $cur_metadata_inst.season_all_fanart then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Fanart</label>
+            <label for="${cur_id}_season_all_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_poster" #if $cur_metadata_inst.season_all_poster then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Poster</label>
+            <label for="${cur_id}_season_all_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_banner" #if $cur_metadata_inst.season_all_banner then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Banner</label>
+            <label for="${cur_id}_season_fanarts" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_fanarts" #if $cur_metadata_inst.season_fanarts then "checked=\"checked\"" else ""#/>&nbsp;Season Fanarts</label>
+            <label for="${cur_id}_season_posters" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_posters" #if $cur_metadata_inst.season_posters then "checked=\"checked\"" else ""#/>&nbsp;Season Posters</label>
+            <label for="${cur_id}_season_banners" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_banners" #if $cur_metadata_inst.season_banners then "checked=\"checked\"" else ""#/>&nbsp;Season Banners</label>
             <label for="${cur_id}_episode_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_metadata" #if $cur_metadata_inst.episode_metadata then "checked=\"checked\"" else ""#/>&nbsp;Episode Metadata</label>
-            <label for="${cur_id}_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_fanart" #if $cur_metadata_inst.fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
-            <label for="${cur_id}_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_poster" #if $cur_metadata_inst.poster then "checked=\"checked\"" else ""#/>&nbsp;Show Folder Image</label>
             <label for="${cur_id}_episode_thumbnails" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_thumbnails" #if $cur_metadata_inst.episode_thumbnails then "checked=\"checked\"" else ""#/>&nbsp;Episode Thumbnail</label>
-            <label for="${cur_id}_season_thumbnails" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_thumbnails" #if $cur_metadata_inst.season_thumbnails then "checked=\"checked\"" else ""#/>&nbsp;Season Thumbnail</label>
         </div>
     </div>
     <div class="metadata-example-wrapper">
         <h4>Results:</h4>
         <div class="metadata-example">
             <label for="${cur_id}_show_metadata"><span id="${cur_id}_eg_show_metadata">$cur_metadata_inst.eg_show_metadata</span></label>
+            <label for="${cur_id}_show_fanart"><span id="${cur_id}_eg_show_fanart">$cur_metadata_inst.eg_show_fanart</span></label>
+            <label for="${cur_id}_show_poster"><span id="${cur_id}_eg_show_poster">$cur_metadata_inst.eg_show_poster</span></label>
+            <label for="${cur_id}_show_banner"><span id="${cur_id}_eg_show_banner">$cur_metadata_inst.eg_show_banner</span></label>
+            <label for="${cur_id}_season_all_fanart"><span id="${cur_id}_eg_season_all_fanart">$cur_metadata_inst.eg_season_all_fanart</span></label>
+            <label for="${cur_id}_season_all_poster"><span id="${cur_id}_eg_season_all_poster">$cur_metadata_inst.eg_season_all_poster</span></label>
+            <label for="${cur_id}_season_all_banner"><span id="${cur_id}_eg_season_all_banner">$cur_metadata_inst.eg_season_all_banner</span></label>
+            <label for="${cur_id}_season_fanarts"><span id="${cur_id}_eg_season_fanarts">$cur_metadata_inst.eg_season_fanarts</span></label>
+            <label for="${cur_id}_season_posters"><span id="${cur_id}_eg_season_posters">$cur_metadata_inst.eg_season_posters</span></label>
+            <label for="${cur_id}_season_banners"><span id="${cur_id}_eg_season_banners">$cur_metadata_inst.eg_season_banners</span></label>
             <label for="${cur_id}_episode_metadata"><span id="${cur_id}_eg_episode_metadata">$cur_metadata_inst.eg_episode_metadata</span></label>
-            <label for="${cur_id}_fanart"><span id="${cur_id}_eg_fanart">$cur_metadata_inst.eg_fanart</span></label>
-            <label for="${cur_id}_poster"><span id="${cur_id}_eg_poster">$cur_metadata_inst.eg_poster</span></label>
             <label for="${cur_id}_episode_thumbnails"><span id="${cur_id}_eg_episode_thumbnails">$cur_metadata_inst.eg_episode_thumbnails</span></label>
-            <label for="${cur_id}_season_thumbnails"><span id="${cur_id}_eg_season_thumbnails">$cur_metadata_inst.eg_season_thumbnails</span></label>
         </div>
     </div>
 
@@ -499,7 +511,7 @@
                             <input type="checkbox" name="use_banner" id="use_banner" #if $sickbeard.USE_BANNER then "checked=checked" else ""#/>
                             <label class="clearfix" for="use_banner">
                                 <span class="component-title">Use Banners</span>
-                                <span class="component-desc">Use banners instead of posters for 'Show Folder Image'</span>
+                                <span class="component-desc">Use banners instead of posters for 'Show Folder Image' (not for XBMC)</span>
                             </label>
                         </div>
 

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -476,9 +476,9 @@
             <label for="${cur_id}_show_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_fanart" #if $cur_metadata_inst.show_fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
             <label for="${cur_id}_show_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_poster" #if $cur_metadata_inst.show_poster then "checked=\"checked\"" else ""#/>&nbsp;Show Poster Image</label>
             <label for="${cur_id}_show_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_banner" #if $cur_metadata_inst.show_banner then "checked=\"checked\"" else ""#/>&nbsp;Show Banner Image</label>
-            <label for="${cur_id}_seasons_all_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_seasons_all_fanart" #if $cur_metadata_inst.seasons_all_fanart then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Fanart</label>
-            <label for="${cur_id}_seasons_all_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_seasons_all_poster" #if $cur_metadata_inst.seasons_all_poster then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Poster</label>
-            <label for="${cur_id}_seasons_all_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_seasons_all_banner" #if $cur_metadata_inst.seasons_all_banner then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Banner</label>
+            <label for="${cur_id}_season_all_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_fanart" #if $cur_metadata_inst.season_all_fanart then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Fanart</label>
+            <label for="${cur_id}_season_all_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_poster" #if $cur_metadata_inst.season_all_poster then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Poster</label>
+            <label for="${cur_id}_season_all_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_banner" #if $cur_metadata_inst.season_all_banner then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Banner</label>
             <label for="${cur_id}_season_fanarts" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_fanarts" #if $cur_metadata_inst.season_fanarts then "checked=\"checked\"" else ""#/>&nbsp;Season Fanarts</label>
             <label for="${cur_id}_season_posters" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_posters" #if $cur_metadata_inst.season_posters then "checked=\"checked\"" else ""#/>&nbsp;Season Posters</label>
             <label for="${cur_id}_season_banners" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_banners" #if $cur_metadata_inst.season_banners then "checked=\"checked\"" else ""#/>&nbsp;Season Banners</label>
@@ -493,9 +493,9 @@
             <label for="${cur_id}_show_fanart"><span id="${cur_id}_eg_show_fanart">$cur_metadata_inst.eg_show_fanart</span></label>
             <label for="${cur_id}_show_poster"><span id="${cur_id}_eg_show_poster">$cur_metadata_inst.eg_show_poster</span></label>
             <label for="${cur_id}_show_banner"><span id="${cur_id}_eg_show_banner">$cur_metadata_inst.eg_show_banner</span></label>
-            <label for="${cur_id}_seasons_all_fanart"><span id="${cur_id}_eg_seasons_all_fanart">$cur_metadata_inst.eg_seasons_all_fanart</span></label>
-            <label for="${cur_id}_seasons_all_poster"><span id="${cur_id}_eg_seasons_all_poster">$cur_metadata_inst.eg_seasons_all_poster</span></label>
-            <label for="${cur_id}_seasons_all_banner"><span id="${cur_id}_eg_seasons_all_banner">$cur_metadata_inst.eg_seasons_all_banner</span></label>
+            <label for="${cur_id}_season_all_fanart"><span id="${cur_id}_eg_seasons_all_fanart">$cur_metadata_inst.eg_seasons_all_fanart</span></label>
+            <label for="${cur_id}_season_all_poster"><span id="${cur_id}_eg_seasons_all_poster">$cur_metadata_inst.eg_seasons_all_poster</span></label>
+            <label for="${cur_id}_season_all_banner"><span id="${cur_id}_eg_seasons_all_banner">$cur_metadata_inst.eg_seasons_all_banner</span></label>
             <label for="${cur_id}_season_fanarts"><span id="${cur_id}_eg_season_fanarts">$cur_metadata_inst.eg_season_fanarts</span></label>
             <label for="${cur_id}_season_posters"><span id="${cur_id}_eg_season_posters">$cur_metadata_inst.eg_season_posters</span></label>
             <label for="${cur_id}_season_banners"><span id="${cur_id}_eg_season_banners">$cur_metadata_inst.eg_season_banners</span></label>

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -469,25 +469,38 @@
 #set $cur_id = $GenericMetadata.makeID($cur_name)
 <div class="metadataDiv clearfix" id="$cur_id">
     <div class="metadata-options-wrapper">
+                <!-- IRC: TO BE DONE: Edit new metadata opsions here-->
         <h4>Create:</h4>
         <div class="metadata-options">
             <label for="${cur_id}_show_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_metadata" #if $cur_metadata_inst.show_metadata then "checked=\"checked\"" else ""#/>&nbsp;Show Metadata</label>
+            <label for="${cur_id}_show_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_fanart" #if $cur_metadata_inst.show_fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
+            <label for="${cur_id}_show_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_poster" #if $cur_metadata_inst.show_poster then "checked=\"checked\"" else ""#/>&nbsp;Show Poster Image</label>
+            <label for="${cur_id}_show_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_banner" #if $cur_metadata_inst.show_banner then "checked=\"checked\"" else ""#/>&nbsp;Show Banner Image</label>
+            <label for="${cur_id}_seasons_all_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_seasons_all_fanart" #if $cur_metadata_inst.seasons_all_fanart then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Fanart</label>
+            <label for="${cur_id}_seasons_all_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_seasons_all_poster" #if $cur_metadata_inst.seasons_all_poster then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Poster</label>
+            <label for="${cur_id}_seasons_all_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_seasons_all_banner" #if $cur_metadata_inst.seasons_all_banner then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Banner</label>
+            <label for="${cur_id}_season_fanarts" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_fanarts" #if $cur_metadata_inst.season_fanarts then "checked=\"checked\"" else ""#/>&nbsp;Season Fanarts</label>
+            <label for="${cur_id}_season_posters" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_posters" #if $cur_metadata_inst.season_posters then "checked=\"checked\"" else ""#/>&nbsp;Season Posters</label>
+            <label for="${cur_id}_season_banners" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_banners" #if $cur_metadata_inst.season_banners then "checked=\"checked\"" else ""#/>&nbsp;Season Banners</label>
             <label for="${cur_id}_episode_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_metadata" #if $cur_metadata_inst.episode_metadata then "checked=\"checked\"" else ""#/>&nbsp;Episode Metadata</label>
-            <label for="${cur_id}_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_fanart" #if $cur_metadata_inst.fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
-            <label for="${cur_id}_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_poster" #if $cur_metadata_inst.poster then "checked=\"checked\"" else ""#/>&nbsp;Show Folder Image</label>
             <label for="${cur_id}_episode_thumbnails" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_thumbnails" #if $cur_metadata_inst.episode_thumbnails then "checked=\"checked\"" else ""#/>&nbsp;Episode Thumbnail</label>
-            <label for="${cur_id}_season_thumbnails" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_thumbnails" #if $cur_metadata_inst.season_thumbnails then "checked=\"checked\"" else ""#/>&nbsp;Season Thumbnail</label>
         </div>
     </div>
     <div class="metadata-example-wrapper">
         <h4>Results:</h4>
         <div class="metadata-example">
             <label for="${cur_id}_show_metadata"><span id="${cur_id}_eg_show_metadata">$cur_metadata_inst.eg_show_metadata</span></label>
+            <label for="${cur_id}_show_fanart"><span id="${cur_id}_eg_show_fanart">$cur_metadata_inst.eg_show_fanart</span></label>
+            <label for="${cur_id}_show_poster"><span id="${cur_id}_eg_show_poster">$cur_metadata_inst.eg_show_poster</span></label>
+            <label for="${cur_id}_show_banner"><span id="${cur_id}_eg_show_banner">$cur_metadata_inst.eg_show_banner</span></label>
+            <label for="${cur_id}_seasons_all_fanart"><span id="${cur_id}_eg_seasons_all_fanart">$cur_metadata_inst.eg_seasons_all_fanart</span></label>
+            <label for="${cur_id}_seasons_all_poster"><span id="${cur_id}_eg_seasons_all_poster">$cur_metadata_inst.eg_seasons_all_poster</span></label>
+            <label for="${cur_id}_seasons_all_banner"><span id="${cur_id}_eg_seasons_all_banner">$cur_metadata_inst.eg_seasons_all_banner</span></label>
+            <label for="${cur_id}_season_fanarts"><span id="${cur_id}_eg_season_fanarts">$cur_metadata_inst.eg_season_fanarts</span></label>
+            <label for="${cur_id}_season_posters"><span id="${cur_id}_eg_season_posters">$cur_metadata_inst.eg_season_posters</span></label>
+            <label for="${cur_id}_season_banners"><span id="${cur_id}_eg_season_banners">$cur_metadata_inst.eg_season_banners</span></label>
             <label for="${cur_id}_episode_metadata"><span id="${cur_id}_eg_episode_metadata">$cur_metadata_inst.eg_episode_metadata</span></label>
-            <label for="${cur_id}_fanart"><span id="${cur_id}_eg_fanart">$cur_metadata_inst.eg_fanart</span></label>
-            <label for="${cur_id}_poster"><span id="${cur_id}_eg_poster">$cur_metadata_inst.eg_poster</span></label>
             <label for="${cur_id}_episode_thumbnails"><span id="${cur_id}_eg_episode_thumbnails">$cur_metadata_inst.eg_episode_thumbnails</span></label>
-            <label for="${cur_id}_season_thumbnails"><span id="${cur_id}_eg_season_thumbnails">$cur_metadata_inst.eg_season_thumbnails</span></label>
         </div>
     </div>
 
@@ -499,7 +512,7 @@
                             <input type="checkbox" name="use_banner" id="use_banner" #if $sickbeard.USE_BANNER then "checked=checked" else ""#/>
                             <label class="clearfix" for="use_banner">
                                 <span class="component-title">Use Banners</span>
-                                <span class="component-desc">Use banners instead of posters for 'Show Folder Image'</span>
+                                <span class="component-desc">Use banners instead of posters for 'Show Folder Image' (not for XBMC)</span>
                             </label>
                         </div>
 

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -493,9 +493,9 @@
             <label for="${cur_id}_show_fanart"><span id="${cur_id}_eg_show_fanart">$cur_metadata_inst.eg_show_fanart</span></label>
             <label for="${cur_id}_show_poster"><span id="${cur_id}_eg_show_poster">$cur_metadata_inst.eg_show_poster</span></label>
             <label for="${cur_id}_show_banner"><span id="${cur_id}_eg_show_banner">$cur_metadata_inst.eg_show_banner</span></label>
-            <label for="${cur_id}_season_all_fanart"><span id="${cur_id}_eg_seasons_all_fanart">$cur_metadata_inst.eg_seasons_all_fanart</span></label>
-            <label for="${cur_id}_season_all_poster"><span id="${cur_id}_eg_seasons_all_poster">$cur_metadata_inst.eg_seasons_all_poster</span></label>
-            <label for="${cur_id}_season_all_banner"><span id="${cur_id}_eg_seasons_all_banner">$cur_metadata_inst.eg_seasons_all_banner</span></label>
+            <label for="${cur_id}_season_all_fanart"><span id="${cur_id}_eg_season_all_fanart">$cur_metadata_inst.eg_season_all_fanart</span></label>
+            <label for="${cur_id}_season_all_poster"><span id="${cur_id}_eg_season_all_poster">$cur_metadata_inst.eg_season_all_poster</span></label>
+            <label for="${cur_id}_season_all_banner"><span id="${cur_id}_eg_season_all_banner">$cur_metadata_inst.eg_season_all_banner</span></label>
             <label for="${cur_id}_season_fanarts"><span id="${cur_id}_eg_season_fanarts">$cur_metadata_inst.eg_season_fanarts</span></label>
             <label for="${cur_id}_season_posters"><span id="${cur_id}_eg_season_posters">$cur_metadata_inst.eg_season_posters</span></label>
             <label for="${cur_id}_season_banners"><span id="${cur_id}_eg_season_banners">$cur_metadata_inst.eg_season_banners</span></label>

--- a/data/js/configPostProcessing.js
+++ b/data/js/configPostProcessing.js
@@ -205,18 +205,34 @@ $(document).ready(function () {
 
             var config_arr = [];
             var show_metadata = $("#" + generator_name + "_show_metadata").prop('checked');
+            var show_fanart = $("#" + generator_name + "_show_fanart").prop('checked');
+            var show_poster = $("#" + generator_name + "_show_poster").prop('checked');
+            var show_banner = $("#" + generator_name + "_show_banner").prop('checked');
+            var season_all_fanart = $("#" + generator_name + "_season_all_fanart").prop('checked');
+            var season_all_poster = $("#" + generator_name + "_season_all_poster").prop('checked');
+            var season_all_banner = $("#" + generator_name + "_season_all_banner").prop('checked');
+
+            var season_fanarts = $("#" + generator_name + "_season_fanarts").prop('checked');
+            var season_posters = $("#" + generator_name + "_season_posters").prop('checked');
+            var season_banners = $("#" + generator_name + "_season_banners").prop('checked');
+
             var episode_metadata = $("#" + generator_name + "_episode_metadata").prop('checked');
-            var fanart = $("#" + generator_name + "_fanart").prop('checked');
-            var poster = $("#" + generator_name + "_poster").prop('checked');
             var episode_thumbnails = $("#" + generator_name + "_episode_thumbnails").prop('checked');
-            var season_thumbnails = $("#" + generator_name + "_season_thumbnails").prop('checked');
 
             config_arr.push(show_metadata ? '1' : '0');
-            config_arr.push(episode_metadata ? '1' : '0');
-            config_arr.push(poster ? '1' : '0');
-            config_arr.push(fanart ? '1' : '0');
+            config_arr.push(show_fanart ? '1' : '0');
+            config_arr.push(show_poster ? '1' : '0');
+            config_arr.push(show_banner ? '1' : '0');
+            config_arr.push(season_all_fanart ? '1' : '0');
+            config_arr.push(season_all_poster ? '1' : '0');
+            config_arr.push(season_all_banner ? '1' : '0');
+
+            config_arr.push(season_fanarts ? '1' : '0');
+            config_arr.push(season_posters ? '1' : '0');
+            config_arr.push(season_banners ? '1' : '0');
+
             config_arr.push(episode_thumbnails ? '1' : '0');
-            config_arr.push(season_thumbnails ? '1' : '0');
+            config_arr.push(episode_metadata ? '1' : '0');
 
             var cur_num = 0;
             for (var i = 0; i < config_arr.length; i++)
@@ -227,11 +243,20 @@ $(document).ready(function () {
             }
 
             $("#" + generator_name + "_eg_show_metadata").attr('class', show_metadata ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_show_fanart").attr('class', show_fanart ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_show_poster").attr('class', show_poster ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_show_banner").attr('class', show_banner ? 'enabled' : 'disabled');
+
+            $("#" + generator_name + "_eg_season_all_fanart").attr('class', season_all_fanart ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_all_poster").attr('class', season_all_poster ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_all_banner").attr('class', season_all_banner ? 'enabled' : 'disabled');
+
+            $("#" + generator_name + "_eg_season_fanarts").attr('class', season_fanarts ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_posters").attr('class', season_posters ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_banners").attr('class', season_banners ? 'enabled' : 'disabled');
+
             $("#" + generator_name + "_eg_episode_metadata").attr('class', episode_metadata ? 'enabled' : 'disabled');
-            $("#" + generator_name + "_eg_poster").attr('class', poster ? 'enabled' : 'disabled');
-            $("#" + generator_name + "_eg_fanart").attr('class', fanart ? 'enabled' : 'disabled');
             $("#" + generator_name + "_eg_episode_thumbnails").attr('class', episode_thumbnails ? 'enabled' : 'disabled');
-            $("#" + generator_name + "_eg_season_thumbnails").attr('class', season_thumbnails ? 'enabled' : 'disabled');
             $("#" + generator_name + "_data").val(config_arr.join('|'))
 
         });

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -816,6 +816,22 @@ class Tvdb:
         for cur_ep in epsEt.findall("Episode"):
             seas_no = int(cur_ep.find('SeasonNumber').text)
             ep_no = int(cur_ep.find('EpisodeNumber').text)
+            #American Dad!
+            if sid == 73141:
+                if seas_no == 2:
+                    seas_no = 1
+                    ep_no = ep_no + 7
+                if seas_no > 2:
+                    seas_no=seas_no - 1
+            #Kitchen Nightmares (US)
+            if sid == 80552:
+                if seas_no > 1:
+                    seas_no = seas_no + 1
+                if seas_no == 1:
+                    if ep_no > 10:
+                        seas_no = 2
+                        ep_no = ep_no - 10
+
             for cur_item in cur_ep.getchildren():
                 tag = cur_item.tag.lower()
                 value = cur_item.text

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -816,6 +816,9 @@ class Tvdb:
         for cur_ep in epsEt.findall("Episode"):
             seas_no = int(cur_ep.find('SeasonNumber').text)
             ep_no = int(cur_ep.find('EpisodeNumber').text)
+            #Fix the Season and Episide numbers as TVDB
+            #out of sync with other sources
+            #is able to download the correct episodes from NZBs
             #American Dad!
             if sid == 73141:
                 if seas_no == 2:

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -458,8 +458,6 @@ def initialize(consoleLogging=True):
         METADATA_TYPE = check_setting_str(CFG, 'General', 'metadata_type', '')
 
         metadata_provider_dict = metadata.get_metadata_generator_dict()
-    	# do be edited more first run?
-		# IRC: TO BE DONE
         # if this exists it's legacy, use the info to upgrade metadata to the new settings
         if METADATA_TYPE:
 
@@ -473,7 +471,7 @@ def initialize(consoleLogging=True):
                 old_metadata_class = metadata.ps3.metadata_class
 
             if old_metadata_class:
-				#fix to new options
+                # fix to new options
                 METADATA_SHOW = bool(check_setting_int(CFG, 'General', 'metadata_show', 1))
                 METADATA_EPISODE = bool(check_setting_int(CFG, 'General', 'metadata_episode', 1))
 
@@ -503,7 +501,6 @@ def initialize(consoleLogging=True):
         else:
             METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0|0|0|0|0|0|0')
             METADATA_XBMCORIG = check_setting_str(CFG, 'General', 'metadata_xbmcorig', '0|0|0|0|0|0|0|0|0|0|0|0')
-            #if lenght of METADATA_XBMC = 11 and METADATA_XBMCORIG = '0|0|0|0|0|0|0|0|0|0|0|0'
             if METADATA_XBMC.__len__() == 11 and METADATA_XBMCORIG == '0|0|0|0|0|0|0|0|0|0|0|0':
             	METADATA_XBMCORIG = METADATA_XBMC[0:1] + '|' + METADATA_XBMC[6:7] + '|' + METADATA_XBMC[4:5] + '|0|0|0|0|0|' + METADATA_XBMC[10:11] + '|0|' + METADATA_XBMC[2:3] + '|' + METADATA_XBMC[8:9]	            
                 METADATA_XBMC = '0|0|0|0|0|0|0|0|0|0|0|0'

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -117,6 +117,7 @@ ROOT_DIRS = None
 USE_BANNER = None
 USE_LISTVIEW = None
 METADATA_XBMC = None
+METADATA_XBMCORIG = None
 METADATA_MEDIABROWSER = None
 METADATA_PS3 = None
 METADATA_WDTV = None
@@ -335,7 +336,7 @@ def initialize(consoleLogging=True):
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
-                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
+                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_XBMCORIG, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
                 ADD_SHOWS_WO_DIR
@@ -457,7 +458,6 @@ def initialize(consoleLogging=True):
         METADATA_TYPE = check_setting_str(CFG, 'General', 'metadata_type', '')
 
         metadata_provider_dict = metadata.get_metadata_generator_dict()
-
         # if this exists it's legacy, use the info to upgrade metadata to the new settings
         if METADATA_TYPE:
 
@@ -471,7 +471,7 @@ def initialize(consoleLogging=True):
                 old_metadata_class = metadata.ps3.metadata_class
 
             if old_metadata_class:
-
+                # fix to new options
                 METADATA_SHOW = bool(check_setting_int(CFG, 'General', 'metadata_show', 1))
                 METADATA_EPISODE = bool(check_setting_int(CFG, 'General', 'metadata_episode', 1))
 
@@ -479,26 +479,54 @@ def initialize(consoleLogging=True):
                 ART_FANART = bool(check_setting_int(CFG, 'General', 'art_fanart', 1))
                 ART_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_thumbnails', 1))
                 ART_SEASON_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_season_thumbnails', 1))
+                blankvalue = bool(0)
 
                 new_metadata_class = old_metadata_class(METADATA_SHOW,
-                                                        METADATA_EPISODE,
-                                                        ART_POSTER,
                                                         ART_FANART,
-                                                        ART_THUMBNAILS,
-                                                        ART_SEASON_THUMBNAILS)
+                                                        ART_POSTER,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,              
+                                                        ART_SEASON_THUMBNAILS, 	
+                                                        blankvalue,
+                                                        METADATA_EPISODE,
+                                                        ART_THUMBNAILS)
 
                 metadata_provider_dict[new_metadata_class.name] = new_metadata_class
 
         # this is the normal codepath for metadata config
+        # if 0|0|0|0|0|0 and not '0|0|0|0|0|0|0|0|0|0|0|0' old setting to update to new....
         else:
-            METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0')
-            METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0')
-            METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0')
-            METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0')
-            METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0')
-            METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0')
+            METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0|0|0|0|0|0|0')
+            METADATA_XBMCORIG = check_setting_str(CFG, 'General', 'metadata_xbmcorig', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_XBMC.__len__() == 11 and METADATA_XBMCORIG == '0|0|0|0|0|0|0|0|0|0|0|0':
+            	METADATA_XBMCORIG = METADATA_XBMC[0:1] + '|' + METADATA_XBMC[6:7] + '|' + METADATA_XBMC[4:5] + '|0|0|0|0|0|' + METADATA_XBMC[10:11] + '|0|' + METADATA_XBMC[2:3] + '|' + METADATA_XBMC[8:9]	            
+                METADATA_XBMC = '0|0|0|0|0|0|0|0|0|0|0|0'
+            
+            METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_MEDIABROWSER.__len__() == 11: 
+            	METADATA_MEDIABROWSER = METADATA_MEDIABROWSER[0:1] + '|' + METADATA_MEDIABROWSER[6:7] + '|' + METADATA_MEDIABROWSER[4:5] + '|0|0|0|0|0|' + METADATA_MEDIABROWSER[10:11] + '|0|' + METADATA_MEDIABROWSER[2:3] + '|' + METADATA_MEDIABROWSER[8:9]	            
+
+            METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_PS3.__len__() == 11: 
+            	METADATA_PS3 = METADATA_PS3[0:1] + '|' + METADATA_PS3[6:7] + '|' + METADATA_PS3[4:5] + '|0|0|0|0|0|' + METADATA_PS3[10:11] + '|0|' + METADATA_PS3[2:3] + '|' + METADATA_PS3[8:9]	            
+
+            METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_WDTV.__len__() == 11: 
+            	METADATA_WDTV = METADATA_WDTV[0:1] + '|' + METADATA_WDTV[6:7] + '|' + METADATA_WDTV[4:5] + '|0|0|0|0|0|' + METADATA_WDTV[10:11] + '|0|' + METADATA_WDTV[2:3] + '|' + METADATA_WDTV[8:9]	            
+
+            METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_TIVO.__len__() == 11: 
+            	METADATA_TIVO = METADATA_TIVO[0:1] + '|' + METADATA_TIVO[6:7] + '|' + METADATA_TIVO[4:5] + '|0|0|0|0|0|' + METADATA_TIVO[10:11] + '|0|' + METADATA_TIVO[2:3] + '|' + METADATA_TIVO[8:9]	            
+
+            METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_SYNOLOGY.__len__() == 11: 
+            	METADATA_SYNOLOGY = METADATA_SYNOLOGY[0:1] + '|' + METADATA_SYNOLOGY[6:7] + '|' + METADATA_SYNOLOGY[4:5] + '|0|0|0|0|0|' + METADATA_SYNOLOGY[10:11] + '|0|' + METADATA_SYNOLOGY[2:3] + '|' + METADATA_SYNOLOGY[8:9]	            
 
             for cur_metadata_tuple in [(METADATA_XBMC, metadata.xbmc),
+                                       (METADATA_XBMCORIG, metadata.xbmcorig),
                                        (METADATA_MEDIABROWSER, metadata.mediabrowser),
                                        (METADATA_PS3, metadata.ps3),
                                        (METADATA_WDTV, metadata.wdtv),
@@ -970,7 +998,9 @@ def save_config():
 
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
+
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()
+    new_config['General']['metadata_xbmcorig'] = metadata_provider_dict['XBMCOrig'].get_config()
     new_config['General']['metadata_mediabrowser'] = metadata_provider_dict['MediaBrowser'].get_config()
     new_config['General']['metadata_ps3'] = metadata_provider_dict['Sony PS3'].get_config()
     new_config['General']['metadata_wdtv'] = metadata_provider_dict['WDTV'].get_config()

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1001,8 +1001,9 @@ def save_config():
 
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
-    #to be edited
+
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()
+    new_config['General']['metadata_xbmcorig'] = metadata_provider_dict['XBMCOrig'].get_config()
     new_config['General']['metadata_mediabrowser'] = metadata_provider_dict['MediaBrowser'].get_config()
     new_config['General']['metadata_ps3'] = metadata_provider_dict['Sony PS3'].get_config()
     new_config['General']['metadata_wdtv'] = metadata_provider_dict['WDTV'].get_config()

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -117,6 +117,7 @@ ROOT_DIRS = None
 USE_BANNER = None
 USE_LISTVIEW = None
 METADATA_XBMC = None
+METADATA_XBMCORIG = None
 METADATA_MEDIABROWSER = None
 METADATA_PS3 = None
 METADATA_WDTV = None
@@ -335,7 +336,7 @@ def initialize(consoleLogging=True):
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
                 USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
-                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
+                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_XBMCORIG, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
                 ADD_SHOWS_WO_DIR
@@ -457,7 +458,8 @@ def initialize(consoleLogging=True):
         METADATA_TYPE = check_setting_str(CFG, 'General', 'metadata_type', '')
 
         metadata_provider_dict = metadata.get_metadata_generator_dict()
-
+    	# do be edited more first run?
+		# IRC: TO BE DONE
         # if this exists it's legacy, use the info to upgrade metadata to the new settings
         if METADATA_TYPE:
 
@@ -471,7 +473,7 @@ def initialize(consoleLogging=True):
                 old_metadata_class = metadata.ps3.metadata_class
 
             if old_metadata_class:
-
+				#fix to new options
                 METADATA_SHOW = bool(check_setting_int(CFG, 'General', 'metadata_show', 1))
                 METADATA_EPISODE = bool(check_setting_int(CFG, 'General', 'metadata_episode', 1))
 
@@ -481,24 +483,52 @@ def initialize(consoleLogging=True):
                 ART_SEASON_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_season_thumbnails', 1))
 
                 new_metadata_class = old_metadata_class(METADATA_SHOW,
-                                                        METADATA_EPISODE,
-                                                        ART_POSTER,
                                                         ART_FANART,
-                                                        ART_THUMBNAILS,
-                                                        ART_SEASON_THUMBNAILS)
+                                                        ART_POSTER,
+                                                        false,
+                                                        false,
+                                                        false,
+                                                        false,
+                                                        false,               
+                                                        ART_SEASON_THUMBNAILS 	
+                                                        false,
+                                                        METADATA_EPISODE,
+                                                        ART_THUMBNAILS)
 
                 metadata_provider_dict[new_metadata_class.name] = new_metadata_class
 
         # this is the normal codepath for metadata config
+        # if 0|0|0|0|0|0 and not '0|0|0|0|0|0|0|0|0|0|0|0' old setting to update to new....
         else:
-            METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0')
-            METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0')
-            METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0')
-            METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0')
-            METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0')
-            METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0')
+            METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0|0|0|0|0|0|0')
+            METADATA_XBMCORIG = check_setting_str(CFG, 'General', 'metadata_xbmcorig', '0|0|0|0|0|0|0|0|0|0|0|0')
+            #if lenght of METADATA_XBMC = 11 and METADATA_XBMCORIG = '0|0|0|0|0|0|0|0|0|0|0|0'
+            if METADATA_XBMC.__len__() = 11 and METADATA_XBMCORIG = '0|0|0|0|0|0|0|0|0|0|0|0':
+            	METADATA_XBMCORIG = METADATA_XBMC[1:1] + '|' + METADATA_XBMC[7:7] + '|' + METADATA_XBMC[5:5] + '|0|0|0|0|0|' + METADATA_XBMC[11:11] + '|0|' + METADATA_XBMC[3:3] + '|' + METADATA_XBMC[9:9]	            
+	            METADATA_XBMC = '0|0|0|0|0|0|0|0|0|0|0|0'
+            
+            METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_MEDIABROWSER.__len__() = 11 
+            	METADATA_MEDIABROWSER = METADATA_MEDIABROWSER[1:1] + '|' + METADATA_MEDIABROWSER[7:7] + '|' + METADATA_MEDIABROWSER[5:5] + '|0|0|0|0|0|' + METADATA_MEDIABROWSER[11:11] + '|0|' + METADATA_MEDIABROWSER[3:3] + '|' + METADATA_MEDIABROWSER[9:9]	            
+
+            METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_PS3.__len__() = 11 
+            	METADATA_PS3 = METADATA_PS3[1:1] + '|' + METADATA_PS3[7:7] + '|' + METADATA_PS3[5:5] + '|0|0|0|0|0|' + METADATA_PS3[11:11] + '|0|' + METADATA_PS3[3:3] + '|' + METADATA_PS3[9:9]	            
+
+            METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_WDTV.__len__() = 11 
+            	METADATA_WDTV = METADATA_WDTV[1:1] + '|' + METADATA_WDTV[7:7] + '|' + METADATA_WDTV[5:5] + '|0|0|0|0|0|' + METADATA_WDTV[11:11] + '|0|' + METADATA_WDTV[3:3] + '|' + METADATA_WDTV[9:9]	            
+
+            METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_TIVO.__len__() = 11 
+            	METADATA_TIVO = METADATA_TIVO[1:1] + '|' + METADATA_TIVO[7:7] + '|' + METADATA_TIVO[5:5] + '|0|0|0|0|0|' + METADATA_TIVO[11:11] + '|0|' + METADATA_TIVO[3:3] + '|' + METADATA_TIVO[9:9]	            
+
+            METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_SYNOLOGY.__len__() = 11 
+            	METADATA_SYNOLOGY = METADATA_SYNOLOGY[1:1] + '|' + METADATA_SYNOLOGY[7:7] + '|' + METADATA_SYNOLOGY[5:5] + '|0|0|0|0|0|' + METADATA_SYNOLOGY[11:11] + '|0|' + METADATA_SYNOLOGY[3:3] + '|' + METADATA_SYNOLOGY[9:9]	            
 
             for cur_metadata_tuple in [(METADATA_XBMC, metadata.xbmc),
+                                       (METADATA_XBMCORIG, metadata.xbmcorig),
                                        (METADATA_MEDIABROWSER, metadata.mediabrowser),
                                        (METADATA_PS3, metadata.ps3),
                                        (METADATA_WDTV, metadata.wdtv),
@@ -970,6 +1000,7 @@ def save_config():
 
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
+    #to be edited
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()
     new_config['General']['metadata_mediabrowser'] = metadata_provider_dict['MediaBrowser'].get_config()
     new_config['General']['metadata_ps3'] = metadata_provider_dict['Sony PS3'].get_config()

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -481,17 +481,18 @@ def initialize(consoleLogging=True):
                 ART_FANART = bool(check_setting_int(CFG, 'General', 'art_fanart', 1))
                 ART_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_thumbnails', 1))
                 ART_SEASON_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_season_thumbnails', 1))
+                blankvalue = bool(0)
 
                 new_metadata_class = old_metadata_class(METADATA_SHOW,
                                                         ART_FANART,
                                                         ART_POSTER,
-                                                        false,
-                                                        false,
-                                                        false,
-                                                        false,
-                                                        false,               
-                                                        ART_SEASON_THUMBNAILS 	
-                                                        false,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,              
+                                                        ART_SEASON_THUMBNAILS, 	
+                                                        blankvalue,
                                                         METADATA_EPISODE,
                                                         ART_THUMBNAILS)
 
@@ -503,29 +504,29 @@ def initialize(consoleLogging=True):
             METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0|0|0|0|0|0|0')
             METADATA_XBMCORIG = check_setting_str(CFG, 'General', 'metadata_xbmcorig', '0|0|0|0|0|0|0|0|0|0|0|0')
             #if lenght of METADATA_XBMC = 11 and METADATA_XBMCORIG = '0|0|0|0|0|0|0|0|0|0|0|0'
-            if METADATA_XBMC.__len__() = 11 and METADATA_XBMCORIG = '0|0|0|0|0|0|0|0|0|0|0|0':
-            	METADATA_XBMCORIG = METADATA_XBMC[1:1] + '|' + METADATA_XBMC[7:7] + '|' + METADATA_XBMC[5:5] + '|0|0|0|0|0|' + METADATA_XBMC[11:11] + '|0|' + METADATA_XBMC[3:3] + '|' + METADATA_XBMC[9:9]	            
-	            METADATA_XBMC = '0|0|0|0|0|0|0|0|0|0|0|0'
+            if METADATA_XBMC.__len__() == 11 and METADATA_XBMCORIG == '0|0|0|0|0|0|0|0|0|0|0|0':
+            	METADATA_XBMCORIG = METADATA_XBMC[0:1] + '|' + METADATA_XBMC[6:7] + '|' + METADATA_XBMC[4:5] + '|0|0|0|0|0|' + METADATA_XBMC[10:11] + '|0|' + METADATA_XBMC[2:3] + '|' + METADATA_XBMC[8:9]	            
+                METADATA_XBMC = '0|0|0|0|0|0|0|0|0|0|0|0'
             
             METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0|0|0|0|0|0|0')
-            if METADATA_MEDIABROWSER.__len__() = 11 
-            	METADATA_MEDIABROWSER = METADATA_MEDIABROWSER[1:1] + '|' + METADATA_MEDIABROWSER[7:7] + '|' + METADATA_MEDIABROWSER[5:5] + '|0|0|0|0|0|' + METADATA_MEDIABROWSER[11:11] + '|0|' + METADATA_MEDIABROWSER[3:3] + '|' + METADATA_MEDIABROWSER[9:9]	            
+            if METADATA_MEDIABROWSER.__len__() == 11: 
+            	METADATA_MEDIABROWSER = METADATA_MEDIABROWSER[0:1] + '|' + METADATA_MEDIABROWSER[6:7] + '|' + METADATA_MEDIABROWSER[4:5] + '|0|0|0|0|0|' + METADATA_MEDIABROWSER[10:11] + '|0|' + METADATA_MEDIABROWSER[2:3] + '|' + METADATA_MEDIABROWSER[8:9]	            
 
             METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0|0|0|0|0|0|0')
-            if METADATA_PS3.__len__() = 11 
-            	METADATA_PS3 = METADATA_PS3[1:1] + '|' + METADATA_PS3[7:7] + '|' + METADATA_PS3[5:5] + '|0|0|0|0|0|' + METADATA_PS3[11:11] + '|0|' + METADATA_PS3[3:3] + '|' + METADATA_PS3[9:9]	            
+            if METADATA_PS3.__len__() == 11: 
+            	METADATA_PS3 = METADATA_PS3[0:1] + '|' + METADATA_PS3[6:7] + '|' + METADATA_PS3[4:5] + '|0|0|0|0|0|' + METADATA_PS3[10:11] + '|0|' + METADATA_PS3[2:3] + '|' + METADATA_PS3[8:9]	            
 
             METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0|0|0|0|0|0|0')
-            if METADATA_WDTV.__len__() = 11 
-            	METADATA_WDTV = METADATA_WDTV[1:1] + '|' + METADATA_WDTV[7:7] + '|' + METADATA_WDTV[5:5] + '|0|0|0|0|0|' + METADATA_WDTV[11:11] + '|0|' + METADATA_WDTV[3:3] + '|' + METADATA_WDTV[9:9]	            
+            if METADATA_WDTV.__len__() == 11: 
+            	METADATA_WDTV = METADATA_WDTV[0:1] + '|' + METADATA_WDTV[6:7] + '|' + METADATA_WDTV[4:5] + '|0|0|0|0|0|' + METADATA_WDTV[10:11] + '|0|' + METADATA_WDTV[2:3] + '|' + METADATA_WDTV[8:9]	            
 
             METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0|0|0|0|0|0|0')
-            if METADATA_TIVO.__len__() = 11 
-            	METADATA_TIVO = METADATA_TIVO[1:1] + '|' + METADATA_TIVO[7:7] + '|' + METADATA_TIVO[5:5] + '|0|0|0|0|0|' + METADATA_TIVO[11:11] + '|0|' + METADATA_TIVO[3:3] + '|' + METADATA_TIVO[9:9]	            
+            if METADATA_TIVO.__len__() == 11: 
+            	METADATA_TIVO = METADATA_TIVO[0:1] + '|' + METADATA_TIVO[6:7] + '|' + METADATA_TIVO[4:5] + '|0|0|0|0|0|' + METADATA_TIVO[10:11] + '|0|' + METADATA_TIVO[2:3] + '|' + METADATA_TIVO[8:9]	            
 
             METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0|0|0|0|0|0|0')
-            if METADATA_SYNOLOGY.__len__() = 11 
-            	METADATA_SYNOLOGY = METADATA_SYNOLOGY[1:1] + '|' + METADATA_SYNOLOGY[7:7] + '|' + METADATA_SYNOLOGY[5:5] + '|0|0|0|0|0|' + METADATA_SYNOLOGY[11:11] + '|0|' + METADATA_SYNOLOGY[3:3] + '|' + METADATA_SYNOLOGY[9:9]	            
+            if METADATA_SYNOLOGY.__len__() == 11: 
+            	METADATA_SYNOLOGY = METADATA_SYNOLOGY[0:1] + '|' + METADATA_SYNOLOGY[6:7] + '|' + METADATA_SYNOLOGY[4:5] + '|0|0|0|0|0|' + METADATA_SYNOLOGY[10:11] + '|0|' + METADATA_SYNOLOGY[2:3] + '|' + METADATA_SYNOLOGY[8:9]	            
 
             for cur_metadata_tuple in [(METADATA_XBMC, metadata.xbmc),
                                        (METADATA_XBMCORIG, metadata.xbmcorig),

--- a/sickbeard/image_cache.py
+++ b/sickbeard/image_cache.py
@@ -198,8 +198,8 @@ class ImageCache:
         try:
             for cur_provider in sickbeard.metadata_provider_dict.values():
                 logger.log(u"Checking if we can use the show image from the "+cur_provider.name+" metadata", logger.DEBUG)
-                if ek.ek(os.path.isfile, cur_provider.get_poster_path(show_obj)):
-                    cur_file_name = os.path.abspath(cur_provider.get_poster_path(show_obj))
+                if ek.ek(os.path.isfile, cur_provider.get_show_poster_path(show_obj)):
+                    cur_file_name = os.path.abspath(cur_provider.get_show_poster_path(show_obj))
                     cur_file_type = self.which_type(cur_file_name)
                     
                     if cur_file_type == None:
@@ -212,6 +212,23 @@ class ImageCache:
                         logger.log(u"Found an image in the show dir that doesn't exist in the cache, caching it: "+cur_file_name+", type "+str(cur_file_type), logger.DEBUG)
                         self._cache_image_from_file(cur_file_name, cur_file_type, show_obj.tvdbid)
                         need_images[cur_file_type] = False
+
+                if ek.ek(os.path.isfile, cur_provider.get_show_banner_path(show_obj)):
+                    cur_file_name = os.path.abspath(cur_provider.get_show_banner_path(show_obj))
+                    cur_file_type = self.which_type(cur_file_name)
+
+                    if cur_file_type == None:
+                        logger.log(u"Unable to retrieve image type, not using the image from "+str(cur_file_name), logger.WARNING)
+                        continue
+
+                    logger.log(u"Checking if image "+cur_file_name+" (type "+str(cur_file_type)+" needs metadata: "+str(need_images[cur_file_type]), logger.DEBUG)
+
+                    if cur_file_type in need_images and need_images[cur_file_type]:
+                        logger.log(u"Found an image in the show dir that doesn't exist in the cache, caching it: "+cur_file_name+", type "+str(cur_file_type), logger.DEBUG)
+                        self._cache_image_from_file(cur_file_name, cur_file_type, show_obj.tvdbid)
+                        need_images[cur_file_type] = False
+
+
         except exceptions.ShowDirNotFoundException:
             logger.log(u"Unable to search for images in show dir because it doesn't exist", logger.WARNING)
                     

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['generic', 'helpers', 'xbmc', 'mediabrowser', 'synology', 'ps3', 'wdtv', 'tivo']
+__all__ = ['generic', 'helpers', 'xbmc', 'xbmcorig', 'mediabrowser', 'synology', 'ps3', 'wdtv', 'tivo']
 
 import sys
-import xbmc, mediabrowser, synology, ps3, wdtv, tivo
+import xbmc, xbmcorig, mediabrowser, synology, ps3, wdtv, tivo
 
 def available_generators():
     return filter(lambda x: x not in ('generic', 'helpers'), __all__)

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -15,7 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
-
+# 
+# luxmoggy updated to create metadata in the new xbmc style
+# 
 import os.path
 
 import xml.etree.cElementTree as etree
@@ -38,42 +40,64 @@ class GenericMetadata():
     Base class for all metadata providers. Default behavior is meant to mostly
     follow XBMC metadata standards. Has support for:
     
-    - show poster
-    - show fanart
     - show metadata file
-    - episode thumbnail
+    - show fanart
+    - show poster
+    - show banner
+    - season all fanart
+    - season all poster
+    - season all banner    
+    - season fanart (still needs to be written)
+    - season poster
+    - season banner
     - episode metadata file
-    - season thumbnails
+    - episode thumbnail
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
-        self._show_file_name = "tvshow.nfo"
-        self._ep_nfo_extension = "nfo"
-        
-        self.poster_name = "folder.jpg"
-        self.fanart_name = "fanart.jpg"
-
-        self.generate_show_metadata = True
-        self.generate_ep_metadata = True
-        
         self.name = 'Generic'
+        self._ep_nfo_extension = "nfo"
+
+        self._show_metadata_name = "tvshow.nfo"
+
+        self.show_fanart_name = "fanart.jpg"
+        self.show_poster_name = "poster.jpg"
+        self.show_banner_name = "banner.jpg"
+        self.season_all_fanart_name = "season-all-fanart.jpg"
+        self.season_all_poster_name = "season-all-poster.jpg"
+        self.season_all_banner_name = "season-all-banner.jpg"
 
         self.show_metadata = show_metadata
+        self.show_fanart = show_fanart
+        self.show_poster = show_poster
+        self.show_banner = show_banner
+
+        self.season_all_fanart = season_all_fanart
+        self.season_all_poster = season_all_poster
+        self.season_all_banner = season_all_banner
+        self.season_fanarts = season_fanarts
+        self.season_posters = season_posters
+        self.season_banners = season_banners
+
         self.episode_metadata = episode_metadata
-        self.poster = poster
-        self.fanart = fanart
         self.episode_thumbnails = episode_thumbnails
-        self.season_thumbnails = season_thumbnails
+
     
     def get_config(self):
-        config_list = [self.show_metadata, self.episode_metadata, self.poster, self.fanart, self.episode_thumbnails, self.season_thumbnails]
+        config_list = [self.show_metadata, self.show_fanart, self.show_poster, self.show_banner, self.season_all_fanart, self.season_all_poster, self.season_all_banner, self.season_fanarts, self.season_posters, self.season_banners, self.episode_metadata, self.episode_thumbnails]
         return '|'.join([str(int(x)) for x in config_list])
 
     def get_id(self):
@@ -86,30 +110,77 @@ class GenericMetadata():
     def set_config(self, string):
         config_list = [bool(int(x)) for x in string.split('|')]
         self.show_metadata = config_list[0]
-        self.episode_metadata = config_list[1]
-        self.poster = config_list[2]
-        self.fanart = config_list[3]
-        self.episode_thumbnails = config_list[4]
-        self.season_thumbnails = config_list[5]
+        self.show_fanart = config_list[1]
+        self.show_poster = config_list[2]
+        self.show_banner = config_list[3]
+        self.season_all_fanart = config_list[4]
+        self.season_all_poster = config_list[5]
+        self.season_all_banner = config_list[6]
+        self.season_fanarts = config_list[7]
+        self.season_posters = config_list[8]
+        self.season_banners = config_list[9]
+        self.episode_metadata = config_list[10]
+        self.episode_thumbnails = config_list[11]
     
     def _has_show_metadata(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_show_file_path(show_obj))
+        result = ek.ek(os.path.isfile, self.get_show_metadata_path(show_obj))
         logger.log("Checking if "+self.get_show_file_path(show_obj)+" exists: "+str(result), logger.DEBUG)
         return result
     
+    def _has_show_fanart(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_fanart_path(show_obj))
+        logger.log("Checking if "+self.get_show_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        return result
+    
+    def _has_show_poster(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_poster_path(show_obj))
+        logger.log("Checking if "+self.get_show_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_show_banner(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_banner_path(show_obj))
+        logger.log("Checking if "+self.get_show_banner_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_all_fanart(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_fanart_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        return result
+    
+    def _has_season_all_poster(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_poster_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_all_banner(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_banner_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_banner_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_fanart(self, show_obj, season):
+        location = self.season_fanart_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_poster(self, show_obj, season):
+        location = self.season_poster_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_banner(self, show_obj, season):
+        location = self.season_banner_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+        return result
+
     def _has_episode_metadata(self, ep_obj):
         result = ek.ek(os.path.isfile, self.get_episode_file_path(ep_obj))
         logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def _has_poster(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_poster_path(show_obj))
-        logger.log("Checking if "+self.get_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def _has_fanart(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_fanart_path(show_obj))
-        logger.log("Checking if "+self.get_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_episode_thumb(self, ep_obj):
@@ -119,40 +190,31 @@ class GenericMetadata():
             logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
         return result
     
-    def _has_season_thumb(self, show_obj, season):
-        location = self.get_season_thumb_path(show_obj, season)
-        result = location != None and ek.ek(os.path.isfile, location)
-        if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def get_show_file_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self._show_file_name)
+    def get_show_metadata_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self._show_metadata_name)
 
     def get_episode_file_path(self, ep_obj):
         return helpers.replaceExtension(ep_obj.location, self._ep_nfo_extension)
 
-    def get_poster_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.poster_name)
-            
-    def get_fanart_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.fanart_name)
-            
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns the path where the episode thumbnail should be stored. Defaults to
-        the same path as the episode file but with a .tbn extension.
-        
-        ep_obj: a TVEpisode instance for which to create the thumbnail
-        """
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_filename = helpers.replaceExtension(ep_obj.location, 'tbn')
-        else:
-            return None
-        
-        return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
+    def get_show_fanart_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_fanart_name)
+
+    def get_show_poster_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_poster_name)
+
+    def get_show_banner_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_poster_name)
+
+    def get_season_all_fanart_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_fanart_name)
+
+    def get_season_all_poster_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_poster_name)
+
+    def get_season_all_banner_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_banner_name)
+
+    def get_season_fanart_path(self, show_obj, season):
         """
         Returns the full path to the file for a given season thumb.
         
@@ -167,7 +229,43 @@ class GenericMetadata():
         else:
             season_thumb_file_path = 'season' + str(season).zfill(2)
         
-        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'.tbn')
+        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'-fanart.jpg')
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        if img_type == 'season':
+           season_pb_file_ext = '-poster.jpg'
+        else:
+           season_pb_file_ext = '-banner.jpg'
+           
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+season_pb_file_ext)            
+            
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .tbn extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'tbn')
+        else:
+            return None
+        
+        return tbn_filename
     
     def _show_data(self, show_obj):
         """
@@ -188,36 +286,239 @@ class GenericMetadata():
             logger.log("Metadata provider "+self.name+" creating show metadata for "+show_obj.name, logger.DEBUG)
             return self.write_show_file(show_obj)
         return False
+
+    def create_show_fanart(self, show_obj):
+        if self.show_fanart and show_obj and not self._has_show_fanart(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show fanart for "+show_obj.name, logger.DEBUG)
+            fanart_path = self.get_show_fanart_path(show_obj)
+            return self.save_show_fpb(show_obj, "fanart", fanart_path)
+        return False
     
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            return self.save_show_fpb(show_obj, "poster", poster_path)
+        return False
+
+    def create_show_banner(self, show_obj):
+        if self.show_banner and show_obj and not self._has_show_banner(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show banner for "+show_obj.name, logger.DEBUG)
+            banner_path = self.get_show_banner_path(show_obj)
+            return self.save_show_fpb(show_obj, "banner", banner_path)
+        return False
+
+    def create_season_all_fanart(self, show_obj):
+        if self.season_all_fanart and show_obj and not self._has_season_all_fanart(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all fanart for "+show_obj.name, logger.DEBUG)
+            season_all_fanart_path = self.get_season_all_fanart_path(show_obj)
+            return self.save_show_fpb(show_obj, "fanart", season_all_fanart_path)
+        return False
+    
+    def create_season_all_poster(self, show_obj):
+        if self.season_all_poster and show_obj and not self._has_season_all_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all poster for "+show_obj.name, logger.DEBUG)
+            season_all_poster_path = self.get_season_all_poster_path(show_obj)
+            return self.save_show_fpb(show_obj, "poster", season_all_poster_path)
+        return False
+
+    def create_season_all_banner(self, show_obj):
+        if self.season_all_banner and show_obj and not self._has_season_all_banner(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all banner for "+show_obj.name, logger.DEBUG)
+            season_all_banner_path = self.get_season_all_banner_path(show_obj)
+            return self.save_show_fpb(show_obj, "banner", season_all_banner_path)
+        return False
+
+    def create_season_fanart(self, show_obj):
+        if self.season_fanart and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season fanart for "+show_obj.name, logger.DEBUG)
+            return self.save_season_fanart(show_obj)
+        return False
+
+    def create_season_poster(self, show_obj):
+        if self.season_poster and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season poster for "+show_obj.name, logger.DEBUG)
+            return self.save_season_pb(show_obj,'season')
+        return False
+
+    def create_season_banner(self, show_obj):
+        if self.season_banner and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season banner for "+show_obj.name, logger.DEBUG)
+            return self.save_season_pb(show_obj,'seasonwide')
+        return False
+
     def create_episode_metadata(self, ep_obj):
         if self.episode_metadata and ep_obj and not self._has_episode_metadata(ep_obj):
             logger.log("Metadata provider "+self.name+" creating episode metadata for "+ep_obj.prettyName(), logger.DEBUG)
             return self.write_ep_file(ep_obj)
         return False
     
-    def create_poster(self, show_obj):
-        if self.poster and show_obj and not self._has_poster(show_obj):
-            logger.log("Metadata provider "+self.name+" creating poster for "+show_obj.name, logger.DEBUG)
-            return self.save_poster(show_obj)
-        return False
-    
-    def create_fanart(self, show_obj):
-        if self.fanart and show_obj and not self._has_fanart(show_obj):
-            logger.log("Metadata provider "+self.name+" creating fanart for "+show_obj.name, logger.DEBUG)
-            return self.save_fanart(show_obj)
-        return False
-    
     def create_episode_thumb(self, ep_obj):
         if self.episode_thumbnails and ep_obj and not self._has_episode_thumb(ep_obj):
-            logger.log("Metadata provider "+self.name+" creating show metadata for "+ep_obj.prettyName(), logger.DEBUG)
-            return self.save_thumbnail(ep_obj)
+            logger.log("Metadata provider "+self.name+" creating episode thumbnail for "+ep_obj.prettyName(), logger.DEBUG)
+            return self.save_episode_thumbnail(ep_obj)
         return  False
     
-    def create_season_thumbs(self, show_obj):
-        if self.season_thumbnails and show_obj:
-            logger.log("Metadata provider "+self.name+" creating season thumbnails for "+show_obj.name, logger.DEBUG)
-            return self.save_season_thumbs(show_obj)
-        return False
+    def write_show_file(self, show_obj):
+        """
+        Generates and writes show_obj's metadata under the given path to the
+        filename given by get_show_file_path()
+        
+        show_obj: TVShow object for which to create the metadata
+        
+        path: An absolute or relative path where we should put the file. Note that
+                the file name will be the default show_file_name.
+        
+        Note that this method expects that _show_data will return an ElementTree
+        object. If your _show_data returns data in another format you'll need to
+        override this method.
+        """
+        
+        data = self._show_data(show_obj)
+        
+        if not data:
+            return False
+        
+        nfo_file_path = self.get_show_file_path(show_obj)
+        nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
+
+        try:
+            if not ek.ek(os.path.isdir, nfo_file_dir):
+                logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
+                ek.ek(os.makedirs, nfo_file_dir)
+                helpers.chmodAsParent(nfo_file_dir)
+    
+            logger.log(u"Writing show nfo file to "+nfo_file_path)
+            
+            nfo_file = ek.ek(open, nfo_file_path, 'w')
+    
+            data.write(nfo_file, encoding="utf-8")
+            nfo_file.close()
+            helpers.chmodAsParent(nfo_file_path)
+        except IOError, e:
+            logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+ex(e), logger.ERROR)
+            return False
+        
+        return True
+
+    def save_show_fpb(self, show_obj, img_type, img_path, which=None):
+        """
+        Downloads a image and saves it to the filename specified by img_path
+        inside the show's root folder.
+        
+        show_obj: a TVShow object for which to download fanart/poster/banner 
+        """
+        
+        img_data = self._retrieve_show_image(img_type, show_obj, which)
+
+        if not img_data:
+            logger.log(u"No " + img_type + " image was retrieved, unable to write " + img_type, logger.DEBUG)
+            return False
+
+        return self._write_image(img_data, img_path)
+
+    def _season_fanart_dict(self, show_obj):
+        """
+    	need to write query for this    	
+    	"""
+    	# IRC: TO BE DONE
+		pass
+
+    def _season_pb_dict(self, show_obj):
+        """
+        Should return a dict like:
+        
+        result = {<season number>: 
+                    {1: '<url 1>', 2: <url 2>, ...},}
+        """
+
+        # This holds our resulting dictionary of season art
+        result = {}
+    
+        tvdb_lang = show_obj.lang
+
+        try:
+            # There's gotta be a better way of doing this but we don't wanna
+            # change the language value elsewhere
+            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+            if tvdb_lang and not tvdb_lang == 'en':
+                ltvdb_api_parms['language'] = tvdb_lang
+
+            t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
+            tvdb_show_obj = t[show_obj.tvdbid]
+        except (tvdb_exceptions.tvdb_error, IOError), e:
+            logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
+            return result
+    
+        #  How many seasons?
+        num_seasons = len(tvdb_show_obj)
+    
+        # if we have no season banners then just finish
+        if 'season' not in tvdb_show_obj['_banners'] or 'season' not in tvdb_show_obj['_banners']['season']:
+            return result
+    
+        # Give us just the normal poster-style season graphics
+        seasonsArtObj = tvdb_show_obj['_banners']['season']['season']
+    
+        # Returns a nested dictionary of season art with the season
+        # number as primary key. It's really overkill but gives the option
+        # to present to user via ui to pick down the road.
+        for cur_season in range(num_seasons):
+
+            result[cur_season] = {}
+            
+            # find the correct season in the tvdb object and just copy the dict into our result dict
+            for seasonArtID in seasonsArtObj.keys():
+                if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
+                    result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
+            
+            if len(result[cur_season]) == 0:
+                continue
+
+        return result
+
+    def save_season_pb(self, show_obj, img_type):
+        """
+        Saves all season poster/banner to disk for the given show.
+        
+        show_obj: a TVShow object for which to save the season poster/banner
+        
+        Cycles through all seasons and saves the season poster/banner if possible. This
+        method should not need to be overridden by implementing classes, changing
+        _season_thumb_dict and get_season_thumb_path should be good enough.
+        """
+    
+        season_dict = self._season_pb_dict(show_obj, img_type)
+    
+        # Returns a nested dictionary of season art with the season
+        # number as primary key. It's really overkill but gives the option
+        # to present to user via ui to pick down the road.
+        for cur_season in season_dict:
+
+            cur_season_art = season_dict[cur_season]
+            
+            if len(cur_season_art) == 0:
+                continue
+    
+            # Just grab whatever's there for now
+            art_id, season_url = cur_season_art.popitem() #@UnusedVariable
+
+            season_thumb_file_path = self.get_season_pb_path(show_obj, cur_season, img_type)
+            
+            if not season_thumb_file_path:
+                logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
+                continue
+    
+            seasonData = metadata_helpers.getShowImage(season_url)
+            
+            if not seasonData:
+                logger.log(u"No season thumb data available, skipping this season", logger.DEBUG)
+                continue
+            
+            self._write_image(seasonData, img_path)
+    
+        return True
     
     def _get_episode_thumb_url(self, ep_obj):
         """
@@ -262,47 +563,6 @@ class GenericMetadata():
 
         return None
     
-    def write_show_file(self, show_obj):
-        """
-        Generates and writes show_obj's metadata under the given path to the
-        filename given by get_show_file_path()
-        
-        show_obj: TVShow object for which to create the metadata
-        
-        path: An absolute or relative path where we should put the file. Note that
-                the file name will be the default show_file_name.
-        
-        Note that this method expects that _show_data will return an ElementTree
-        object. If your _show_data returns data in another format you'll need to
-        override this method.
-        """
-        
-        data = self._show_data(show_obj)
-        
-        if not data:
-            return False
-        
-        nfo_file_path = self.get_show_file_path(show_obj)
-        nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
-
-        try:
-            if not ek.ek(os.path.isdir, nfo_file_dir):
-                logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
-                ek.ek(os.makedirs, nfo_file_dir)
-                helpers.chmodAsParent(nfo_file_dir)
-    
-            logger.log(u"Writing show nfo file to "+nfo_file_path)
-            
-            nfo_file = ek.ek(open, nfo_file_path, 'w')
-    
-            data.write(nfo_file, encoding="utf-8")
-            nfo_file.close()
-            helpers.chmodAsParent(nfo_file_path)
-        except IOError, e:
-            logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+ex(e), logger.ERROR)
-            return False
-        
-        return True
 
     def write_ep_file(self, ep_obj):
         """
@@ -381,93 +641,6 @@ class GenericMetadata():
             cur_ep.hastbn = True
     
         return True
-    
-    def save_fanart(self, show_obj, which=None):
-        """
-        Downloads a fanart image and saves it to the filename specified by fanart_name
-        inside the show's root folder.
-        
-        show_obj: a TVShow object for which to download fanart 
-        """
-
-        # use the default fanart name
-        fanart_path = self.get_fanart_path(show_obj)
-        
-        fanart_data = self._retrieve_show_image('fanart', show_obj, which)
-
-        if not fanart_data:
-            logger.log(u"No fanart image was retrieved, unable to write fanart", logger.DEBUG)
-            return False
-
-        return self._write_image(fanart_data, fanart_path)
-
-
-    def save_poster(self, show_obj, which=None):
-        """
-        Downloads a poster image and saves it to the filename specified by poster_name
-        inside the show's root folder.
-        
-        show_obj: a TVShow object for which to download a poster 
-        """
-
-        # use the default poster name
-        poster_path = self.get_poster_path(show_obj)
-        
-        if sickbeard.USE_BANNER:
-            img_type = 'banner'
-        else:
-            img_type = 'poster'
-        
-        poster_data = self._retrieve_show_image(img_type, show_obj, which)
-
-        if not poster_data:
-            logger.log(u"No show folder image was retrieved, unable to write poster", logger.DEBUG)
-            return False
-
-        return self._write_image(poster_data, poster_path)
-
-
-    def save_season_thumbs(self, show_obj):
-        """
-        Saves all season thumbnails to disk for the given show.
-        
-        show_obj: a TVShow object for which to save the season thumbs
-        
-        Cycles through all seasons and saves the season thumbs if possible. This
-        method should not need to be overridden by implementing classes, changing
-        _season_thumb_dict and get_season_thumb_path should be good enough.
-        """
-    
-        season_dict = self._season_thumb_dict(show_obj)
-    
-        # Returns a nested dictionary of season art with the season
-        # number as primary key. It's really overkill but gives the option
-        # to present to user via ui to pick down the road.
-        for cur_season in season_dict:
-
-            cur_season_art = season_dict[cur_season]
-            
-            if len(cur_season_art) == 0:
-                continue
-    
-            # Just grab whatever's there for now
-            art_id, season_url = cur_season_art.popitem() #@UnusedVariable
-
-            season_thumb_file_path = self.get_season_thumb_path(show_obj, cur_season)
-            
-            if not season_thumb_file_path:
-                logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
-                continue
-    
-            seasonData = metadata_helpers.getShowImage(season_url)
-            
-            if not seasonData:
-                logger.log(u"No season thumb data available, skipping this season", logger.DEBUG)
-                continue
-            
-            self._write_image(seasonData, season_thumb_file_path)
-    
-        return True
 
     def _write_image(self, image_data, image_path):
         """
@@ -542,65 +715,12 @@ class GenericMetadata():
 
         return image_data
     
-    def _season_thumb_dict(self, show_obj):
-        """
-        Should return a dict like:
-        
-        result = {<season number>: 
-                    {1: '<url 1>', 2: <url 2>, ...},}
-        """
-
-        # This holds our resulting dictionary of season art
-        result = {}
-    
-        tvdb_lang = show_obj.lang
-
-        try:
-            # There's gotta be a better way of doing this but we don't wanna
-            # change the language value elsewhere
-            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
-
-            if tvdb_lang and not tvdb_lang == 'en':
-                ltvdb_api_parms['language'] = tvdb_lang
-
-            t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
-            tvdb_show_obj = t[show_obj.tvdbid]
-        except (tvdb_exceptions.tvdb_error, IOError), e:
-            logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
-            return result
-    
-        #  How many seasons?
-        num_seasons = len(tvdb_show_obj)
-    
-        # if we have no season banners then just finish
-        if 'season' not in tvdb_show_obj['_banners'] or 'season' not in tvdb_show_obj['_banners']['season']:
-            return result
-    
-        # Give us just the normal poster-style season graphics
-        seasonsArtObj = tvdb_show_obj['_banners']['season']['season']
-    
-        # Returns a nested dictionary of season art with the season
-        # number as primary key. It's really overkill but gives the option
-        # to present to user via ui to pick down the road.
-        for cur_season in range(num_seasons):
-
-            result[cur_season] = {}
-            
-            # find the correct season in the tvdb object and just copy the dict into our result dict
-            for seasonArtID in seasonsArtObj.keys():
-                if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
-                    result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
-            
-            if len(result[cur_season]) == 0:
-                continue
-
-        return result
 
     def retrieveShowMetadata(self, dir):
     
         empty_return = (None, None)
     
-        metadata_path = ek.ek(os.path.join, dir, self._show_file_name)
+        metadata_path = ek.ek(os.path.join, dir, self._show_metadata_name)
     
         if not ek.ek(os.path.isdir, dir) or not ek.ek(os.path.isfile, metadata_path):
             logger.log(u"Can't load the metadata file from "+repr(metadata_path)+", it doesn't exist", logger.DEBUG)

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -124,70 +124,70 @@ class GenericMetadata():
     
     def _has_show_metadata(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_show_metadata_path(show_obj))
-        logger.log("Checking if "+self.get_show_file_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_show_metadata_path(show_obj)+" (Show Metadata) exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_show_fanart(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_show_fanart_path(show_obj))
-        logger.log("Checking if "+self.get_show_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_show_fanart_path(show_obj)+" (Show Fanart) exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_show_poster(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_show_poster_path(show_obj))
-        logger.log("Checking if "+self.get_show_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_show_poster_path(show_obj)+" (Show Poster) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_show_banner(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_show_banner_path(show_obj))
-        logger.log("Checking if "+self.get_show_banner_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_show_banner_path(show_obj)+" (Show Banner) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_season_all_fanart(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_season_all_fanart_path(show_obj))
-        logger.log("Checking if "+self.get_season_all_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_season_all_fanart_path(show_obj)+" (Season All Fanart) exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_season_all_poster(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_season_all_poster_path(show_obj))
-        logger.log("Checking if "+self.get_season_all_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_season_all_poster_path(show_obj)+" (Season All Poster) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_season_all_banner(self, show_obj):
         result = ek.ek(os.path.isfile, self.get_season_all_banner_path(show_obj))
-        logger.log("Checking if "+self.get_season_all_banner_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_season_all_banner_path(show_obj)+" (Season All Banner) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_season_fanart(self, show_obj, season):
         location = self.season_fanart_path(show_obj, season)
         result = location != None and ek.ek(os.path.isfile, location)
         if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+            logger.log("Checking if "+location+" (Season Fanart) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_season_poster(self, show_obj, season):
         location = self.season_poster_path(show_obj, season)
         result = location != None and ek.ek(os.path.isfile, location)
         if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+            logger.log("Checking if "+location+" (Season Poster) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_season_banner(self, show_obj, season):
         location = self.season_banner_path(show_obj, season)
         result = location != None and ek.ek(os.path.isfile, location)
         if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+            logger.log("Checking if "+location+" (Season Banner) exists: "+str(result), logger.DEBUG)
         return result
 
     def _has_episode_metadata(self, ep_obj):
         result = ek.ek(os.path.isfile, self.get_episode_file_path(ep_obj))
-        logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" (Episode Metadata) exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_episode_thumb(self, ep_obj):
         location = self.get_episode_thumb_path(ep_obj)
         result = location != None and ek.ek(os.path.isfile, location)
         if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+            logger.log("Checking if "+location+" (Episode Thumbnail) exists: "+str(result), logger.DEBUG)
         return result
     
     def get_show_metadata_path(self, show_obj):
@@ -203,7 +203,7 @@ class GenericMetadata():
         return ek.ek(os.path.join, show_obj.location, self.show_poster_name)
 
     def get_show_banner_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.show_poster_name)
+        return ek.ek(os.path.join, show_obj.location, self.show_banner_name)
 
     def get_season_all_fanart_path(self, show_obj):
         return ek.ek(os.path.join, show_obj.location, self.season_all_fanart_name)
@@ -225,11 +225,11 @@ class GenericMetadata():
 
         # Our specials thumbnail is, well, special
         if season == 0:
-            season_thumb_file_path = 'season-specials'
+            season_pb_file_path = 'season-specials'
         else:
-            season_thumb_file_path = 'season' + str(season).zfill(2)
+            season_pb_file_path = 'season' + str(season).zfill(2)
         
-        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'-fanart.jpg')
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+'-fanart.jpg')
 
     def get_season_pb_path(self, show_obj, season, img_type):
         """
@@ -239,19 +239,19 @@ class GenericMetadata():
         season: a season number to be used for the path. Note that sesaon 0
                 means specials.
         """
-
         # Our specials thumbnail is, well, special
         if season == 0:
             season_pb_file_path = 'season-specials'
         else:
-            season_pb_file_path = 'season' + str(season).zfill(2)
+            season_pb_file_path = 'season' + str(season).zfill(2)        
         
         if img_type == 'season':
            season_pb_file_ext = '-poster.jpg'
         else:
            season_pb_file_ext = '-banner.jpg'
-           
-        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+season_pb_file_ext)            
+        
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path)            
             
     def get_episode_thumb_path(self, ep_obj):
         """
@@ -330,19 +330,19 @@ class GenericMetadata():
         return False
 
     def create_season_fanart(self, show_obj):
-        if self.season_fanart and show_obj:
+        if self.season_fanarts and show_obj:
             logger.log("Metadata provider "+self.name+" creating season fanart for "+show_obj.name, logger.DEBUG)
             return self.save_season_fanart(show_obj)
         return False
 
     def create_season_poster(self, show_obj):
-        if self.season_poster and show_obj:
+        if self.season_posters and show_obj:
             logger.log("Metadata provider "+self.name+" creating season poster for "+show_obj.name, logger.DEBUG)
             return self.save_season_pb(show_obj,'season')
         return False
 
     def create_season_banner(self, show_obj):
-        if self.season_banner and show_obj:
+        if self.season_banners and show_obj:
             logger.log("Metadata provider "+self.name+" creating season banner for "+show_obj.name, logger.DEBUG)
             return self.save_season_pb(show_obj,'seasonwide')
         return False
@@ -379,7 +379,7 @@ class GenericMetadata():
         if not data:
             return False
         
-        nfo_file_path = self.get_show_file_path(show_obj)
+        nfo_file_path = self.get_show_metadata_path(show_obj)
         nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
 
         try:
@@ -422,9 +422,9 @@ class GenericMetadata():
     	need to write query for this    	
     	"""
     	# IRC: TO BE DONE
-		pass
+	return result	
 
-    def _season_pb_dict(self, show_obj):
+    def _season_pb_dict(self, show_obj, img_type):
         """
         Should return a dict like:
         
@@ -453,18 +453,26 @@ class GenericMetadata():
     
         #  How many seasons?
         num_seasons = len(tvdb_show_obj)
+        logger.log(u"TV Show has " + str(num_seasons) + " season(s)", logger.DEBUG)
     
         # if we have no season banners then just finish
-        if 'season' not in tvdb_show_obj['_banners'] or 'season' not in tvdb_show_obj['_banners']['season']:
+        if 'season' not in tvdb_show_obj['_banners'] or img_type not in tvdb_show_obj['_banners']['season']:
             return result
     
         # Give us just the normal poster-style season graphics
-        seasonsArtObj = tvdb_show_obj['_banners']['season']['season']
-    
+        seasonsArtObj = tvdb_show_obj['_banners']['season'][img_type]
+
+        #for seasonArtID in seasonsArtObj.keys():
+        #    if int(seasonsArtObj[seasonArtID]['season']) == 2 and seasonsArtObj[seasonArtID]['language'] == 'en':
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['season'], logger.DEBUG)
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['language'], logger.DEBUG)
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['_bannerpath'], logger.DEBUG)
+
         # Returns a nested dictionary of season art with the season
         # number as primary key. It's really overkill but gives the option
         # to present to user via ui to pick down the road.
-        for cur_season in range(num_seasons):
+        # edited the range as not always getting last season
+        for cur_season in range(num_seasons+1):
 
             result[cur_season] = {}
             
@@ -472,6 +480,8 @@ class GenericMetadata():
             for seasonArtID in seasonsArtObj.keys():
                 if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
                     result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
+
+            #logger.log(u"Season " + str(cur_season) + " artwork found", logger.DEBUG)
             
             if len(result[cur_season]) == 0:
                 continue
@@ -490,7 +500,8 @@ class GenericMetadata():
         """
     
         season_dict = self._season_pb_dict(show_obj, img_type)
-    
+        logger.log(u"Season image list filled", logger.DEBUG)
+   
         # Returns a nested dictionary of season art with the season
         # number as primary key. It's really overkill but gives the option
         # to present to user via ui to pick down the road.
@@ -500,24 +511,28 @@ class GenericMetadata():
             
             if len(cur_season_art) == 0:
                 continue
-    
+
             # Just grab whatever's there for now
             art_id, season_url = cur_season_art.popitem() #@UnusedVariable
-
-            season_thumb_file_path = self.get_season_pb_path(show_obj, cur_season, img_type)
+            #logger.log(u"Season " + str(cur_season) + " artwork url: " + season_url, logger.DEBUG)
+            season_image_path = self.get_season_pb_path(show_obj, cur_season, img_type)
+            #logger.log(u"Season " + str(cur_season) + " artwork path: " + season_image_path, logger.DEBUG)
             
-            if not season_thumb_file_path:
+            if not season_image_path:
                 logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
                 continue
-    
+            
             seasonData = metadata_helpers.getShowImage(season_url)
             
             if not seasonData:
-                logger.log(u"No season thumb data available, skipping this season", logger.DEBUG)
+                logger.log(u"No season image data available, skipping this season", logger.DEBUG)
                 continue
             
-            self._write_image(seasonData, img_path)
-    
+            #logger.log(u"Season " + str(cur_season) + " image data recieved", logger.DEBUG)            
+            result = self._write_image(seasonData, season_image_path)
+            #logger.log(u"Season " + str(cur_season) + " image data saved", logger.DEBUG)
+            
+        #logger.log(u"Season artwork Finished: " + img_type, logger.DEBUG)    
         return True
     
     def _get_episode_thumb_url(self, ep_obj):
@@ -650,6 +665,7 @@ class GenericMetadata():
         image_data: binary image data to write to file
         image_path: file location to save the image to
         """
+        #logger.log(u"Creating Image from data:" + image_path, logger.DEBUG)
         
         # don't bother overwriting it
         if ek.ek(os.path.isfile, image_path):
@@ -659,7 +675,7 @@ class GenericMetadata():
         if not image_data:
             logger.log(u"Unable to retrieve image, skipping", logger.WARNING)
             return False
-
+        
         image_dir = ek.ek(os.path.dirname, image_path)
         
         try:
@@ -667,7 +683,7 @@ class GenericMetadata():
                 logger.log("Metadata dir didn't exist, creating it at "+image_dir, logger.DEBUG)
                 ek.ek(os.makedirs, image_dir)
                 helpers.chmodAsParent(image_dir)
-
+            
             outFile = ek.ek(open, image_path, 'wb')
             outFile.write(image_data)
             outFile.close()
@@ -675,7 +691,7 @@ class GenericMetadata():
         except IOError, e:
             logger.log(u"Unable to write image to "+image_path+" - are you sure the show folder is writable? "+ex(e), logger.ERROR)
             return False
-    
+        
         return True
     
     def _retrieve_show_image(self, image_type, show_obj, which=None):

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -15,7 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
-
+# 
+# luxmoggy updated to create metadata in the new xbmc style
+# 
 import os.path
 
 import xml.etree.cElementTree as etree
@@ -38,42 +40,64 @@ class GenericMetadata():
     Base class for all metadata providers. Default behavior is meant to mostly
     follow XBMC metadata standards. Has support for:
     
-    - show poster
-    - show fanart
     - show metadata file
-    - episode thumbnail
+    - show fanart
+    - show poster
+    - show banner
+    - season all fanart
+    - season all poster
+    - season all banner    
+    - season fanart (still needs to be written)
+    - season poster
+    - season banner
     - episode metadata file
-    - season thumbnails
+    - episode thumbnail
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
-        self._show_file_name = "tvshow.nfo"
-        self._ep_nfo_extension = "nfo"
-        
-        self.poster_name = "folder.jpg"
-        self.fanart_name = "fanart.jpg"
-
-        self.generate_show_metadata = True
-        self.generate_ep_metadata = True
-        
         self.name = 'Generic'
+        self._ep_nfo_extension = "nfo"
+
+        self._show_metadata_name = "tvshow.nfo"
+
+        self.show_fanart_name = "fanart.jpg"
+        self.show_poster_name = "poster.jpg"
+        self.show_banner_name = "banner.jpg"
+        self.season_all_fanart_name = "season-all-fanart.jpg"
+        self.season_all_poster_name = "season-all-poster.jpg"
+        self.season_all_banner_name = "season-all-banner.jpg"
 
         self.show_metadata = show_metadata
+        self.show_fanart = show_fanart
+        self.show_poster = show_poster
+        self.show_banner = show_banner
+
+        self.season_all_fanart = season_all_fanart
+        self.season_all_poster = season_all_poster
+        self.season_all_banner = season_all_banner
+        self.season_fanarts = season_fanarts
+        self.season_posters = season_posters
+        self.season_banners = season_banners
+
         self.episode_metadata = episode_metadata
-        self.poster = poster
-        self.fanart = fanart
         self.episode_thumbnails = episode_thumbnails
-        self.season_thumbnails = season_thumbnails
+
     
     def get_config(self):
-        config_list = [self.show_metadata, self.episode_metadata, self.poster, self.fanart, self.episode_thumbnails, self.season_thumbnails]
+        config_list = [self.show_metadata, self.show_fanart, self.show_poster, self.show_banner, self.season_all_fanart, self.season_all_poster, self.season_all_banner, self.season_fanarts, self.season_posters, self.season_banners, self.episode_metadata, self.episode_thumbnails]
         return '|'.join([str(int(x)) for x in config_list])
 
     def get_id(self):
@@ -86,57 +110,148 @@ class GenericMetadata():
     def set_config(self, string):
         config_list = [bool(int(x)) for x in string.split('|')]
         self.show_metadata = config_list[0]
-        self.episode_metadata = config_list[1]
-        self.poster = config_list[2]
-        self.fanart = config_list[3]
-        self.episode_thumbnails = config_list[4]
-        self.season_thumbnails = config_list[5]
+        self.show_fanart = config_list[1]
+        self.show_poster = config_list[2]
+        self.show_banner = config_list[3]
+        self.season_all_fanart = config_list[4]
+        self.season_all_poster = config_list[5]
+        self.season_all_banner = config_list[6]
+        self.season_fanarts = config_list[7]
+        self.season_posters = config_list[8]
+        self.season_banners = config_list[9]
+        self.episode_metadata = config_list[10]
+        self.episode_thumbnails = config_list[11]
     
     def _has_show_metadata(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_show_file_path(show_obj))
-        logger.log("Checking if "+self.get_show_file_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        result = ek.ek(os.path.isfile, self.get_show_metadata_path(show_obj))
+        logger.log("Checking if "+self.get_show_metadata_path(show_obj)+" (Show Metadata) exists: "+str(result), logger.DEBUG)
         return result
     
+    def _has_show_fanart(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_fanart_path(show_obj))
+        logger.log("Checking if "+self.get_show_fanart_path(show_obj)+" (Show Fanart) exists: "+str(result), logger.DEBUG)
+        return result
+    
+    def _has_show_poster(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_poster_path(show_obj))
+        logger.log("Checking if "+self.get_show_poster_path(show_obj)+" (Show Poster) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_show_banner(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_banner_path(show_obj))
+        logger.log("Checking if "+self.get_show_banner_path(show_obj)+" (Show Banner) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_all_fanart(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_fanart_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_fanart_path(show_obj)+" (Season All Fanart) exists: "+str(result), logger.DEBUG)
+        return result
+    
+    def _has_season_all_poster(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_poster_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_poster_path(show_obj)+" (Season All Poster) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_all_banner(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_banner_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_banner_path(show_obj)+" (Season All Banner) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_fanart(self, show_obj, season):
+        location = self.season_fanart_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" (Season Fanart) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_poster(self, show_obj, season):
+        location = self.season_poster_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" (Season Poster) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_banner(self, show_obj, season):
+        location = self.season_banner_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" (Season Banner) exists: "+str(result), logger.DEBUG)
+        return result
+
     def _has_episode_metadata(self, ep_obj):
         result = ek.ek(os.path.isfile, self.get_episode_file_path(ep_obj))
-        logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def _has_poster(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_poster_path(show_obj))
-        logger.log("Checking if "+self.get_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def _has_fanart(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_fanart_path(show_obj))
-        logger.log("Checking if "+self.get_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" (Episode Metadata) exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_episode_thumb(self, ep_obj):
         location = self.get_episode_thumb_path(ep_obj)
         result = location != None and ek.ek(os.path.isfile, location)
         if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+            logger.log("Checking if "+location+" (Episode Thumbnail) exists: "+str(result), logger.DEBUG)
         return result
     
-    def _has_season_thumb(self, show_obj, season):
-        location = self.get_season_thumb_path(show_obj, season)
-        result = location != None and ek.ek(os.path.isfile, location)
-        if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def get_show_file_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self._show_file_name)
+    def get_show_metadata_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self._show_metadata_name)
 
     def get_episode_file_path(self, ep_obj):
         return helpers.replaceExtension(ep_obj.location, self._ep_nfo_extension)
 
-    def get_poster_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.poster_name)
-            
-    def get_fanart_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.fanart_name)
+    def get_show_fanart_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_fanart_name)
+
+    def get_show_poster_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_poster_name)
+
+    def get_show_banner_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_banner_name)
+
+    def get_season_all_fanart_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_fanart_name)
+
+    def get_season_all_poster_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_poster_name)
+
+    def get_season_all_banner_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_banner_name)
+
+    def get_season_fanart_path(self, show_obj, season):
+        """
+        Returns the full path to the file for a given season thumb.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+'-fanart.jpg')
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)        
+        
+        if img_type == 'season':
+           season_pb_file_ext = '-poster.jpg'
+        else:
+           season_pb_file_ext = '-banner.jpg'
+        
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path)            
             
     def get_episode_thumb_path(self, ep_obj):
         """
@@ -151,23 +266,6 @@ class GenericMetadata():
             return None
         
         return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
-        """
-        Returns the full path to the file for a given season thumb.
-        
-        show_obj: a TVShow instance for which to generate the path
-        season: a season number to be used for the path. Note that sesaon 0
-                means specials.
-        """
-
-        # Our specials thumbnail is, well, special
-        if season == 0:
-            season_thumb_file_path = 'season-specials'
-        else:
-            season_thumb_file_path = 'season' + str(season).zfill(2)
-        
-        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'.tbn')
     
     def _show_data(self, show_obj):
         """
@@ -188,36 +286,255 @@ class GenericMetadata():
             logger.log("Metadata provider "+self.name+" creating show metadata for "+show_obj.name, logger.DEBUG)
             return self.write_show_file(show_obj)
         return False
+
+    def create_show_fanart(self, show_obj):
+        if self.show_fanart and show_obj and not self._has_show_fanart(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show fanart for "+show_obj.name, logger.DEBUG)
+            fanart_path = self.get_show_fanart_path(show_obj)
+            return self.save_show_fpb(show_obj, "fanart", fanart_path)
+        return False
     
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            return self.save_show_fpb(show_obj, "poster", poster_path)
+        return False
+
+    def create_show_banner(self, show_obj):
+        if self.show_banner and show_obj and not self._has_show_banner(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show banner for "+show_obj.name, logger.DEBUG)
+            banner_path = self.get_show_banner_path(show_obj)
+            return self.save_show_fpb(show_obj, "banner", banner_path)
+        return False
+
+    def create_season_all_fanart(self, show_obj):
+        if self.season_all_fanart and show_obj and not self._has_season_all_fanart(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all fanart for "+show_obj.name, logger.DEBUG)
+            season_all_fanart_path = self.get_season_all_fanart_path(show_obj)
+            return self.save_show_fpb(show_obj, "fanart", season_all_fanart_path)
+        return False
+    
+    def create_season_all_poster(self, show_obj):
+        if self.season_all_poster and show_obj and not self._has_season_all_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all poster for "+show_obj.name, logger.DEBUG)
+            season_all_poster_path = self.get_season_all_poster_path(show_obj)
+            return self.save_show_fpb(show_obj, "poster", season_all_poster_path)
+        return False
+
+    def create_season_all_banner(self, show_obj):
+        if self.season_all_banner and show_obj and not self._has_season_all_banner(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all banner for "+show_obj.name, logger.DEBUG)
+            season_all_banner_path = self.get_season_all_banner_path(show_obj)
+            return self.save_show_fpb(show_obj, "banner", season_all_banner_path)
+        return False
+
+    def create_season_fanart(self, show_obj):
+        if self.season_fanarts and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season fanart for "+show_obj.name, logger.DEBUG)
+            return self.save_season_fanart(show_obj)
+        return False
+
+    def create_season_poster(self, show_obj):
+        if self.season_posters and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season poster for "+show_obj.name, logger.DEBUG)
+            return self.save_season_pb(show_obj,'season')
+        return False
+
+    def create_season_banner(self, show_obj):
+        if self.season_banners and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season banner for "+show_obj.name, logger.DEBUG)
+            return self.save_season_pb(show_obj,'seasonwide')
+        return False
+
     def create_episode_metadata(self, ep_obj):
         if self.episode_metadata and ep_obj and not self._has_episode_metadata(ep_obj):
             logger.log("Metadata provider "+self.name+" creating episode metadata for "+ep_obj.prettyName(), logger.DEBUG)
             return self.write_ep_file(ep_obj)
         return False
     
-    def create_poster(self, show_obj):
-        if self.poster and show_obj and not self._has_poster(show_obj):
-            logger.log("Metadata provider "+self.name+" creating poster for "+show_obj.name, logger.DEBUG)
-            return self.save_poster(show_obj)
-        return False
-    
-    def create_fanart(self, show_obj):
-        if self.fanart and show_obj and not self._has_fanart(show_obj):
-            logger.log("Metadata provider "+self.name+" creating fanart for "+show_obj.name, logger.DEBUG)
-            return self.save_fanart(show_obj)
-        return False
-    
     def create_episode_thumb(self, ep_obj):
         if self.episode_thumbnails and ep_obj and not self._has_episode_thumb(ep_obj):
-            logger.log("Metadata provider "+self.name+" creating show metadata for "+ep_obj.prettyName(), logger.DEBUG)
-            return self.save_thumbnail(ep_obj)
+            logger.log("Metadata provider "+self.name+" creating episode thumbnail for "+ep_obj.prettyName(), logger.DEBUG)
+            return self.save_episode_thumbnail(ep_obj)
         return  False
     
-    def create_season_thumbs(self, show_obj):
-        if self.season_thumbnails and show_obj:
-            logger.log("Metadata provider "+self.name+" creating season thumbnails for "+show_obj.name, logger.DEBUG)
-            return self.save_season_thumbs(show_obj)
-        return False
+    def write_show_file(self, show_obj):
+        """
+        Generates and writes show_obj's metadata under the given path to the
+        filename given by get_show_file_path()
+        
+        show_obj: TVShow object for which to create the metadata
+        
+        path: An absolute or relative path where we should put the file. Note that
+                the file name will be the default show_file_name.
+        
+        Note that this method expects that _show_data will return an ElementTree
+        object. If your _show_data returns data in another format you'll need to
+        override this method.
+        """
+        
+        data = self._show_data(show_obj)
+        
+        if not data:
+            return False
+        
+        nfo_file_path = self.get_show_metadata_path(show_obj)
+        nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
+
+        try:
+            if not ek.ek(os.path.isdir, nfo_file_dir):
+                logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
+                ek.ek(os.makedirs, nfo_file_dir)
+                helpers.chmodAsParent(nfo_file_dir)
+    
+            logger.log(u"Writing show nfo file to "+nfo_file_path)
+            
+            nfo_file = ek.ek(open, nfo_file_path, 'w')
+    
+            data.write(nfo_file, encoding="utf-8")
+            nfo_file.close()
+            helpers.chmodAsParent(nfo_file_path)
+        except IOError, e:
+            logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+ex(e), logger.ERROR)
+            return False
+        
+        return True
+
+    def save_show_fpb(self, show_obj, img_type, img_path, which=None):
+        """
+        Downloads a image and saves it to the filename specified by img_path
+        inside the show's root folder.
+        
+        show_obj: a TVShow object for which to download fanart/poster/banner 
+        """
+        
+        img_data = self._retrieve_show_image(img_type, show_obj, which)
+
+        if not img_data:
+            logger.log(u"No " + img_type + " image was retrieved, unable to write " + img_type, logger.DEBUG)
+            return False
+
+        return self._write_image(img_data, img_path)
+
+    def _season_fanart_dict(self, show_obj):
+        """
+    	need to write query for this    	
+    	"""
+    	# IRC: TO BE DONE
+	return result	
+
+    def _season_pb_dict(self, show_obj, img_type):
+        """
+        Should return a dict like:
+        
+        result = {<season number>: 
+                    {1: '<url 1>', 2: <url 2>, ...},}
+        """
+
+        # This holds our resulting dictionary of season art
+        result = {}
+    
+        tvdb_lang = show_obj.lang
+
+        try:
+            # There's gotta be a better way of doing this but we don't wanna
+            # change the language value elsewhere
+            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+            if tvdb_lang and not tvdb_lang == 'en':
+                ltvdb_api_parms['language'] = tvdb_lang
+
+            t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
+            tvdb_show_obj = t[show_obj.tvdbid]
+        except (tvdb_exceptions.tvdb_error, IOError), e:
+            logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
+            return result
+    
+        # How many seasons?
+        # num_seasons = len(tvdb_show_obj)
+        # logger.log(u"TV Show has " + str(num_seasons) + " season(s)", logger.DEBUG)
+    
+        # if we have no season banners then just finish
+        if 'season' not in tvdb_show_obj['_banners'] or img_type not in tvdb_show_obj['_banners']['season']:
+            return result
+    
+        # Give us just the normal poster-style season graphics
+        seasonsArtObj = tvdb_show_obj['_banners']['season'][img_type]
+
+        #for seasonArtID in seasonsArtObj.keys():
+        #    if int(seasonsArtObj[seasonArtID]['season']) == 2 and seasonsArtObj[seasonArtID]['language'] == 'en':
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['season'], logger.DEBUG)
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['language'], logger.DEBUG)
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['_bannerpath'], logger.DEBUG)
+
+        # Returns a nested dictionary of season art with the season
+        # number as primary key. It's really overkill but gives the option
+        # to present to user via ui to pick down the road.
+        # edited the range as not always getting last season
+        #for cur_season in range(num_seasons+1):
+        for cur_season in tvdb_show_obj:
+
+            result[cur_season] = {}
+            
+            # find the correct season in the tvdb object and just copy the dict into our result dict
+            for seasonArtID in seasonsArtObj.keys():
+                if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
+                    result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
+
+            #logger.log(u"Season " + str(cur_season) + " artwork found", logger.DEBUG)
+            
+            if len(result[cur_season]) == 0:
+                continue
+
+        return result
+
+    def save_season_pb(self, show_obj, img_type):
+        """
+        Saves all season poster/banner to disk for the given show.
+        
+        show_obj: a TVShow object for which to save the season poster/banner
+        
+        Cycles through all seasons and saves the season poster/banner if possible. This
+        method should not need to be overridden by implementing classes, changing
+        _season_thumb_dict and get_season_thumb_path should be good enough.
+        """
+    
+        season_dict = self._season_pb_dict(show_obj, img_type)
+        # logger.log(u"Season image list filled", logger.DEBUG)
+   
+        # Returns a nested dictionary of season art with the season
+        # number as primary key. It's really overkill but gives the option
+        # to present to user via ui to pick down the road.
+        for cur_season in season_dict:
+
+            cur_season_art = season_dict[cur_season]
+            
+            if len(cur_season_art) == 0:
+                continue
+
+            # Just grab whatever's there for now
+            art_id, season_url = cur_season_art.popitem() #@UnusedVariable
+            #logger.log(u"Season " + str(cur_season) + " artwork url: " + season_url, logger.DEBUG)
+            season_image_path = self.get_season_pb_path(show_obj, cur_season, img_type)
+            #logger.log(u"Season " + str(cur_season) + " artwork path: " + season_image_path, logger.DEBUG)
+            
+            if not season_image_path:
+                logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
+                continue
+            
+            seasonData = metadata_helpers.getShowImage(season_url)
+            
+            if not seasonData:
+                logger.log(u"No season image data available, skipping this season", logger.DEBUG)
+                continue
+            
+            #logger.log(u"Season " + str(cur_season) + " image data recieved", logger.DEBUG)            
+            result = self._write_image(seasonData, season_image_path)
+            #logger.log(u"Season " + str(cur_season) + " image data saved", logger.DEBUG)
+            
+        #logger.log(u"Season artwork Finished: " + img_type, logger.DEBUG)    
+        return True
     
     def _get_episode_thumb_url(self, ep_obj):
         """
@@ -262,47 +579,6 @@ class GenericMetadata():
 
         return None
     
-    def write_show_file(self, show_obj):
-        """
-        Generates and writes show_obj's metadata under the given path to the
-        filename given by get_show_file_path()
-        
-        show_obj: TVShow object for which to create the metadata
-        
-        path: An absolute or relative path where we should put the file. Note that
-                the file name will be the default show_file_name.
-        
-        Note that this method expects that _show_data will return an ElementTree
-        object. If your _show_data returns data in another format you'll need to
-        override this method.
-        """
-        
-        data = self._show_data(show_obj)
-        
-        if not data:
-            return False
-        
-        nfo_file_path = self.get_show_file_path(show_obj)
-        nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
-
-        try:
-            if not ek.ek(os.path.isdir, nfo_file_dir):
-                logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
-                ek.ek(os.makedirs, nfo_file_dir)
-                helpers.chmodAsParent(nfo_file_dir)
-    
-            logger.log(u"Writing show nfo file to "+nfo_file_path)
-            
-            nfo_file = ek.ek(open, nfo_file_path, 'w')
-    
-            data.write(nfo_file, encoding="utf-8")
-            nfo_file.close()
-            helpers.chmodAsParent(nfo_file_path)
-        except IOError, e:
-            logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+ex(e), logger.ERROR)
-            return False
-        
-        return True
 
     def write_ep_file(self, ep_obj):
         """
@@ -381,93 +657,6 @@ class GenericMetadata():
             cur_ep.hastbn = True
     
         return True
-    
-    def save_fanart(self, show_obj, which=None):
-        """
-        Downloads a fanart image and saves it to the filename specified by fanart_name
-        inside the show's root folder.
-        
-        show_obj: a TVShow object for which to download fanart 
-        """
-
-        # use the default fanart name
-        fanart_path = self.get_fanart_path(show_obj)
-        
-        fanart_data = self._retrieve_show_image('fanart', show_obj, which)
-
-        if not fanart_data:
-            logger.log(u"No fanart image was retrieved, unable to write fanart", logger.DEBUG)
-            return False
-
-        return self._write_image(fanart_data, fanart_path)
-
-
-    def save_poster(self, show_obj, which=None):
-        """
-        Downloads a poster image and saves it to the filename specified by poster_name
-        inside the show's root folder.
-        
-        show_obj: a TVShow object for which to download a poster 
-        """
-
-        # use the default poster name
-        poster_path = self.get_poster_path(show_obj)
-        
-        if sickbeard.USE_BANNER:
-            img_type = 'banner'
-        else:
-            img_type = 'poster'
-        
-        poster_data = self._retrieve_show_image(img_type, show_obj, which)
-
-        if not poster_data:
-            logger.log(u"No show folder image was retrieved, unable to write poster", logger.DEBUG)
-            return False
-
-        return self._write_image(poster_data, poster_path)
-
-
-    def save_season_thumbs(self, show_obj):
-        """
-        Saves all season thumbnails to disk for the given show.
-        
-        show_obj: a TVShow object for which to save the season thumbs
-        
-        Cycles through all seasons and saves the season thumbs if possible. This
-        method should not need to be overridden by implementing classes, changing
-        _season_thumb_dict and get_season_thumb_path should be good enough.
-        """
-    
-        season_dict = self._season_thumb_dict(show_obj)
-    
-        # Returns a nested dictionary of season art with the season
-        # number as primary key. It's really overkill but gives the option
-        # to present to user via ui to pick down the road.
-        for cur_season in season_dict:
-
-            cur_season_art = season_dict[cur_season]
-            
-            if len(cur_season_art) == 0:
-                continue
-    
-            # Just grab whatever's there for now
-            art_id, season_url = cur_season_art.popitem() #@UnusedVariable
-
-            season_thumb_file_path = self.get_season_thumb_path(show_obj, cur_season)
-            
-            if not season_thumb_file_path:
-                logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
-                continue
-    
-            seasonData = metadata_helpers.getShowImage(season_url)
-            
-            if not seasonData:
-                logger.log(u"No season thumb data available, skipping this season", logger.DEBUG)
-                continue
-            
-            self._write_image(seasonData, season_thumb_file_path)
-    
-        return True
 
     def _write_image(self, image_data, image_path):
         """
@@ -477,6 +666,7 @@ class GenericMetadata():
         image_data: binary image data to write to file
         image_path: file location to save the image to
         """
+        #logger.log(u"Creating Image from data:" + image_path, logger.DEBUG)
         
         # don't bother overwriting it
         if ek.ek(os.path.isfile, image_path):
@@ -486,7 +676,7 @@ class GenericMetadata():
         if not image_data:
             logger.log(u"Unable to retrieve image, skipping", logger.WARNING)
             return False
-
+        
         image_dir = ek.ek(os.path.dirname, image_path)
         
         try:
@@ -494,7 +684,7 @@ class GenericMetadata():
                 logger.log("Metadata dir didn't exist, creating it at "+image_dir, logger.DEBUG)
                 ek.ek(os.makedirs, image_dir)
                 helpers.chmodAsParent(image_dir)
-
+            
             outFile = ek.ek(open, image_path, 'wb')
             outFile.write(image_data)
             outFile.close()
@@ -502,7 +692,7 @@ class GenericMetadata():
         except IOError, e:
             logger.log(u"Unable to write image to "+image_path+" - are you sure the show folder is writable? "+ex(e), logger.ERROR)
             return False
-    
+        
         return True
     
     def _retrieve_show_image(self, image_type, show_obj, which=None):
@@ -542,65 +732,12 @@ class GenericMetadata():
 
         return image_data
     
-    def _season_thumb_dict(self, show_obj):
-        """
-        Should return a dict like:
-        
-        result = {<season number>: 
-                    {1: '<url 1>', 2: <url 2>, ...},}
-        """
-
-        # This holds our resulting dictionary of season art
-        result = {}
-    
-        tvdb_lang = show_obj.lang
-
-        try:
-            # There's gotta be a better way of doing this but we don't wanna
-            # change the language value elsewhere
-            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
-
-            if tvdb_lang and not tvdb_lang == 'en':
-                ltvdb_api_parms['language'] = tvdb_lang
-
-            t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
-            tvdb_show_obj = t[show_obj.tvdbid]
-        except (tvdb_exceptions.tvdb_error, IOError), e:
-            logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
-            return result
-    
-        #  How many seasons?
-        num_seasons = len(tvdb_show_obj)
-    
-        # if we have no season banners then just finish
-        if 'season' not in tvdb_show_obj['_banners'] or 'season' not in tvdb_show_obj['_banners']['season']:
-            return result
-    
-        # Give us just the normal poster-style season graphics
-        seasonsArtObj = tvdb_show_obj['_banners']['season']['season']
-    
-        # Returns a nested dictionary of season art with the season
-        # number as primary key. It's really overkill but gives the option
-        # to present to user via ui to pick down the road.
-        for cur_season in range(num_seasons):
-
-            result[cur_season] = {}
-            
-            # find the correct season in the tvdb object and just copy the dict into our result dict
-            for seasonArtID in seasonsArtObj.keys():
-                if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
-                    result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
-            
-            if len(result[cur_season]) == 0:
-                continue
-
-        return result
 
     def retrieveShowMetadata(self, dir):
     
         empty_return = (None, None)
     
-        metadata_path = ek.ek(os.path.join, dir, self._show_file_name)
+        metadata_path = ek.ek(os.path.join, dir, self._show_metadata_name)
     
         if not ek.ek(os.path.isdir, dir) or not ek.ek(os.path.isfile, metadata_path):
             logger.log(u"Can't load the metadata file from "+repr(metadata_path)+", it doesn't exist", logger.DEBUG)

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -451,9 +451,9 @@ class GenericMetadata():
             logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
             return result
     
-        #  How many seasons?
-        num_seasons = len(tvdb_show_obj)
-        logger.log(u"TV Show has " + str(num_seasons) + " season(s)", logger.DEBUG)
+        # How many seasons?
+        # num_seasons = len(tvdb_show_obj)
+        # logger.log(u"TV Show has " + str(num_seasons) + " season(s)", logger.DEBUG)
     
         # if we have no season banners then just finish
         if 'season' not in tvdb_show_obj['_banners'] or img_type not in tvdb_show_obj['_banners']['season']:
@@ -472,7 +472,8 @@ class GenericMetadata():
         # number as primary key. It's really overkill but gives the option
         # to present to user via ui to pick down the road.
         # edited the range as not always getting last season
-        for cur_season in range(num_seasons+1):
+        #for cur_season in range(num_seasons+1):
+        for cur_season in tvdb_show_obj:
 
             result[cur_season] = {}
             
@@ -500,7 +501,7 @@ class GenericMetadata():
         """
     
         season_dict = self._season_pb_dict(show_obj, img_type)
-        logger.log(u"Season image list filled", logger.DEBUG)
+        # logger.log(u"Season image list filled", logger.DEBUG)
    
         # Returns a nested dictionary of season art with the season
         # number as primary key. It's really overkill but gives the option

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -41,11 +41,10 @@ class MediaBrowserMetadata(generic.GenericMetadata):
     http://code.google.com/p/sickbeard/issues/detail?id=311
     
     The following file structure is used:
-    
     show_root/series.xml                           (show metadata)
-    show_root/folder.jpg                           (poster)
-    show_root/backdrop.jpg                         (fanart)
-    show_root/Season 01/folder.jpg                 (season thumb)
+    show_root/folder.jpg                           (show poster)
+    show_root/backdrop.jpg                         (show fanart)
+    show_root/Season 01/folder.jpg                 (season poster)
     show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.xml  (episode metadata)
     show_root/metadata/show - 1x01 - episode.jpg   (episode thumb)
@@ -53,32 +52,54 @@ class MediaBrowserMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
-        self.fanart_name = "backdrop.jpg"
-        self._show_file_name = 'series.xml'
-        self._ep_nfo_extension = 'xml'
 
         self.name = 'MediaBrowser'
+        self._ep_nfo_extension = 'xml'
+
+        self.show_fanart_name = "backdrop.jpg"
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
+        self.eg_show_fanart = "backdrop.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "Season##\\folder.jpg"
+        self.eg_season_banners = "<i>not supported</i>"
+
         self.eg_episode_metadata = "Season##\\metadata\\<i>filename</i>.xml"
-        self.eg_fanart = "backdrop.jpg"
-        self.eg_poster = "folder.jpg"
         self.eg_episode_thumbnails = "Season##\\metadata\\<i>filename</i>.jpg"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
+        
     
     def get_episode_file_path(self, ep_obj):
         """
@@ -98,24 +119,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         
         return xml_file_path
 
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns a full show dir/metadata/episode.jpg path for MediaBrowser
-        episode thumbs.
-        
-        ep_obj: a TVEpisode object to get the path from
-        """
-
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
-            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), 'metadata')
-            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
-        else:
-            return None
-        
-        return tbn_file_path
-    
-    def get_season_thumb_path(self, show_obj, season):
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for MediaBrowser go in Show Dir/Season X/folder.jpg
         
@@ -150,6 +154,23 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns a full show dir/metadata/episode.jpg path for MediaBrowser
+        episode thumbs.
+        
+        ep_obj: a TVEpisode object to get the path from
+        """
+
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
+            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), 'metadata')
+            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
+        else:
+            return None
+        
+        return tbn_file_path
 
     def _show_data(self, show_obj):
         """
@@ -401,6 +422,36 @@ class MediaBrowserMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+	
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+	# all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
     
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -86,19 +86,19 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
-        self.eg_episode_metadata = "Season##\\metadata\\<i>filename</i>.xml"
-        self.eg_episode_thumbnails = "Season##\\metadata\\<i>filename</i>.jpg"
-
         self.eg_show_fanart = "backdrop.jpg"
         self.eg_show_poster = "folder.jpg"
         self.eg_show_banner = "<i>not supported</i>"
-        self.eg_seasons_all_fanart = "<i>not supported</i>"
-        self.eg_seasons_all_poster = "<i>not supported</i>"
-        self.eg_seasons_all_banner = "<i>not supported</i>"
 
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
         self.eg_season_fanarts = "<i>not supported</i>"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
+        self.eg_season_posters = "Season##\\folder.jpg"
         self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\metadata\\<i>filename</i>.xml"
+        self.eg_episode_thumbnails = "Season##\\metadata\\<i>filename</i>.jpg"
         
     
     def get_episode_file_path(self, ep_obj):

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -76,7 +76,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
         
 
         self.name = 'MediaBrowser'
@@ -423,7 +423,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
         return data
 	
-	def create_show_poster(self, show_obj):
+    def create_show_poster(self, show_obj):
         if self.show_poster and show_obj and not self._has_show_poster(show_obj):
             logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
             poster_path = self.get_show_poster_path(show_obj)

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -27,51 +27,59 @@ class PS3Metadata(generic.GenericMetadata):
     Metadata generation class for Sony PS3.
 
     The following file structure is used:
-    
-    show_root/cover.jpg                                      (poster)
-    show_root/Season 01/show - 1x01 - episode.avi            (existing video)
+    show_root/cover.jpg                                      (show poster)
+    show_root/Season 01/show - 1x01 - episode.avi            (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.avi.cover.jpg  (episode thumb)
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
-        self.poster_name = 'cover.jpg'
+
         self.name = 'Sony PS3'
 
+        self.show_poster_name = 'cover.jpg'
+
         self.eg_show_metadata = "<i>not supported</i>"
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "cover.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "<i>not supported</i>" 
+        self.eg_season_banners = "<i>not supported</i>"
+
         self.eg_episode_metadata = "<i>not supported</i>"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "cover.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.ext.cover.jpg"
-        self.eg_season_thumbnails = "<i>not supported</i>"
-    
-    # all of the following are not supported, so do nothing
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_episode_metadata(self, ep_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def create_season_thumbs(self, show_obj):
-        pass
-    
+
     def get_episode_thumb_path(self, ep_obj):
         """
         Returns the path where the episode thumbnail should be stored. Defaults to
@@ -85,6 +93,48 @@ class PS3Metadata(generic.GenericMetadata):
             return None
         
         return tbn_filename
+
+    # all of the following are not supported, so do nothing
+    def create_show_metadata(self, show_obj):
+        pass
+
+    def create_show_fanart(self, show_obj): 
+        pass
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+    def create_show_banner(self, show_obj): 
+        pass
+
+    def create_season_all_fanart(self, show_obj): 
+        pass
+
+    def create_season_all_poster(self, show_obj): 
+        pass
+
+    def create_season_all_banner(self, show_obj): 
+        pass
+
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_poster(self, show_obj):
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
+
+    def create_episode_metadata(self, ep_obj):
+        pass
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -58,7 +58,7 @@ class PS3Metadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
         
 
         self.name = 'Sony PS3'

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -27,51 +27,59 @@ class PS3Metadata(generic.GenericMetadata):
     Metadata generation class for Sony PS3.
 
     The following file structure is used:
-    
-    show_root/cover.jpg                                      (poster)
-    show_root/Season 01/show - 1x01 - episode.avi            (existing video)
+    show_root/cover.jpg                                      (show poster)
+    show_root/Season 01/show - 1x01 - episode.avi            (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.avi.cover.jpg  (episode thumb)
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails):
         
-        self.poster_name = 'cover.jpg'
+
         self.name = 'Sony PS3'
+
+        self.show_poster_name = 'cover.jpg'
 
         self.eg_show_metadata = "<i>not supported</i>"
         self.eg_episode_metadata = "<i>not supported</i>"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "cover.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.ext.cover.jpg"
-        self.eg_season_thumbnails = "<i>not supported</i>"
-    
-    # all of the following are not supported, so do nothing
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_episode_metadata(self, ep_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def create_season_thumbs(self, show_obj):
-        pass
-    
+
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "cover.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+        self.eg_seasons_all_fanart = "<i>not supported</i>"
+        self.eg_seasons_all_poster = "<i>not supported</i>"
+        self.eg_seasons_all_banner = "<i>not supported</i>"
+
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_thumbnails = "<i>not supported</i>" 
+        self.eg_season_banners = "<i>not supported</i>"
+
     def get_episode_thumb_path(self, ep_obj):
         """
         Returns the path where the episode thumbnail should be stored. Defaults to
@@ -85,6 +93,48 @@ class PS3Metadata(generic.GenericMetadata):
             return None
         
         return tbn_filename
+
+    # all of the following are not supported, so do nothing
+    def create_show_metadata(self, show_obj):
+        pass
+
+    def create_show_fanart(self, show_obj): 
+        pass
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+    def create_show_banner(self, show_obj): 
+        pass
+
+    def create_season_all_fanart(self, show_obj): 
+        pass
+
+    def create_season_all_poster(self, show_obj): 
+        pass
+
+    def create_season_all_banner(self, show_obj): 
+        pass
+
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_poster(self, show_obj):
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
+
+    def create_episode_metadata(self, ep_obj):
+        pass
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -66,19 +66,19 @@ class PS3Metadata(generic.GenericMetadata):
         self.show_poster_name = 'cover.jpg'
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "<i>not supported</i>"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.ext.cover.jpg"
-
         self.eg_show_fanart = "<i>not supported</i>"
         self.eg_show_poster = "cover.jpg"
         self.eg_show_banner = "<i>not supported</i>"
-        self.eg_seasons_all_fanart = "<i>not supported</i>"
-        self.eg_seasons_all_poster = "<i>not supported</i>"
-        self.eg_seasons_all_banner = "<i>not supported</i>"
 
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
         self.eg_season_fanarts = "<i>not supported</i>"
-        self.eg_season_thumbnails = "<i>not supported</i>" 
+        self.eg_season_posters = "<i>not supported</i>" 
         self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "<i>not supported</i>"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.ext.cover.jpg"
 
     def get_episode_thumb_path(self, ep_obj):
         """

--- a/sickbeard/metadata/synology.py
+++ b/sickbeard/metadata/synology.py
@@ -42,11 +42,10 @@ class SynologyMetadata(generic.GenericMetadata):
     http://code.google.com/p/sickbeard/issues/detail?id=311
     
     The following file structure is used:
-    
     show_root/series.xml                           (show metadata)
-    show_root/folder.jpg                           (poster)
-    show_root/backdrop.jpg                         (fanart)
-    show_root/Season 01/folder.jpg                 (season thumb)
+    show_root/folder.jpg                           (show poster)
+    show_root/backdrop.jpg                         (show fanart)
+    show_root/Season 01/folder.jpg                 (season poster)
     show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.xml  (episode metadata)
     show_root/Season 01/show - 1x01 - episode.jpg  (episode thumb)
@@ -54,32 +53,53 @@ class SynologyMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
-        self.fanart_name = "backdrop.jpg"
-        self._show_file_name = 'series.xml'
+        self.name = 'Synology'
         self._ep_nfo_extension = 'xml'
 
-        self.name = 'Synology'
+        self._show_metadata_name = 'series.xml'
+        self.show_fanart_name = "backdrop.jpg"
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
+        self.eg_show_fanart = "backdrop.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "Season##\\folder.jpg" 
+        self.eg_season_banners = "<i>not supported</i>"
+
         self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "backdrop.jpg"
-        self.eg_poster = "folder.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
     
     def get_episode_file_path(self, ep_obj):
         """
@@ -99,24 +119,7 @@ class SynologyMetadata(generic.GenericMetadata):
         
         return xml_file_path
 
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns a full show dir/episode.jpg path for Synology
-        episode thumbs.
-        
-        ep_obj: a TVEpisode object to get the path from
-        """
-
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
-            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), '')
-            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
-        else:
-            return None
-        
-        return tbn_file_path
-    
-    def get_season_thumb_path(self, show_obj, season):
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for Synology go in Show Dir/Season X/folder.jpg
         
@@ -151,6 +154,23 @@ class SynologyMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns a full show dir/episode.jpg path for Synology
+        episode thumbs.
+        
+        ep_obj: a TVEpisode object to get the path from
+        """
+
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
+            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), '')
+            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
+        else:
+            return None
+        
+        return tbn_file_path
 
     def _show_data(self, show_obj):
         """
@@ -256,7 +276,6 @@ class SynologyMetadata(generic.GenericMetadata):
         data = etree.ElementTree(tv_node)
 
         return data
-
 
     def _ep_data(self, ep_obj):
         """
@@ -402,6 +421,36 @@ class SynologyMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+	# all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+
+    def create_season_all_fanart(self, show_obj): 
+        pass
+
+    def create_season_all_poster(self, show_obj): 
+        pass
+
+    def create_season_all_banner(self, show_obj): 
+        pass
+
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
     
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/synology.py
+++ b/sickbeard/metadata/synology.py
@@ -87,19 +87,19 @@ class SynologyMetadata(generic.GenericMetadata):
         self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
-
         self.eg_show_fanart = "backdrop.jpg"
         self.eg_show_poster = "folder.jpg"
         self.eg_show_banner = "<i>not supported</i>"
-        self.eg_seasons_all_fanart = "<i>not supported</i>"
-        self.eg_seasons_all_poster = "<i>not supported</i>"
-        self.eg_seasons_all_banner = "<i>not supported</i>"
 
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
         self.eg_season_fanarts = "<i>not supported</i>"
-        self.eg_season_thumbnails = "Season##\\folder.jpg" 
+        self.eg_season_posters = "Season##\\folder.jpg" 
         self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
     
     def get_episode_file_path(self, ep_obj):
         """

--- a/sickbeard/metadata/synology.py
+++ b/sickbeard/metadata/synology.py
@@ -42,11 +42,10 @@ class SynologyMetadata(generic.GenericMetadata):
     http://code.google.com/p/sickbeard/issues/detail?id=311
     
     The following file structure is used:
-    
     show_root/series.xml                           (show metadata)
-    show_root/folder.jpg                           (poster)
-    show_root/backdrop.jpg                         (fanart)
-    show_root/Season 01/folder.jpg                 (season thumb)
+    show_root/folder.jpg                           (show poster)
+    show_root/backdrop.jpg                         (show fanart)
+    show_root/Season 01/folder.jpg                 (season poster)
     show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.xml  (episode metadata)
     show_root/Season 01/show - 1x01 - episode.jpg  (episode thumb)
@@ -54,32 +53,53 @@ class SynologyMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails):
         
-        self.fanart_name = "backdrop.jpg"
-        self._show_file_name = 'series.xml'
+        self.name = 'Synology'
         self._ep_nfo_extension = 'xml'
 
-        self.name = 'Synology'
+        self._show_metadata_name = 'series.xml'
+        self.show_fanart_name = "backdrop.jpg"
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
         self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "backdrop.jpg"
-        self.eg_poster = "folder.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
+
+        self.eg_show_fanart = "backdrop.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+        self.eg_seasons_all_fanart = "<i>not supported</i>"
+        self.eg_seasons_all_poster = "<i>not supported</i>"
+        self.eg_seasons_all_banner = "<i>not supported</i>"
+
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_thumbnails = "Season##\\folder.jpg" 
+        self.eg_season_banners = "<i>not supported</i>"
     
     def get_episode_file_path(self, ep_obj):
         """
@@ -99,24 +119,7 @@ class SynologyMetadata(generic.GenericMetadata):
         
         return xml_file_path
 
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns a full show dir/episode.jpg path for Synology
-        episode thumbs.
-        
-        ep_obj: a TVEpisode object to get the path from
-        """
-
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
-            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), '')
-            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
-        else:
-            return None
-        
-        return tbn_file_path
-    
-    def get_season_thumb_path(self, show_obj, season):
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for Synology go in Show Dir/Season X/folder.jpg
         
@@ -151,6 +154,23 @@ class SynologyMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns a full show dir/episode.jpg path for Synology
+        episode thumbs.
+        
+        ep_obj: a TVEpisode object to get the path from
+        """
+
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
+            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), '')
+            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
+        else:
+            return None
+        
+        return tbn_file_path
 
     def _show_data(self, show_obj):
         """
@@ -256,7 +276,6 @@ class SynologyMetadata(generic.GenericMetadata):
         data = etree.ElementTree(tv_node)
 
         return data
-
 
     def _ep_data(self, ep_obj):
         """
@@ -402,6 +421,36 @@ class SynologyMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+	# all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+
+    def create_season_all_fanart(self, show_obj): 
+        pass
+
+    def create_season_all_poster(self, show_obj): 
+        pass
+
+    def create_season_all_banner(self, show_obj): 
+        pass
+
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
     
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/synology.py
+++ b/sickbeard/metadata/synology.py
@@ -77,7 +77,7 @@ class SynologyMetadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
         
         self.name = 'Synology'
         self._ep_nfo_extension = 'xml'

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -35,8 +35,7 @@ class TIVOMetadata(generic.GenericMetadata):
     Metadata generation class for TIVO
 
     The following file structure is used:
-
-    show_root/Season 01/show - 1x01 - episode.avi.txt       (* existing episode)
+    show_root/Season 01/show - 1x01 - episode.avi           (* example of existing ep of course)
     show_root/Season 01/.meta/show - 1x01 - episode.avi.txt (episode metadata)
     
     This class only generates episode specific metadata files, it does NOT generated a default.txt file.
@@ -44,48 +43,49 @@ class TIVOMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
-        
-        self._ep_nfo_extension = "txt"
-        
-        self.generate_ep_metadata = True
+                                         episode_thumbnails)
         
         self.name = 'TIVO'
+        self._ep_nfo_extension = "txt"
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "<i>not supported</i>"
-        self.eg_episode_thumbnails = "<i>not supported</i>"
-        self.eg_season_thumbnails = "<i>not supported</i>"
-    
-    # Override with empty methods for unsupported features.
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def get_episode_thumb_path(self, ep_obj):
-        pass
-    
-    def get_season_thumb_path(self, show_obj, season):
-        pass
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "<i>not supported</i>"
+        self.eg_show_banner = "<i>not supported</i>"
 
-    def retrieveShowMetadata(self, dir):
-        return (None, None)
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "<i>not supported</i>" 
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
+        self.eg_episode_thumbnails = "<i>not supported</i>"
         
     # Override and implement features for Tivo.
     def get_episode_file_path(self, ep_obj):
@@ -107,6 +107,11 @@ class TIVOMetadata(generic.GenericMetadata):
             logger.log(u"Episode location doesn't exist: "+str(ep_obj.location), logger.DEBUG)
             return ''
         return metadata_file_path
+
+    # Override with empty methods for unsupported features.
+    def get_episode_thumb_path(self, ep_obj):
+        pass
+
 
     def _ep_data(self, ep_obj):
         """
@@ -271,9 +276,42 @@ class TIVOMetadata(generic.GenericMetadata):
             # vGuestStar, vDirector, vExecProducer, vProducer, vWriter, vHost, vChoreographer
             # partCount
             # partIndex
-            
         
         return data
+
+    # Override with empty methods for unsupported features.
+    def create_show_metadata(self, show_obj):
+        pass
+    
+    def create_show_fanart(self, show_obj):
+        pass
+
+    def create_show_poster(self, show_obj):
+        pass
+
+    def create_show_banner(self, show_obj):
+        pass
+
+    def create_season_all_fanart(self, show_obj):
+        pass
+
+    def create_season_all_poster(self, show_obj):
+        pass
+
+    def create_season_all_banner(self, show_obj):
+        pass
+
+    def create_season_fanart(self, show_obj):
+        pass
+
+    def create_season_thumbs(self, show_obj):
+        pass
+
+    def create_season_banner(self, show_obj):
+        pass
+
+    def create_episode_thumb(self, ep_obj):
+        pass
 
     def write_ep_file(self, ep_obj):
         """
@@ -314,6 +352,9 @@ class TIVOMetadata(generic.GenericMetadata):
             return False
         
         return True
+
+    def retrieveShowMetadata(self, dir):
+        return (None, None)
 
 # present a standard "interface"
 metadata_class = TIVOMetadata

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -35,8 +35,7 @@ class TIVOMetadata(generic.GenericMetadata):
     Metadata generation class for TIVO
 
     The following file structure is used:
-
-    show_root/Season 01/show - 1x01 - episode.avi.txt       (* existing episode)
+    show_root/Season 01/show - 1x01 - episode.avi           (* example of existing ep of course)
     show_root/Season 01/.meta/show - 1x01 - episode.avi.txt (episode metadata)
     
     This class only generates episode specific metadata files, it does NOT generated a default.txt file.
@@ -44,48 +43,49 @@ class TIVOMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
-        
-        self._ep_nfo_extension = "txt"
-        
-        self.generate_ep_metadata = True
+                                         episode_thumbnails):
         
         self.name = 'TIVO'
+        self._ep_nfo_extension = "txt"
 
         self.eg_show_metadata = "<i>not supported</i>"
         self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "<i>not supported</i>"
         self.eg_episode_thumbnails = "<i>not supported</i>"
-        self.eg_season_thumbnails = "<i>not supported</i>"
-    
-    # Override with empty methods for unsupported features.
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def get_episode_thumb_path(self, ep_obj):
-        pass
-    
-    def get_season_thumb_path(self, show_obj, season):
-        pass
 
-    def retrieveShowMetadata(self, dir):
-        return (None, None)
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "<i>not supported</i>"
+        self.eg_show_banner = "<i>not supported</i>"
+        self.eg_seasons_all_fanart = "<i>not supported</i>"
+        self.eg_seasons_all_poster = "<i>not supported</i>"
+        self.eg_seasons_all_banner = "<i>not supported</i>"
+
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_thumbnails = "<i>not supported</i>" 
+        self.eg_season_banners = "<i>not supported</i>"
         
     # Override and implement features for Tivo.
     def get_episode_file_path(self, ep_obj):
@@ -107,6 +107,11 @@ class TIVOMetadata(generic.GenericMetadata):
             logger.log(u"Episode location doesn't exist: "+str(ep_obj.location), logger.DEBUG)
             return ''
         return metadata_file_path
+
+    # Override with empty methods for unsupported features.
+    def get_episode_thumb_path(self, ep_obj):
+        pass
+
 
     def _ep_data(self, ep_obj):
         """
@@ -271,9 +276,42 @@ class TIVOMetadata(generic.GenericMetadata):
             # vGuestStar, vDirector, vExecProducer, vProducer, vWriter, vHost, vChoreographer
             # partCount
             # partIndex
-            
         
         return data
+
+    # Override with empty methods for unsupported features.
+    def create_show_metadata(self, show_obj):
+        pass
+    
+    def def create_show_fanart(self, show_obj):
+        pass
+
+    def create_show_poster(self, show_obj):
+        pass
+
+    def create_show_banner(self, show_obj):
+        pass
+
+    def create_season_all_fanart(self, show_obj):
+        pass
+
+    def create_season_all_poster(self, show_obj):
+        pass
+
+    def create_season_all_banner(self, show_obj):
+        pass
+
+    def create_season_fanart(self, show_obj):
+        pass
+
+    def create_season_thumbs(self, show_obj):
+        pass
+
+    def create_season_banner(self, show_obj):
+        pass
+
+    def create_episode_thumb(self, ep_obj):
+        pass
 
     def write_ep_file(self, ep_obj):
         """
@@ -314,6 +352,9 @@ class TIVOMetadata(generic.GenericMetadata):
             return False
         
         return True
+
+    def retrieveShowMetadata(self, dir):
+        return (None, None)
 
 # present a standard "interface"
 metadata_class = TIVOMetadata

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -73,19 +73,19 @@ class TIVOMetadata(generic.GenericMetadata):
         self._ep_nfo_extension = "txt"
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
-        self.eg_episode_thumbnails = "<i>not supported</i>"
-
         self.eg_show_fanart = "<i>not supported</i>"
         self.eg_show_poster = "<i>not supported</i>"
         self.eg_show_banner = "<i>not supported</i>"
-        self.eg_seasons_all_fanart = "<i>not supported</i>"
-        self.eg_seasons_all_poster = "<i>not supported</i>"
-        self.eg_seasons_all_banner = "<i>not supported</i>"
 
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
         self.eg_season_fanarts = "<i>not supported</i>"
-        self.eg_season_thumbnails = "<i>not supported</i>" 
+        self.eg_season_posters = "<i>not supported</i>" 
         self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
+        self.eg_episode_thumbnails = "<i>not supported</i>"
         
     # Override and implement features for Tivo.
     def get_episode_file_path(self, ep_obj):

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -67,7 +67,7 @@ class TIVOMetadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
         
         self.name = 'TIVO'
         self._ep_nfo_extension = "txt"
@@ -283,7 +283,7 @@ class TIVOMetadata(generic.GenericMetadata):
     def create_show_metadata(self, show_obj):
         pass
     
-    def def create_show_fanart(self, show_obj):
+    def create_show_fanart(self, show_obj):
         pass
 
     def create_show_poster(self, show_obj):

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -36,62 +36,61 @@ class WDTVMetadata(generic.GenericMetadata):
     Metadata generation class for WDTV
 
     The following file structure is used:
-    
-    show_root/folder.jpg                                     (poster)
-    show_root/Season 01/folder.jpg                           (season thumb)
+    show_root/folder.jpg                                     (show poster)
+    show_root/Season 01/folder.jpg                           (season poster)
     show_root/Season 01/show - 1x01 - episode.metathumb      (episode thumb)
     show_root/Season 01/show - 1x01 - episode.xml            (episode metadata)
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
-        
-        self._ep_nfo_extension = 'xml'
+                                         episode_thumbnails):
 
         self.name = 'WDTV'
+        self._ep_nfo_extension = 'xml'
+
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "<i>not supported</i>"
         self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "folder.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
-    
-    # all of the following are not supported, so do nothing
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns the path where the episode thumbnail should be stored. Defaults to
-        the same path as the episode file but with a .metathumb extension.
-        
-        ep_obj: a TVEpisode instance for which to create the thumbnail
-        """
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
-        else:
-            return None
 
-        return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+        self.eg_seasons_all_fanart = "<i>not supported</i>"
+        self.eg_seasons_all_poster = "<i>not supported</i>"
+        self.eg_seasons_all_banner = "<i>not supported</i>"
+
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_thumbnails = "Season##\\folder.jpg"
+        self.eg_season_banners = "<i>not supported</i>"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for WDTV go in Show Dir/Season X/folder.jpg
         
@@ -126,6 +125,20 @@ class WDTVMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .metathumb extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
+        else:
+            return None
+
+        return tbn_filename
 
     def _ep_data(self, ep_obj):
         """
@@ -224,6 +237,43 @@ class WDTVMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+
+
+    # all of the following are not supported, so do nothing
+    def create_show_metadata(self, show_obj): 
+        pass
+        
+    def create_show_fanart(self, show_obj): 
+        pass
+
+	def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+        
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj):  
+        pass
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -36,62 +36,61 @@ class WDTVMetadata(generic.GenericMetadata):
     Metadata generation class for WDTV
 
     The following file structure is used:
-    
-    show_root/folder.jpg                                     (poster)
-    show_root/Season 01/folder.jpg                           (season thumb)
+    show_root/folder.jpg                                     (show poster)
+    show_root/Season 01/folder.jpg                           (season poster)
     show_root/Season 01/show - 1x01 - episode.metathumb      (episode thumb)
     show_root/Season 01/show - 1x01 - episode.xml            (episode metadata)
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
-        
-        self._ep_nfo_extension = 'xml'
+                                         episode_thumbnails)
 
         self.name = 'WDTV'
+        self._ep_nfo_extension = 'xml'
+
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "folder.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
-    
-    # all of the following are not supported, so do nothing
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns the path where the episode thumbnail should be stored. Defaults to
-        the same path as the episode file but with a .metathumb extension.
-        
-        ep_obj: a TVEpisode instance for which to create the thumbnail
-        """
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
-        else:
-            return None
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
 
-        return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "Season##\\folder.jpg"
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for WDTV go in Show Dir/Season X/folder.jpg
         
@@ -126,6 +125,20 @@ class WDTVMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .metathumb extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
+        else:
+            return None
+
+        return tbn_filename
 
     def _ep_data(self, ep_obj):
         """
@@ -224,6 +237,43 @@ class WDTVMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+
+
+    # all of the following are not supported, so do nothing
+    def create_show_metadata(self, show_obj): 
+        pass
+        
+    def create_show_fanart(self, show_obj): 
+        pass
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+        
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj):  
+        pass
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -76,19 +76,19 @@ class WDTVMetadata(generic.GenericMetadata):
         self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
-
         self.eg_show_fanart = "<i>not supported</i>"
         self.eg_show_poster = "folder.jpg"
         self.eg_show_banner = "<i>not supported</i>"
-        self.eg_seasons_all_fanart = "<i>not supported</i>"
-        self.eg_seasons_all_poster = "<i>not supported</i>"
-        self.eg_seasons_all_banner = "<i>not supported</i>"
 
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
         self.eg_season_fanarts = "<i>not supported</i>"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
+        self.eg_season_posters = "Season##\\folder.jpg"
         self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
 
     def get_season_pb_path(self, show_obj, season, img_type):
         """

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -68,7 +68,7 @@ class WDTVMetadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
 
         self.name = 'WDTV'
         self._ep_nfo_extension = 'xml'
@@ -246,7 +246,7 @@ class WDTVMetadata(generic.GenericMetadata):
     def create_show_fanart(self, show_obj): 
         pass
 
-	def create_show_poster(self, show_obj):
+    def create_show_poster(self, show_obj):
         if self.show_poster and show_obj and not self._has_show_poster(show_obj):
             logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
             poster_path = self.get_show_poster_path(show_obj)

--- a/sickbeard/metadata/xbmc.py
+++ b/sickbeard/metadata/xbmc.py
@@ -34,28 +34,69 @@ class XBMCMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails):
         
         self.name = 'XBMC'
 
         self.eg_show_metadata = "tvshow.nfo"
         self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
-        self.eg_fanart = "fanart.jpg"
-        self.eg_poster = "folder.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
-        self.eg_season_thumbnails = "season##.tbn"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>-thumb.jpg"
+
+        self.eg_show_fanart = "fanart.jpg"
+        self.eg_show_poster = "poster.jpg"
+        self.eg_show_banner = "banner.jpg"
+        self.eg_seasons_all_fanart = "season-all-fanart.jpg"
+        self.eg_seasons_all_poster = "season-all-poster.jpg"
+        self.eg_seasons_all_banner = "season-all-banner.jpg"
+
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "season##-poster.jpg"
+        self.eg_season_banners = "season##-banner.jpg"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        season_pb_file_ext = '.tbn'
+           
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+season_pb_file_ext)            
+    
+    
     
     def _show_data(self, show_obj):
         """
@@ -313,6 +354,10 @@ class XBMCMetadata(generic.GenericMetadata):
         data = etree.ElementTree( rootNode )
 
         return data
+
+    # all of the following are not supported, so do nothing
+    def create_season_fanart(self, show_obj): 
+        pass
 
 # present a standard "interface" from the module
 metadata_class = XBMCMetadata

--- a/sickbeard/metadata/xbmc.py
+++ b/sickbeard/metadata/xbmc.py
@@ -58,7 +58,7 @@ class XBMCMetadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
         
         self.name = 'XBMC'
 

--- a/sickbeard/metadata/xbmc.py
+++ b/sickbeard/metadata/xbmc.py
@@ -34,29 +34,49 @@ class XBMCMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
         self.name = 'XBMC'
 
         self.eg_show_metadata = "tvshow.nfo"
+        self.eg_show_fanart = "fanart.jpg"
+        self.eg_show_poster = "poster.jpg"
+        self.eg_show_banner = "banner.jpg"
+
+        self.eg_season_all_fanart = "season-all-fanart.jpg"
+        self.eg_season_all_poster = "season-all-poster.jpg"
+        self.eg_season_all_banner = "season-all-banner.jpg"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "season##-poster.jpg"
+        self.eg_season_banners = "season##-banner.jpg"
+
         self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
-        self.eg_fanart = "fanart.jpg"
-        self.eg_poster = "folder.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
-        self.eg_season_thumbnails = "season##.tbn"
-    
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>-thumb.jpg"
+
     def _show_data(self, show_obj):
         """
         Creates an elementTree XML structure for an XBMC-style tvshow.nfo and
@@ -313,6 +333,10 @@ class XBMCMetadata(generic.GenericMetadata):
         data = etree.ElementTree( rootNode )
 
         return data
+
+    # all of the following are not supported, so do nothing
+    def create_season_fanart(self, show_obj): 
+        pass
 
 # present a standard "interface" from the module
 metadata_class = XBMCMetadata

--- a/sickbeard/metadata/xbmc.py
+++ b/sickbeard/metadata/xbmc.py
@@ -63,41 +63,20 @@ class XBMCMetadata(generic.GenericMetadata):
         self.name = 'XBMC'
 
         self.eg_show_metadata = "tvshow.nfo"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>-thumb.jpg"
-
         self.eg_show_fanart = "fanart.jpg"
         self.eg_show_poster = "poster.jpg"
         self.eg_show_banner = "banner.jpg"
-        self.eg_seasons_all_fanart = "season-all-fanart.jpg"
-        self.eg_seasons_all_poster = "season-all-poster.jpg"
-        self.eg_seasons_all_banner = "season-all-banner.jpg"
 
+        self.eg_season_all_fanart = "season-all-fanart.jpg"
+        self.eg_season_all_poster = "season-all-poster.jpg"
+        self.eg_season_all_banner = "season-all-banner.jpg"
         self.eg_season_fanarts = "<i>not supported</i>"
         self.eg_season_posters = "season##-poster.jpg"
         self.eg_season_banners = "season##-banner.jpg"
 
-    def get_season_pb_path(self, show_obj, season, img_type):
-        """
-        Returns the full path to the file for a given season poster/banner.
-        
-        show_obj: a TVShow instance for which to generate the path
-        season: a season number to be used for the path. Note that sesaon 0
-                means specials.
-        """
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>-thumb.jpg"
 
-        # Our specials thumbnail is, well, special
-        if season == 0:
-            season_pb_file_path = 'season-specials'
-        else:
-            season_pb_file_path = 'season' + str(season).zfill(2)
-        
-        season_pb_file_ext = '.tbn'
-           
-        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+season_pb_file_ext)            
-    
-    
-    
     def _show_data(self, show_obj):
         """
         Creates an elementTree XML structure for an XBMC-style tvshow.nfo and

--- a/sickbeard/metadata/xbmcorig.py
+++ b/sickbeard/metadata/xbmcorig.py
@@ -17,6 +17,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+import os
 
 import sickbeard
 
@@ -24,9 +25,9 @@ import generic
 
 from sickbeard.common import XML_NSMAP
 from sickbeard import logger, exceptions, helpers
-from sickbeard.exceptions import ex
-
+from sickbeard import encodingKludge as ek
 from lib.tvdb_api import tvdb_api, tvdb_exceptions
+from sickbeard.exceptions import ex
 
 import xml.etree.cElementTree as etree
 
@@ -108,7 +109,7 @@ class XBMCOrigMetadata(generic.GenericMetadata):
             season_pb_file_path = 'season' + str(season).zfill(2)
         
         season_pb_file_ext = '.tbn'
-        season_pb_file_path = season_pb_file_path + season_pb_file_ext
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext        
         return ek.ek(os.path.join, show_obj.location, season_pb_file_path)
 
     def get_episode_thumb_path(self, ep_obj):

--- a/sickbeard/metadata/xbmcorig.py
+++ b/sickbeard/metadata/xbmcorig.py
@@ -72,7 +72,7 @@ class XBMCOrigMetadata(generic.GenericMetadata):
                                          season_posters,
                                          season_banners,
                                          episode_metadata,
-                                         episode_thumbnails):
+                                         episode_thumbnails)
         
         self.name = 'XBMCOrig'
 
@@ -364,7 +364,7 @@ class XBMCOrigMetadata(generic.GenericMetadata):
 
         return data
 
-  def create_show_poster(self, show_obj):
+    def create_show_poster(self, show_obj):
         if self.show_poster and show_obj and not self._has_show_poster(show_obj):
             logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
             poster_path = self.get_show_poster_path(show_obj)

--- a/sickbeard/metadata/xbmcorig.py
+++ b/sickbeard/metadata/xbmcorig.py
@@ -1,0 +1,417 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import os
+
+import sickbeard
+
+import generic
+
+from sickbeard.common import XML_NSMAP
+from sickbeard import logger, exceptions, helpers
+from sickbeard import encodingKludge as ek
+from lib.tvdb_api import tvdb_api, tvdb_exceptions
+from sickbeard.exceptions import ex
+
+import xml.etree.cElementTree as etree
+
+class XBMCOrigMetadata(generic.GenericMetadata):
+    """
+    Metadata generation class for XBMCOrig
+
+    The following file structure is used:
+    Metadata generation class for WDTV
+
+    The following file structure is used:
+    show_root/tvshow.nfo                           (show metadata)
+    show_root/folder.jpg                           (show poster)
+    show_root/fanart.jpg                           (show fanart)
+    show_root/SeasonXX.tbn                         (season poster)
+    show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
+    show_root/Season 01/show - 1x01 - episode.tnb  (episode thumb)
+    show_root/Season 01/show - 1x01 - episode.nfo  (episode metadata)
+    """
+    def __init__(self,
+                 show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
+                 episode_metadata=False,
+                 episode_thumbnails=False):
+
+        generic.GenericMetadata.__init__(self,
+                                         show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
+                                         episode_metadata,
+                                         episode_thumbnails)
+        
+        self.name = 'XBMCOrig'
+
+        self.show_poster_name = "folder.jpg"
+
+        self.eg_show_metadata = "tvshow.nfo"
+        self.eg_show_fanart = "fanart.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "season##.tbn"
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        season_pb_file_ext = '.tbn'
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext        
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path)
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .metathumb extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'tbn')
+        else:
+            return None
+
+        return tbn_filename
+
+    def _show_data(self, show_obj):
+        """
+        Creates an elementTree XML structure for an XBMC-style tvshow.nfo and
+        returns the resulting data object.
+        
+        show_obj: a TVShow instance to create the NFO for
+        """
+
+        show_ID = show_obj.tvdbid
+
+        tvdb_lang = show_obj.lang
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+        if tvdb_lang and not tvdb_lang == 'en':
+            ltvdb_api_parms['language'] = tvdb_lang
+
+        t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+    
+        tv_node = etree.Element("tvshow")
+        for ns in XML_NSMAP.keys():
+            tv_node.set(ns, XML_NSMAP[ns])
+    
+        try:
+            myShow = t[int(show_ID)]
+        except tvdb_exceptions.tvdb_shownotfound:
+            logger.log(u"Unable to find show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+            raise
+    
+        except tvdb_exceptions.tvdb_error:
+            logger.log(u"TVDB is down, can't use its data to add this show", logger.ERROR)
+            raise
+    
+        # check for title and id
+        try:
+            if myShow["seriesname"] == None or myShow["seriesname"] == "" or myShow["id"] == None or myShow["id"] == "":
+                logger.log(u"Incomplete info for show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+    
+                return False
+        except tvdb_exceptions.tvdb_attributenotfound:
+            logger.log(u"Incomplete info for show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+    
+            return False
+    
+        title = etree.SubElement(tv_node, "title")
+        if myShow["seriesname"] != None:
+            title.text = myShow["seriesname"]
+    
+        rating = etree.SubElement(tv_node, "rating")
+        if myShow["rating"] != None:
+            rating.text = myShow["rating"]
+    
+        plot = etree.SubElement(tv_node, "plot")
+        if myShow["overview"] != None:
+            plot.text = myShow["overview"]
+    
+        episodeguide = etree.SubElement(tv_node, "episodeguide")
+        episodeguideurl = etree.SubElement( episodeguide, "url")
+        episodeguideurl2 = etree.SubElement(tv_node, "episodeguideurl")
+        if myShow["id"] != None:
+            showurl = sickbeard.TVDB_BASE_URL + '/series/' + myShow["id"] + '/all/en.zip'
+            episodeguideurl.text = showurl
+            episodeguideurl2.text = showurl
+    
+        mpaa = etree.SubElement(tv_node, "mpaa")
+        if myShow["contentrating"] != None:
+            mpaa.text = myShow["contentrating"]
+    
+        tvdbid = etree.SubElement(tv_node, "id")
+        if myShow["id"] != None:
+            tvdbid.text = myShow["id"]
+    
+        genre = etree.SubElement(tv_node, "genre")
+        if myShow["genre"] != None:
+            genre.text = " / ".join([x for x in myShow["genre"].split('|') if x])
+    
+        premiered = etree.SubElement(tv_node, "premiered")
+        if myShow["firstaired"] != None:
+            premiered.text = myShow["firstaired"]
+    
+        studio = etree.SubElement(tv_node, "studio")
+        if myShow["network"] != None:
+            studio.text = myShow["network"]
+    
+        for actor in myShow['_actors']:
+    
+            cur_actor = etree.SubElement(tv_node, "actor")
+    
+            cur_actor_name = etree.SubElement( cur_actor, "name")
+            cur_actor_name.text = actor['name']
+            cur_actor_role = etree.SubElement( cur_actor, "role")
+            cur_actor_role_text = actor['role']
+    
+            if cur_actor_role_text != None:
+                cur_actor_role.text = cur_actor_role_text
+    
+            cur_actor_thumb = etree.SubElement( cur_actor, "thumb")
+            cur_actor_thumb_text = actor['image']
+    
+            if cur_actor_thumb_text != None:
+                cur_actor_thumb.text = cur_actor_thumb_text
+    
+        # Make it purdy
+        helpers.indentXML(tv_node)
+
+        data = etree.ElementTree(tv_node)
+
+        return data
+    
+    def _ep_data(self, ep_obj):
+        """
+        Creates an elementTree XML structure for an XBMC-style episode.nfo and
+        returns the resulting data object.
+        
+        show_obj: a TVEpisode instance to create the NFO for
+        """
+
+        eps_to_write = [ep_obj] + ep_obj.relatedEps
+
+        tvdb_lang = ep_obj.show.lang
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+        if tvdb_lang and not tvdb_lang == 'en':
+            ltvdb_api_parms['language'] = tvdb_lang
+
+        try:
+            t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+            myShow = t[ep_obj.show.tvdbid]
+        except tvdb_exceptions.tvdb_shownotfound, e:
+            raise exceptions.ShowNotFoundException(e.message)
+        except tvdb_exceptions.tvdb_error, e:
+            logger.log(u"Unable to connect to TVDB while creating meta files - skipping - "+ex(e), logger.ERROR)
+            return
+
+        if len(eps_to_write) > 1:
+            rootNode = etree.Element( "xbmcmultiepisode" )
+        else:
+            rootNode = etree.Element( "episodedetails" )
+
+        # Set our namespace correctly
+        for ns in XML_NSMAP.keys():
+            rootNode.set(ns, XML_NSMAP[ns])
+
+        # write an NFO containing info for all matching episodes
+        for curEpToWrite in eps_to_write:
+
+            try:
+                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+            except (tvdb_exceptions.tvdb_episodenotfound, tvdb_exceptions.tvdb_seasonnotfound):
+                logger.log(u"Unable to find episode " + str(curEpToWrite.season) + "x" + str(curEpToWrite.episode) + " on tvdb... has it been removed? Should I delete from db?")
+                return None
+
+            if not myEp["firstaired"]:
+                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+
+            if not myEp["episodename"]:
+                logger.log(u"Not generating nfo because the ep has no title", logger.DEBUG)
+                return None
+
+            logger.log(u"Creating metadata for episode "+str(ep_obj.season)+"x"+str(ep_obj.episode), logger.DEBUG)
+
+            if len(eps_to_write) > 1:
+                episode = etree.SubElement( rootNode, "episodedetails" )
+            else:
+                episode = rootNode
+
+            title = etree.SubElement( episode, "title" )
+            if curEpToWrite.name != None:
+                title.text = curEpToWrite.name
+
+            season = etree.SubElement( episode, "season" )
+            season.text = str(curEpToWrite.season)
+
+            episodenum = etree.SubElement( episode, "episode" )
+            episodenum.text = str(curEpToWrite.episode)
+
+            aired = etree.SubElement( episode, "aired" )
+            if curEpToWrite.airdate != datetime.date.fromordinal(1):
+                aired.text = str(curEpToWrite.airdate)
+            else:
+                aired.text = ''
+
+            plot = etree.SubElement( episode, "plot" )
+            if curEpToWrite.description != None:
+                plot.text = curEpToWrite.description
+
+            displayseason = etree.SubElement( episode, "displayseason" )
+            if myEp.has_key('airsbefore_season'):
+                displayseason_text = myEp['airsbefore_season']
+                if displayseason_text != None:
+                    displayseason.text = displayseason_text
+
+            displayepisode = etree.SubElement( episode, "displayepisode" )
+            if myEp.has_key('airsbefore_episode'):
+                displayepisode_text = myEp['airsbefore_episode']
+                if displayepisode_text != None:
+                    displayepisode.text = displayepisode_text
+
+            thumb = etree.SubElement( episode, "thumb" )
+            thumb_text = myEp['filename']
+            if thumb_text != None:
+                thumb.text = thumb_text
+
+            watched = etree.SubElement( episode, "watched" )
+            watched.text = 'false'
+
+            credits = etree.SubElement( episode, "credits" )
+            credits_text = myEp['writer']
+            if credits_text != None:
+                credits.text = credits_text
+
+            director = etree.SubElement( episode, "director" )
+            director_text = myEp['director']
+            if director_text != None:
+                director.text = director_text
+
+            rating = etree.SubElement( episode, "rating" )
+            rating_text = myEp['rating']
+            if rating_text != None:
+                rating.text = rating_text
+
+            gueststar_text = myEp['gueststars']
+            if gueststar_text != None:
+                for actor in gueststar_text.split('|'):
+                    cur_actor = etree.SubElement( episode, "actor" )
+                    cur_actor_name = etree.SubElement(
+                        cur_actor, "name"
+                        )
+                    cur_actor_name.text = actor
+
+            for actor in myShow['_actors']:
+                cur_actor = etree.SubElement( episode, "actor" )
+
+                cur_actor_name = etree.SubElement( cur_actor, "name" )
+                cur_actor_name.text = actor['name']
+
+                cur_actor_role = etree.SubElement( cur_actor, "role" )
+                cur_actor_role_text = actor['role']
+                if cur_actor_role_text != None:
+                    cur_actor_role.text = cur_actor_role_text
+
+                cur_actor_thumb = etree.SubElement( cur_actor, "thumb" )
+                cur_actor_thumb_text = actor['image']
+                if cur_actor_thumb_text != None:
+                    cur_actor_thumb.text = cur_actor_thumb_text
+
+        #
+        # Make it purdy
+        helpers.indentXML( rootNode )
+
+        data = etree.ElementTree( rootNode )
+
+        return data
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+        
+    # all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj):  
+        pass
+        
+# present a standard "interface" from the module
+metadata_class = XBMCOrigMetadata

--- a/sickbeard/metadata/xbmcorig.py
+++ b/sickbeard/metadata/xbmcorig.py
@@ -1,0 +1,398 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+import sickbeard
+
+import generic
+
+from sickbeard.common import XML_NSMAP
+from sickbeard import logger, exceptions, helpers
+from sickbeard.exceptions import ex
+
+from lib.tvdb_api import tvdb_api, tvdb_exceptions
+
+import xml.etree.cElementTree as etree
+
+class XBMCOrigMetadata(generic.GenericMetadata):
+    """
+    Metadata generation class for XBMCOrig
+
+    The following file structure is used:
+    Metadata generation class for WDTV
+
+    The following file structure is used:
+    show_root/tvshow.nfo                           (show metadata)
+    show_root/folder.jpg                           (show poster)
+    show_root/fanart.jpg                           (show fanart)
+    show_root/SeasonXX.tbn                         (season poster)
+    show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
+    show_root/Season 01/show - 1x01 - episode.tnb  (episode thumb)
+    show_root/Season 01/show - 1x01 - episode.nfo  (episode metadata)
+    """
+    def __init__(self,
+                 show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
+                 episode_metadata=False,
+                 episode_thumbnails=False):
+
+        generic.GenericMetadata.__init__(self,
+                                         show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
+                                         episode_metadata,
+                                         episode_thumbnails):
+        
+        self.name = 'XBMCOrig'
+
+        self.show_poster_name = "folder.jpg"
+
+        self.eg_show_metadata = "tvshow.nfo"
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
+
+        self.eg_show_fanart = "fanart.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+        self.eg_seasons_all_fanart = "<i>not supported</i>"
+        self.eg_seasons_all_poster = "<i>not supported</i>"
+        self.eg_seasons_all_banner = "<i>not supported</i>"
+
+        self.eg_banner = "<i>not supported</i>"
+        self.eg_season_thumbnails = "season##.tbn"
+        self.eg_banner = "<i>not supported</i>"
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .metathumb extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'tbn')
+        else:
+            return None
+
+        return tbn_filename
+
+    def _show_data(self, show_obj):
+        """
+        Creates an elementTree XML structure for an XBMC-style tvshow.nfo and
+        returns the resulting data object.
+        
+        show_obj: a TVShow instance to create the NFO for
+        """
+
+        show_ID = show_obj.tvdbid
+
+        tvdb_lang = show_obj.lang
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+        if tvdb_lang and not tvdb_lang == 'en':
+            ltvdb_api_parms['language'] = tvdb_lang
+
+        t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+    
+        tv_node = etree.Element("tvshow")
+        for ns in XML_NSMAP.keys():
+            tv_node.set(ns, XML_NSMAP[ns])
+    
+        try:
+            myShow = t[int(show_ID)]
+        except tvdb_exceptions.tvdb_shownotfound:
+            logger.log(u"Unable to find show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+            raise
+    
+        except tvdb_exceptions.tvdb_error:
+            logger.log(u"TVDB is down, can't use its data to add this show", logger.ERROR)
+            raise
+    
+        # check for title and id
+        try:
+            if myShow["seriesname"] == None or myShow["seriesname"] == "" or myShow["id"] == None or myShow["id"] == "":
+                logger.log(u"Incomplete info for show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+    
+                return False
+        except tvdb_exceptions.tvdb_attributenotfound:
+            logger.log(u"Incomplete info for show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+    
+            return False
+    
+        title = etree.SubElement(tv_node, "title")
+        if myShow["seriesname"] != None:
+            title.text = myShow["seriesname"]
+    
+        rating = etree.SubElement(tv_node, "rating")
+        if myShow["rating"] != None:
+            rating.text = myShow["rating"]
+    
+        plot = etree.SubElement(tv_node, "plot")
+        if myShow["overview"] != None:
+            plot.text = myShow["overview"]
+    
+        episodeguide = etree.SubElement(tv_node, "episodeguide")
+        episodeguideurl = etree.SubElement( episodeguide, "url")
+        episodeguideurl2 = etree.SubElement(tv_node, "episodeguideurl")
+        if myShow["id"] != None:
+            showurl = sickbeard.TVDB_BASE_URL + '/series/' + myShow["id"] + '/all/en.zip'
+            episodeguideurl.text = showurl
+            episodeguideurl2.text = showurl
+    
+        mpaa = etree.SubElement(tv_node, "mpaa")
+        if myShow["contentrating"] != None:
+            mpaa.text = myShow["contentrating"]
+    
+        tvdbid = etree.SubElement(tv_node, "id")
+        if myShow["id"] != None:
+            tvdbid.text = myShow["id"]
+    
+        genre = etree.SubElement(tv_node, "genre")
+        if myShow["genre"] != None:
+            genre.text = " / ".join([x for x in myShow["genre"].split('|') if x])
+    
+        premiered = etree.SubElement(tv_node, "premiered")
+        if myShow["firstaired"] != None:
+            premiered.text = myShow["firstaired"]
+    
+        studio = etree.SubElement(tv_node, "studio")
+        if myShow["network"] != None:
+            studio.text = myShow["network"]
+    
+        for actor in myShow['_actors']:
+    
+            cur_actor = etree.SubElement(tv_node, "actor")
+    
+            cur_actor_name = etree.SubElement( cur_actor, "name")
+            cur_actor_name.text = actor['name']
+            cur_actor_role = etree.SubElement( cur_actor, "role")
+            cur_actor_role_text = actor['role']
+    
+            if cur_actor_role_text != None:
+                cur_actor_role.text = cur_actor_role_text
+    
+            cur_actor_thumb = etree.SubElement( cur_actor, "thumb")
+            cur_actor_thumb_text = actor['image']
+    
+            if cur_actor_thumb_text != None:
+                cur_actor_thumb.text = cur_actor_thumb_text
+    
+        # Make it purdy
+        helpers.indentXML(tv_node)
+
+        data = etree.ElementTree(tv_node)
+
+        return data
+    
+    def _ep_data(self, ep_obj):
+        """
+        Creates an elementTree XML structure for an XBMC-style episode.nfo and
+        returns the resulting data object.
+        
+        show_obj: a TVEpisode instance to create the NFO for
+        """
+
+        eps_to_write = [ep_obj] + ep_obj.relatedEps
+
+        tvdb_lang = ep_obj.show.lang
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+        if tvdb_lang and not tvdb_lang == 'en':
+            ltvdb_api_parms['language'] = tvdb_lang
+
+        try:
+            t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+            myShow = t[ep_obj.show.tvdbid]
+        except tvdb_exceptions.tvdb_shownotfound, e:
+            raise exceptions.ShowNotFoundException(e.message)
+        except tvdb_exceptions.tvdb_error, e:
+            logger.log(u"Unable to connect to TVDB while creating meta files - skipping - "+ex(e), logger.ERROR)
+            return
+
+        if len(eps_to_write) > 1:
+            rootNode = etree.Element( "xbmcmultiepisode" )
+        else:
+            rootNode = etree.Element( "episodedetails" )
+
+        # Set our namespace correctly
+        for ns in XML_NSMAP.keys():
+            rootNode.set(ns, XML_NSMAP[ns])
+
+        # write an NFO containing info for all matching episodes
+        for curEpToWrite in eps_to_write:
+
+            try:
+                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+            except (tvdb_exceptions.tvdb_episodenotfound, tvdb_exceptions.tvdb_seasonnotfound):
+                logger.log(u"Unable to find episode " + str(curEpToWrite.season) + "x" + str(curEpToWrite.episode) + " on tvdb... has it been removed? Should I delete from db?")
+                return None
+
+            if not myEp["firstaired"]:
+                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+
+            if not myEp["episodename"]:
+                logger.log(u"Not generating nfo because the ep has no title", logger.DEBUG)
+                return None
+
+            logger.log(u"Creating metadata for episode "+str(ep_obj.season)+"x"+str(ep_obj.episode), logger.DEBUG)
+
+            if len(eps_to_write) > 1:
+                episode = etree.SubElement( rootNode, "episodedetails" )
+            else:
+                episode = rootNode
+
+            title = etree.SubElement( episode, "title" )
+            if curEpToWrite.name != None:
+                title.text = curEpToWrite.name
+
+            season = etree.SubElement( episode, "season" )
+            season.text = str(curEpToWrite.season)
+
+            episodenum = etree.SubElement( episode, "episode" )
+            episodenum.text = str(curEpToWrite.episode)
+
+            aired = etree.SubElement( episode, "aired" )
+            if curEpToWrite.airdate != datetime.date.fromordinal(1):
+                aired.text = str(curEpToWrite.airdate)
+            else:
+                aired.text = ''
+
+            plot = etree.SubElement( episode, "plot" )
+            if curEpToWrite.description != None:
+                plot.text = curEpToWrite.description
+
+            displayseason = etree.SubElement( episode, "displayseason" )
+            if myEp.has_key('airsbefore_season'):
+                displayseason_text = myEp['airsbefore_season']
+                if displayseason_text != None:
+                    displayseason.text = displayseason_text
+
+            displayepisode = etree.SubElement( episode, "displayepisode" )
+            if myEp.has_key('airsbefore_episode'):
+                displayepisode_text = myEp['airsbefore_episode']
+                if displayepisode_text != None:
+                    displayepisode.text = displayepisode_text
+
+            thumb = etree.SubElement( episode, "thumb" )
+            thumb_text = myEp['filename']
+            if thumb_text != None:
+                thumb.text = thumb_text
+
+            watched = etree.SubElement( episode, "watched" )
+            watched.text = 'false'
+
+            credits = etree.SubElement( episode, "credits" )
+            credits_text = myEp['writer']
+            if credits_text != None:
+                credits.text = credits_text
+
+            director = etree.SubElement( episode, "director" )
+            director_text = myEp['director']
+            if director_text != None:
+                director.text = director_text
+
+            rating = etree.SubElement( episode, "rating" )
+            rating_text = myEp['rating']
+            if rating_text != None:
+                rating.text = rating_text
+
+            gueststar_text = myEp['gueststars']
+            if gueststar_text != None:
+                for actor in gueststar_text.split('|'):
+                    cur_actor = etree.SubElement( episode, "actor" )
+                    cur_actor_name = etree.SubElement(
+                        cur_actor, "name"
+                        )
+                    cur_actor_name.text = actor
+
+            for actor in myShow['_actors']:
+                cur_actor = etree.SubElement( episode, "actor" )
+
+                cur_actor_name = etree.SubElement( cur_actor, "name" )
+                cur_actor_name.text = actor['name']
+
+                cur_actor_role = etree.SubElement( cur_actor, "role" )
+                cur_actor_role_text = actor['role']
+                if cur_actor_role_text != None:
+                    cur_actor_role.text = cur_actor_role_text
+
+                cur_actor_thumb = etree.SubElement( cur_actor, "thumb" )
+                cur_actor_thumb_text = actor['image']
+                if cur_actor_thumb_text != None:
+                    cur_actor_thumb.text = cur_actor_thumb_text
+
+        #
+        # Make it purdy
+        helpers.indentXML( rootNode )
+
+        data = etree.ElementTree( rootNode )
+
+        return data
+
+  def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+        
+    # all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj):  
+        pass
+        
+# present a standard "interface" from the module
+metadata_class = XBMCOrigMetadata

--- a/sickbeard/metadata/xbmcorig.py
+++ b/sickbeard/metadata/xbmcorig.py
@@ -79,19 +79,37 @@ class XBMCOrigMetadata(generic.GenericMetadata):
         self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "tvshow.nfo"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
-
         self.eg_show_fanart = "fanart.jpg"
         self.eg_show_poster = "folder.jpg"
         self.eg_show_banner = "<i>not supported</i>"
-        self.eg_seasons_all_fanart = "<i>not supported</i>"
-        self.eg_seasons_all_poster = "<i>not supported</i>"
-        self.eg_seasons_all_banner = "<i>not supported</i>"
 
-        self.eg_banner = "<i>not supported</i>"
-        self.eg_season_thumbnails = "season##.tbn"
-        self.eg_banner = "<i>not supported</i>"
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "season##.tbn"
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        season_pb_file_ext = '.tbn'
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path)
 
     def get_episode_thumb_path(self, ep_obj):
         """

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -399,13 +399,15 @@ class TVShow(object):
         show_fanart_result = show_poster_result = show_banner_result = season_all_fanart_result = season_all_poster_result = season_all_banner_result = season_fanarts_result = season_posters_result = season_banners_result = False
 
         for cur_provider in sickbeard.metadata_provider_dict.values():
-            logger.log("Running season folders for "+cur_provider.name, logger.DEBUG)
+            logger.log("Getting Show images for "+cur_provider.name, logger.DEBUG)
             show_fanart_result = cur_provider.create_show_fanart(self) or show_fanart_result
             show_poster_result = cur_provider.create_show_poster(self) or show_poster_result
             show_banner_result = cur_provider.create_show_banner(self) or show_banner_result
+            logger.log("Getting season all images for "+cur_provider.name, logger.DEBUG)
             season_all_fanart_result = cur_provider.create_season_all_fanart(self) or season_all_fanart_result
             season_all_poster_result = cur_provider.create_season_all_poster(self) or season_all_poster_result
             season_all_banner_result = cur_provider.create_season_all_banner(self) or season_all_banner_result
+            logger.log("Getting season images for "+cur_provider.name, logger.DEBUG)
             season_fanarts_result = cur_provider.create_season_fanart(self) or season_fanarts_result
             season_posters_result = cur_provider.create_season_poster(self) or season_posters_result
             season_banners_result = cur_provider.create_season_banner(self) or season_banners_result

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -396,15 +396,23 @@ class TVShow(object):
 
     def getImages(self, fanart=None, poster=None):
 
-        poster_result = fanart_result = season_thumb_result = False
+        show_fanart_result = show_poster_result = show_banner_result = season_all_fanart_result = season_all_poster_result = season_all_banner_result = season_fanarts_result = season_posters_result = season_banners_result = False
 
         for cur_provider in sickbeard.metadata_provider_dict.values():
-            logger.log("Running season folders for "+cur_provider.name, logger.DEBUG)
-            poster_result = cur_provider.create_poster(self) or poster_result
-            fanart_result = cur_provider.create_fanart(self) or fanart_result
-            season_thumb_result = cur_provider.create_season_thumbs(self) or season_thumb_result
+            logger.log("Getting Show images for "+cur_provider.name, logger.DEBUG)
+            show_fanart_result = cur_provider.create_show_fanart(self) or show_fanart_result
+            show_poster_result = cur_provider.create_show_poster(self) or show_poster_result
+            show_banner_result = cur_provider.create_show_banner(self) or show_banner_result
+            logger.log("Getting season all images for "+cur_provider.name, logger.DEBUG)
+            season_all_fanart_result = cur_provider.create_season_all_fanart(self) or season_all_fanart_result
+            season_all_poster_result = cur_provider.create_season_all_poster(self) or season_all_poster_result
+            season_all_banner_result = cur_provider.create_season_all_banner(self) or season_all_banner_result
+            logger.log("Getting season images for "+cur_provider.name, logger.DEBUG)
+            season_fanarts_result = cur_provider.create_season_fanart(self) or season_fanarts_result
+            season_posters_result = cur_provider.create_season_poster(self) or season_posters_result
+            season_banners_result = cur_provider.create_season_banner(self) or season_banners_result
 
-        return poster_result or fanart_result or season_thumb_result
+        return show_fanart_result or show_poster_result or show_banner_result or season_all_fanart_result or season_all_poster_result or season_all_banner_result or season_fanarts_result or season_posters_result or season_banners_result
 
     def loadLatestFromTVRage(self):
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -401,11 +401,11 @@ class TVShow(object):
         for cur_provider in sickbeard.metadata_provider_dict.values():
             logger.log("Running season folders for "+cur_provider.name, logger.DEBUG)
             show_fanart_result = cur_provider.create_show_fanart(self) or show_fanart_result
-            show_poster_result = cur_provider.create_show_fanart(self) or show_poster_result
-            show_banner_result = cur_provider.create_show_fanart(self) or show_banner_result
+            show_poster_result = cur_provider.create_show_poster(self) or show_poster_result
+            show_banner_result = cur_provider.create_show_banner(self) or show_banner_result
             season_all_fanart_result = cur_provider.create_season_all_fanart(self) or season_all_fanart_result
-            season_all_poster_result = cur_provider.create_season_all_fanart(self) or season_all_poster_result
-            season_all_banner_result = cur_provider.create_season_all_fanart(self) or season_all_banner_result
+            season_all_poster_result = cur_provider.create_season_all_poster(self) or season_all_poster_result
+            season_all_banner_result = cur_provider.create_season_all_banner(self) or season_all_banner_result
             season_fanarts_result = cur_provider.create_season_fanart(self) or season_fanarts_result
             season_posters_result = cur_provider.create_season_poster(self) or season_posters_result
             season_banners_result = cur_provider.create_season_banner(self) or season_banners_result

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -396,15 +396,21 @@ class TVShow(object):
 
     def getImages(self, fanart=None, poster=None):
 
-        poster_result = fanart_result = season_thumb_result = False
+        show_fanart_result = show_poster_result = show_banner_result = seasons_all_fanart_result = seasons_all_poster_result = seasons_all_banner_result = season_fanarts_result = season_posters_result = season_banners_result = False
 
         for cur_provider in sickbeard.metadata_provider_dict.values():
             logger.log("Running season folders for "+cur_provider.name, logger.DEBUG)
-            poster_result = cur_provider.create_poster(self) or poster_result
-            fanart_result = cur_provider.create_fanart(self) or fanart_result
-            season_thumb_result = cur_provider.create_season_thumbs(self) or season_thumb_result
+            show_fanart_result = cur_provider.create_show_fanart(self) or show_fanart_result
+            show_poster_result = cur_provider.create_show_fanart(self) or show_poster_result
+            show_banner_result = cur_provider.create_show_fanart(self) or show_banner_result
+            seasons_all_fanart_result = cur_provider.create_seasons_all_fanart(self) or seasons_all_fanart_result
+            seasons_all_poster_result = cur_provider.create_seasons_all_fanart(self) or seasons_all_poster_result
+            seasons_all_banner_result = cur_provider.create_seasons_all_fanart(self) or seasons_all_banner_result
+            season_fanarts_result = cur_provider.create_season_fanart(self) or season_fanarts_result
+            season_posters_result = cur_provider.create_season_poster(self) or season_posters_result
+            season_banners_result = cur_provider.create_season_banner(self) or season_banners_result
 
-        return poster_result or fanart_result or season_thumb_result
+        return show_fanart_result or show_poster_result or show_banner_result or seasons_all_fanart_result or seasons_all_poster_result or seasons_all_banner_result or season_fanarts_result or season_posters_result or season_banners_result
 
     def loadLatestFromTVRage(self):
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -396,21 +396,21 @@ class TVShow(object):
 
     def getImages(self, fanart=None, poster=None):
 
-        show_fanart_result = show_poster_result = show_banner_result = seasons_all_fanart_result = seasons_all_poster_result = seasons_all_banner_result = season_fanarts_result = season_posters_result = season_banners_result = False
+        show_fanart_result = show_poster_result = show_banner_result = season_all_fanart_result = season_all_poster_result = season_all_banner_result = season_fanarts_result = season_posters_result = season_banners_result = False
 
         for cur_provider in sickbeard.metadata_provider_dict.values():
             logger.log("Running season folders for "+cur_provider.name, logger.DEBUG)
             show_fanart_result = cur_provider.create_show_fanart(self) or show_fanart_result
             show_poster_result = cur_provider.create_show_fanart(self) or show_poster_result
             show_banner_result = cur_provider.create_show_fanart(self) or show_banner_result
-            seasons_all_fanart_result = cur_provider.create_seasons_all_fanart(self) or seasons_all_fanart_result
-            seasons_all_poster_result = cur_provider.create_seasons_all_fanart(self) or seasons_all_poster_result
-            seasons_all_banner_result = cur_provider.create_seasons_all_fanart(self) or seasons_all_banner_result
+            season_all_fanart_result = cur_provider.create_season_all_fanart(self) or season_all_fanart_result
+            season_all_poster_result = cur_provider.create_season_all_fanart(self) or season_all_poster_result
+            season_all_banner_result = cur_provider.create_season_all_fanart(self) or season_all_banner_result
             season_fanarts_result = cur_provider.create_season_fanart(self) or season_fanarts_result
             season_posters_result = cur_provider.create_season_poster(self) or season_posters_result
             season_banners_result = cur_provider.create_season_banner(self) or season_banners_result
 
-        return show_fanart_result or show_poster_result or show_banner_result or seasons_all_fanart_result or seasons_all_poster_result or seasons_all_banner_result or season_fanarts_result or season_posters_result or season_banners_result
+        return show_fanart_result or show_poster_result or show_banner_result or season_all_fanart_result or season_all_poster_result or season_all_banner_result or season_fanarts_result or season_posters_result or season_banners_result
 
     def loadLatestFromTVRage(self):
 

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -15,6 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+# 
+# changed to point to luxmoggy
+#
 
 import sickbeard
 from sickbeard import version, ui

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -447,7 +447,7 @@ class SourceUpdateManager(GitUpdateManager):
         Downloads the latest source tarball from github and installs it over the existing version.
         """
 
-        tar_download_url = 'https://github.com/luxmoggyy/Sick-Beard/tarball/'+version.SICKBEARD_VERSION
+        tar_download_url = 'https://github.com/luxmoggy/Sick-Beard/tarball/'+version.SICKBEARD_VERSION
         sb_update_dir = os.path.join(sickbeard.PROG_DIR, 'sb-update')
         version_path = os.path.join(sickbeard.PROG_DIR, 'version.txt')
 

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -311,7 +311,7 @@ class GitUpdateManager(UpdateManager):
         gh = github.GitHub()
 
         # find newest commit
-        for curCommit in gh.commits('midgetspy', 'Sick-Beard', self.branch):
+        for curCommit in gh.commits('luxmoggy', 'Sick-Beard', self.branch):
             if not self._newest_commit_hash:
                 self._newest_commit_hash = curCommit['sha']
                 if not self._cur_commit_hash:
@@ -339,9 +339,9 @@ class GitUpdateManager(UpdateManager):
             return
 
         if self._newest_commit_hash:
-            url = 'http://github.com/midgetspy/Sick-Beard/compare/'+self._cur_commit_hash+'...'+self._newest_commit_hash
+            url = 'http://github.com/luxmoggy/Sick-Beard/compare/'+self._cur_commit_hash+'...'+self._newest_commit_hash
         else:
-            url = 'http://github.com/midgetspy/Sick-Beard/commits/'
+            url = 'http://github.com/luxmoggy/Sick-Beard/commits/'
 
         new_str = 'There is a <a href="'+url+'" onclick="window.open(this.href); return false;">newer version available</a> ('+message+')'
         new_str += "&mdash; <a href=\""+self.get_update_url()+"\">Update Now</a>"
@@ -447,7 +447,7 @@ class SourceUpdateManager(GitUpdateManager):
         Downloads the latest source tarball from github and installs it over the existing version.
         """
 
-        tar_download_url = 'https://github.com/midgetspy/Sick-Beard/tarball/'+version.SICKBEARD_VERSION
+        tar_download_url = 'https://github.com/luxmoggyy/Sick-Beard/tarball/'+version.SICKBEARD_VERSION
         sb_update_dir = os.path.join(sickbeard.PROG_DIR, 'sb-update')
         version_path = os.path.join(sickbeard.PROG_DIR, 'version.txt')
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -846,7 +846,7 @@ class ConfigPostProcessing:
 
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
-                    xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
+                    xbmc_data=None,  xbmcorig_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
@@ -892,6 +892,7 @@ class ConfigPostProcessing:
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
+        sickbeard.metadata_provider_dict['XBMCOrig'].set_config(xbmcorig_data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)
         sickbeard.metadata_provider_dict['Synology'].set_config(synology_data)
         sickbeard.metadata_provider_dict['Sony PS3'].set_config(sony_ps3_data)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -846,7 +846,7 @@ class ConfigPostProcessing:
 
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
-                    xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
+                    xbmc_data=None,  xbmcorig_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
@@ -892,6 +892,7 @@ class ConfigPostProcessing:
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
+        sickbeard.metadata_provider_dict['XBMCORIG'].set_config(xbmcorig_data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)
         sickbeard.metadata_provider_dict['Synology'].set_config(synology_data)
         sickbeard.metadata_provider_dict['Sony PS3'].set_config(sony_ps3_data)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -892,7 +892,7 @@ class ConfigPostProcessing:
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
-        sickbeard.metadata_provider_dict['XBMCORIG'].set_config(xbmcorig_data)
+        sickbeard.metadata_provider_dict['XBMCOrig'].set_config(xbmcorig_data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)
         sickbeard.metadata_provider_dict['Synology'].set_config(synology_data)
         sickbeard.metadata_provider_dict['Sony PS3'].set_config(sony_ps3_data)


### PR DESCRIPTION
The code for the new version of the metadata. Can be used to generate the XMBC in both the new and old format. 

Only the changes in the following files are needed:
sickbeard/**init**.py
sickbeard/tv.py
sickbeard/webserve.py
sickbeard/image_cache.py
sickbeard/metadata/**init**.py
sickbeard/metadata/generic.py
sickbeard/metadata/mediabrowser.py
sickbeard/metadata/ps3.py
sickbeard/metadata/synology.py
sickbeard/metadata/tivo.py
sickbeard/metadata/wdtv.py
sickbeard/metadata/xbmc.py
sickbeard/metadata/xbmcorig.py
data/interfaces/default/config_postProcessing.tmpl
data/js/configPostProcessing.js

tvdb_api & checkVersion (have changes in them that are nothing to do with this change - don't know how to exclude them)

Have tested the generation of metadata providers. config.ini is updating correctly.
The PostProcessing screen is showing the new options.

The code for Season Fanart isn't working and is skipped in all Metadata providers
