### PR TITLE
update for new metadata using new XBMC as base for generic.py

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -472,22 +472,34 @@
         <h4>Create:</h4>
         <div class="metadata-options">
             <label for="${cur_id}_show_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_metadata" #if $cur_metadata_inst.show_metadata then "checked=\"checked\"" else ""#/>&nbsp;Show Metadata</label>
+            <label for="${cur_id}_show_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_fanart" #if $cur_metadata_inst.show_fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
+            <label for="${cur_id}_show_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_poster" #if $cur_metadata_inst.show_poster then "checked=\"checked\"" else ""#/>&nbsp;Show Poster Image</label>
+            <label for="${cur_id}_show_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_show_banner" #if $cur_metadata_inst.show_banner then "checked=\"checked\"" else ""#/>&nbsp;Show Banner Image</label>
+            <label for="${cur_id}_season_all_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_fanart" #if $cur_metadata_inst.season_all_fanart then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Fanart</label>
+            <label for="${cur_id}_season_all_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_poster" #if $cur_metadata_inst.season_all_poster then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Poster</label>
+            <label for="${cur_id}_season_all_banner" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_banner" #if $cur_metadata_inst.season_all_banner then "checked=\"checked\"" else ""#/>&nbsp;Seasons All Banner</label>
+            <label for="${cur_id}_season_fanarts" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_fanarts" #if $cur_metadata_inst.season_fanarts then "checked=\"checked\"" else ""#/>&nbsp;Season Fanarts</label>
+            <label for="${cur_id}_season_posters" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_posters" #if $cur_metadata_inst.season_posters then "checked=\"checked\"" else ""#/>&nbsp;Season Posters</label>
+            <label for="${cur_id}_season_banners" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_banners" #if $cur_metadata_inst.season_banners then "checked=\"checked\"" else ""#/>&nbsp;Season Banners</label>
             <label for="${cur_id}_episode_metadata" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_metadata" #if $cur_metadata_inst.episode_metadata then "checked=\"checked\"" else ""#/>&nbsp;Episode Metadata</label>
-            <label for="${cur_id}_fanart" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_fanart" #if $cur_metadata_inst.fanart then "checked=\"checked\"" else ""#/>&nbsp;Show Fanart Image</label>
-            <label for="${cur_id}_poster" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_poster" #if $cur_metadata_inst.poster then "checked=\"checked\"" else ""#/>&nbsp;Show Folder Image</label>
             <label for="${cur_id}_episode_thumbnails" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_thumbnails" #if $cur_metadata_inst.episode_thumbnails then "checked=\"checked\"" else ""#/>&nbsp;Episode Thumbnail</label>
-            <label for="${cur_id}_season_thumbnails" class="clearfix"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_thumbnails" #if $cur_metadata_inst.season_thumbnails then "checked=\"checked\"" else ""#/>&nbsp;Season Thumbnail</label>
         </div>
     </div>
     <div class="metadata-example-wrapper">
         <h4>Results:</h4>
         <div class="metadata-example">
             <label for="${cur_id}_show_metadata"><span id="${cur_id}_eg_show_metadata">$cur_metadata_inst.eg_show_metadata</span></label>
+            <label for="${cur_id}_show_fanart"><span id="${cur_id}_eg_show_fanart">$cur_metadata_inst.eg_show_fanart</span></label>
+            <label for="${cur_id}_show_poster"><span id="${cur_id}_eg_show_poster">$cur_metadata_inst.eg_show_poster</span></label>
+            <label for="${cur_id}_show_banner"><span id="${cur_id}_eg_show_banner">$cur_metadata_inst.eg_show_banner</span></label>
+            <label for="${cur_id}_season_all_fanart"><span id="${cur_id}_eg_season_all_fanart">$cur_metadata_inst.eg_season_all_fanart</span></label>
+            <label for="${cur_id}_season_all_poster"><span id="${cur_id}_eg_season_all_poster">$cur_metadata_inst.eg_season_all_poster</span></label>
+            <label for="${cur_id}_season_all_banner"><span id="${cur_id}_eg_season_all_banner">$cur_metadata_inst.eg_season_all_banner</span></label>
+            <label for="${cur_id}_season_fanarts"><span id="${cur_id}_eg_season_fanarts">$cur_metadata_inst.eg_season_fanarts</span></label>
+            <label for="${cur_id}_season_posters"><span id="${cur_id}_eg_season_posters">$cur_metadata_inst.eg_season_posters</span></label>
+            <label for="${cur_id}_season_banners"><span id="${cur_id}_eg_season_banners">$cur_metadata_inst.eg_season_banners</span></label>
             <label for="${cur_id}_episode_metadata"><span id="${cur_id}_eg_episode_metadata">$cur_metadata_inst.eg_episode_metadata</span></label>
-            <label for="${cur_id}_fanart"><span id="${cur_id}_eg_fanart">$cur_metadata_inst.eg_fanart</span></label>
-            <label for="${cur_id}_poster"><span id="${cur_id}_eg_poster">$cur_metadata_inst.eg_poster</span></label>
             <label for="${cur_id}_episode_thumbnails"><span id="${cur_id}_eg_episode_thumbnails">$cur_metadata_inst.eg_episode_thumbnails</span></label>
-            <label for="${cur_id}_season_thumbnails"><span id="${cur_id}_eg_season_thumbnails">$cur_metadata_inst.eg_season_thumbnails</span></label>
         </div>
     </div>
 
@@ -499,7 +511,7 @@
                             <input type="checkbox" name="use_banner" id="use_banner" #if $sickbeard.USE_BANNER then "checked=checked" else ""#/>
                             <label class="clearfix" for="use_banner">
                                 <span class="component-title">Use Banners</span>
-                                <span class="component-desc">Use banners instead of posters for 'Show Folder Image'</span>
+                                <span class="component-desc">Use banners instead of posters for 'Show Folder Image' (not for XBMC)</span>
                             </label>
                         </div>
 

--- a/data/js/configPostProcessing.js
+++ b/data/js/configPostProcessing.js
@@ -205,18 +205,34 @@ $(document).ready(function () {
 
             var config_arr = [];
             var show_metadata = $("#" + generator_name + "_show_metadata").prop('checked');
+            var show_fanart = $("#" + generator_name + "_show_fanart").prop('checked');
+            var show_poster = $("#" + generator_name + "_show_poster").prop('checked');
+            var show_banner = $("#" + generator_name + "_show_banner").prop('checked');
+            var season_all_fanart = $("#" + generator_name + "_season_all_fanart").prop('checked');
+            var season_all_poster = $("#" + generator_name + "_season_all_poster").prop('checked');
+            var season_all_banner = $("#" + generator_name + "_season_all_banner").prop('checked');
+
+            var season_fanarts = $("#" + generator_name + "_season_fanarts").prop('checked');
+            var season_posters = $("#" + generator_name + "_season_posters").prop('checked');
+            var season_banners = $("#" + generator_name + "_season_banners").prop('checked');
+
             var episode_metadata = $("#" + generator_name + "_episode_metadata").prop('checked');
-            var fanart = $("#" + generator_name + "_fanart").prop('checked');
-            var poster = $("#" + generator_name + "_poster").prop('checked');
             var episode_thumbnails = $("#" + generator_name + "_episode_thumbnails").prop('checked');
-            var season_thumbnails = $("#" + generator_name + "_season_thumbnails").prop('checked');
 
             config_arr.push(show_metadata ? '1' : '0');
-            config_arr.push(episode_metadata ? '1' : '0');
-            config_arr.push(poster ? '1' : '0');
-            config_arr.push(fanart ? '1' : '0');
+            config_arr.push(show_fanart ? '1' : '0');
+            config_arr.push(show_poster ? '1' : '0');
+            config_arr.push(show_banner ? '1' : '0');
+            config_arr.push(season_all_fanart ? '1' : '0');
+            config_arr.push(season_all_poster ? '1' : '0');
+            config_arr.push(season_all_banner ? '1' : '0');
+
+            config_arr.push(season_fanarts ? '1' : '0');
+            config_arr.push(season_posters ? '1' : '0');
+            config_arr.push(season_banners ? '1' : '0');
+
             config_arr.push(episode_thumbnails ? '1' : '0');
-            config_arr.push(season_thumbnails ? '1' : '0');
+            config_arr.push(episode_metadata ? '1' : '0');
 
             var cur_num = 0;
             for (var i = 0; i < config_arr.length; i++)
@@ -227,11 +243,20 @@ $(document).ready(function () {
             }
 
             $("#" + generator_name + "_eg_show_metadata").attr('class', show_metadata ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_show_fanart").attr('class', show_fanart ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_show_poster").attr('class', show_poster ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_show_banner").attr('class', show_banner ? 'enabled' : 'disabled');
+
+            $("#" + generator_name + "_eg_season_all_fanart").attr('class', season_all_fanart ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_all_poster").attr('class', season_all_poster ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_all_banner").attr('class', season_all_banner ? 'enabled' : 'disabled');
+
+            $("#" + generator_name + "_eg_season_fanarts").attr('class', season_fanarts ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_posters").attr('class', season_posters ? 'enabled' : 'disabled');
+            $("#" + generator_name + "_eg_season_banners").attr('class', season_banners ? 'enabled' : 'disabled');
+
             $("#" + generator_name + "_eg_episode_metadata").attr('class', episode_metadata ? 'enabled' : 'disabled');
-            $("#" + generator_name + "_eg_poster").attr('class', poster ? 'enabled' : 'disabled');
-            $("#" + generator_name + "_eg_fanart").attr('class', fanart ? 'enabled' : 'disabled');
             $("#" + generator_name + "_eg_episode_thumbnails").attr('class', episode_thumbnails ? 'enabled' : 'disabled');
-            $("#" + generator_name + "_eg_season_thumbnails").attr('class', season_thumbnails ? 'enabled' : 'disabled');
             $("#" + generator_name + "_data").val(config_arr.join('|'))
 
         });

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -30,7 +30,7 @@ from threading import Lock
 
 # apparently py2exe won't build these unless they're imported somewhere
 from sickbeard import providers, metadata
-from providers import ezrss, tvtorrents, torrentleech, btn, nzbsrus, newznab, womble, nzbx, omgwtfnzbs
+from providers import ezrss, tvtorrents, torrentleech, btn, nzbsrus, newznab, womble
 from sickbeard.config import CheckSection, check_setting_int, check_setting_str, ConfigMigrator
 
 from sickbeard import searchCurrent, searchBacklog, showUpdater, versionChecker, properFinder, autoPostProcesser
@@ -117,6 +117,7 @@ ROOT_DIRS = None
 USE_BANNER = None
 USE_LISTVIEW = None
 METADATA_XBMC = None
+METADATA_XBMCORIG = None
 METADATA_MEDIABROWSER = None
 METADATA_PS3 = None
 METADATA_WDTV = None
@@ -180,13 +181,6 @@ NZBS_HASH = None
 
 WOMBLE = False
 
-NZBX = False
-NZBX_COMPLETION = 100
-
-OMGWTFNZBS = False
-OMGWTFNZBS_UID = None
-OMGWTFNZBS_KEY = None
-
 NZBSRUS = False
 NZBSRUS_UID = None
 NZBSRUS_HASH = None
@@ -214,7 +208,6 @@ XBMC_NOTIFY_ONSNATCH = False
 XBMC_NOTIFY_ONDOWNLOAD = False
 XBMC_UPDATE_LIBRARY = False
 XBMC_UPDATE_FULL = False
-XBMC_UPDATE_ONLYFIRST = False
 XBMC_HOST = ''
 XBMC_USERNAME = None
 XBMC_PASSWORD = None
@@ -277,11 +270,6 @@ NMJ_MOUNT = None
 
 USE_SYNOINDEX = False
 
-USE_NMJv2 = False
-NMJv2_HOST = None
-NMJv2_DATABASE = None
-NMJv2_DBLOC = None
-
 USE_TRAKT = False
 TRAKT_USERNAME = None
 TRAKT_PASSWORD = None
@@ -327,7 +315,7 @@ def initialize(consoleLogging=True):
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
-                USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, XBMC_UPDATE_ONLYFIRST, \
+                USE_XBMC, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
                 USE_TRAKT, TRAKT_USERNAME, TRAKT_PASSWORD, TRAKT_API, \
                 USE_PLEX, PLEX_NOTIFY_ONSNATCH, PLEX_NOTIFY_ONDOWNLOAD, PLEX_UPDATE_LIBRARY, \
@@ -346,13 +334,13 @@ def initialize(consoleLogging=True):
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 NAMING_PATTERN, NAMING_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, \
                 RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
-                NZBSRUS, NZBSRUS_UID, NZBSRUS_HASH, WOMBLE, NZBX, NZBX_COMPLETION, OMGWTFNZBS, OMGWTFNZBS_UID, OMGWTFNZBS_KEY, providerList, newznabProviderList, \
+                NZBSRUS, NZBSRUS_UID, NZBSRUS_HASH, WOMBLE, providerList, newznabProviderList, \
                 EXTRA_SCRIPTS, USE_TWITTER, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
-                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, USE_SYNOINDEX, \
-                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
+                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_SYNOINDEX, \
+                USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_XBMCORIG, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
                 ADD_SHOWS_WO_DIR
@@ -489,6 +477,7 @@ def initialize(consoleLogging=True):
 
             if old_metadata_class:
 
+                # fix to new options
                 METADATA_SHOW = bool(check_setting_int(CFG, 'General', 'metadata_show', 1))
                 METADATA_EPISODE = bool(check_setting_int(CFG, 'General', 'metadata_episode', 1))
 
@@ -496,26 +485,54 @@ def initialize(consoleLogging=True):
                 ART_FANART = bool(check_setting_int(CFG, 'General', 'art_fanart', 1))
                 ART_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_thumbnails', 1))
                 ART_SEASON_THUMBNAILS = bool(check_setting_int(CFG, 'General', 'art_season_thumbnails', 1))
+                blankvalue = bool(0)
 
                 new_metadata_class = old_metadata_class(METADATA_SHOW,
-                                                        METADATA_EPISODE,
-                                                        ART_POSTER,
                                                         ART_FANART,
-                                                        ART_THUMBNAILS,
-                                                        ART_SEASON_THUMBNAILS)
+                                                        ART_POSTER,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,
+                                                        blankvalue,              
+                                                        ART_SEASON_THUMBNAILS, 	
+                                                        blankvalue,
+                                                        METADATA_EPISODE,
+                                                        ART_THUMBNAILS)
 
                 metadata_provider_dict[new_metadata_class.name] = new_metadata_class
 
         # this is the normal codepath for metadata config
+        # if 0|0|0|0|0|0 and not '0|0|0|0|0|0|0|0|0|0|0|0' old setting to update to new....
         else:
-            METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0')
-            METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0')
-            METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0')
-            METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0')
-            METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0')
-            METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0')
+            METADATA_XBMC = check_setting_str(CFG, 'General', 'metadata_xbmc', '0|0|0|0|0|0|0|0|0|0|0|0')
+            METADATA_XBMCORIG = check_setting_str(CFG, 'General', 'metadata_xbmcorig', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_XBMC.__len__() == 11 and METADATA_XBMCORIG == '0|0|0|0|0|0|0|0|0|0|0|0':
+            	METADATA_XBMCORIG = METADATA_XBMC[0:1] + '|' + METADATA_XBMC[6:7] + '|' + METADATA_XBMC[4:5] + '|0|0|0|0|0|' + METADATA_XBMC[10:11] + '|0|' + METADATA_XBMC[2:3] + '|' + METADATA_XBMC[8:9]	            
+                METADATA_XBMC = '0|0|0|0|0|0|0|0|0|0|0|0'
+            
+            METADATA_MEDIABROWSER = check_setting_str(CFG, 'General', 'metadata_mediabrowser', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_MEDIABROWSER.__len__() == 11: 
+            	METADATA_MEDIABROWSER = METADATA_MEDIABROWSER[0:1] + '|' + METADATA_MEDIABROWSER[6:7] + '|' + METADATA_MEDIABROWSER[4:5] + '|0|0|0|0|0|' + METADATA_MEDIABROWSER[10:11] + '|0|' + METADATA_MEDIABROWSER[2:3] + '|' + METADATA_MEDIABROWSER[8:9]	            
+
+            METADATA_PS3 = check_setting_str(CFG, 'General', 'metadata_ps3', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_PS3.__len__() == 11: 
+            	METADATA_PS3 = METADATA_PS3[0:1] + '|' + METADATA_PS3[6:7] + '|' + METADATA_PS3[4:5] + '|0|0|0|0|0|' + METADATA_PS3[10:11] + '|0|' + METADATA_PS3[2:3] + '|' + METADATA_PS3[8:9]	            
+
+            METADATA_WDTV = check_setting_str(CFG, 'General', 'metadata_wdtv', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_WDTV.__len__() == 11: 
+            	METADATA_WDTV = METADATA_WDTV[0:1] + '|' + METADATA_WDTV[6:7] + '|' + METADATA_WDTV[4:5] + '|0|0|0|0|0|' + METADATA_WDTV[10:11] + '|0|' + METADATA_WDTV[2:3] + '|' + METADATA_WDTV[8:9]	            
+
+            METADATA_TIVO = check_setting_str(CFG, 'General', 'metadata_tivo', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_TIVO.__len__() == 11: 
+            	METADATA_TIVO = METADATA_TIVO[0:1] + '|' + METADATA_TIVO[6:7] + '|' + METADATA_TIVO[4:5] + '|0|0|0|0|0|' + METADATA_TIVO[10:11] + '|0|' + METADATA_TIVO[2:3] + '|' + METADATA_TIVO[8:9]	            
+
+            METADATA_SYNOLOGY = check_setting_str(CFG, 'General', 'metadata_synology', '0|0|0|0|0|0|0|0|0|0|0|0')
+            if METADATA_SYNOLOGY.__len__() == 11: 
+            	METADATA_SYNOLOGY = METADATA_SYNOLOGY[0:1] + '|' + METADATA_SYNOLOGY[6:7] + '|' + METADATA_SYNOLOGY[4:5] + '|0|0|0|0|0|' + METADATA_SYNOLOGY[10:11] + '|0|' + METADATA_SYNOLOGY[2:3] + '|' + METADATA_SYNOLOGY[8:9]	            
 
             for cur_metadata_tuple in [(METADATA_XBMC, metadata.xbmc),
+                                       (METADATA_XBMCORIG, metadata.xbmcorig),
                                        (METADATA_MEDIABROWSER, metadata.mediabrowser),
                                        (METADATA_PS3, metadata.ps3),
                                        (METADATA_WDTV, metadata.wdtv),
@@ -578,15 +595,6 @@ def initialize(consoleLogging=True):
         CheckSection(CFG, 'Womble')
         WOMBLE = bool(check_setting_int(CFG, 'Womble', 'womble', 1))
 
-        CheckSection(CFG, 'nzbX')
-        NZBX = bool(check_setting_int(CFG, 'nzbX', 'nzbx', 0))
-        NZBX_COMPLETION = check_setting_int(CFG, 'nzbX', 'nzbx_completion', 100)
-
-        CheckSection(CFG, 'omgwtfnzbs')
-        OMGWTFNZBS = bool(check_setting_int(CFG, 'omgwtfnzbs', 'omgwtfnzbs', 0))
-        OMGWTFNZBS_UID = check_setting_str(CFG, 'omgwtfnzbs', 'omgwtfnzbs_uid', '')
-        OMGWTFNZBS_KEY = check_setting_str(CFG, 'omgwtfnzbs', 'omgwtfnzbs_key', '')
-
         CheckSection(CFG, 'SABnzbd')
         SAB_USERNAME = check_setting_str(CFG, 'SABnzbd', 'sab_username', '')
         SAB_PASSWORD = check_setting_str(CFG, 'SABnzbd', 'sab_password', '')
@@ -605,7 +613,6 @@ def initialize(consoleLogging=True):
         XBMC_NOTIFY_ONDOWNLOAD = bool(check_setting_int(CFG, 'XBMC', 'xbmc_notify_ondownload', 0))
         XBMC_UPDATE_LIBRARY = bool(check_setting_int(CFG, 'XBMC', 'xbmc_update_library', 0))
         XBMC_UPDATE_FULL = bool(check_setting_int(CFG, 'XBMC', 'xbmc_update_full', 0))
-        XBMC_UPDATE_ONLYFIRST = bool(check_setting_int(CFG, 'XBMC', 'xbmc_update_onlyfirst', 0))
         XBMC_HOST = check_setting_str(CFG, 'XBMC', 'xbmc_host', '')
         XBMC_USERNAME = check_setting_str(CFG, 'XBMC', 'xbmc_username', '')
         XBMC_PASSWORD = check_setting_str(CFG, 'XBMC', 'xbmc_password', '')
@@ -671,12 +678,6 @@ def initialize(consoleLogging=True):
         NMJ_HOST = check_setting_str(CFG, 'NMJ', 'nmj_host', '')
         NMJ_DATABASE = check_setting_str(CFG, 'NMJ', 'nmj_database', '')
         NMJ_MOUNT = check_setting_str(CFG, 'NMJ', 'nmj_mount', '')
-
-        CheckSection(CFG, 'NMJv2')
-        USE_NMJv2 = bool(check_setting_int(CFG, 'NMJv2', 'use_nmjv2', 0))
-        NMJv2_HOST = check_setting_str(CFG, 'NMJv2', 'nmjv2_host', '')
-        NMJv2_DATABASE = check_setting_str(CFG, 'NMJv2', 'nmjv2_database', '')
-        NMJ_DBLOC = check_setting_str(CFG, 'NMJv2', 'nmjv2_dbloc', '')
 
         CheckSection(CFG, 'Synology')
         USE_SYNOINDEX = bool(check_setting_int(CFG, 'Synology', 'use_synoindex', 0))
@@ -1007,7 +1008,9 @@ def save_config():
 
     new_config['General']['use_banner'] = int(USE_BANNER)
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
+
     new_config['General']['metadata_xbmc'] = metadata_provider_dict['XBMC'].get_config()
+    new_config['General']['metadata_xbmcorig'] = metadata_provider_dict['XBMCOrig'].get_config()
     new_config['General']['metadata_mediabrowser'] = metadata_provider_dict['MediaBrowser'].get_config()
     new_config['General']['metadata_ps3'] = metadata_provider_dict['Sony PS3'].get_config()
     new_config['General']['metadata_wdtv'] = metadata_provider_dict['WDTV'].get_config()
@@ -1071,15 +1074,6 @@ def save_config():
     new_config['Womble'] = {}
     new_config['Womble']['womble'] = int(WOMBLE)
 
-    new_config['nzbX'] = {}
-    new_config['nzbX']['nzbx'] = int(NZBX)
-    new_config['nzbX']['nzbx_completion'] = int(NZBX_COMPLETION)
-
-    new_config['omgwtfnzbs'] = {}
-    new_config['omgwtfnzbs']['omgwtfnzbs'] = int(OMGWTFNZBS)
-    new_config['omgwtfnzbs']['omgwtfnzbs_uid'] = OMGWTFNZBS_UID
-    new_config['omgwtfnzbs']['omgwtfnzbs_key'] = OMGWTFNZBS_KEY
-
     new_config['SABnzbd'] = {}
     new_config['SABnzbd']['sab_username'] = SAB_USERNAME
     new_config['SABnzbd']['sab_password'] = SAB_PASSWORD
@@ -1098,7 +1092,6 @@ def save_config():
     new_config['XBMC']['xbmc_notify_ondownload'] = int(XBMC_NOTIFY_ONDOWNLOAD)
     new_config['XBMC']['xbmc_update_library'] = int(XBMC_UPDATE_LIBRARY)
     new_config['XBMC']['xbmc_update_full'] = int(XBMC_UPDATE_FULL)
-    new_config['XBMC']['xbmc_update_onlyfirst'] = int(XBMC_UPDATE_ONLYFIRST)
     new_config['XBMC']['xbmc_host'] = XBMC_HOST
     new_config['XBMC']['xbmc_username'] = XBMC_USERNAME
     new_config['XBMC']['xbmc_password'] = XBMC_PASSWORD
@@ -1167,12 +1160,6 @@ def save_config():
 
     new_config['Synology'] = {}
     new_config['Synology']['use_synoindex'] = int(USE_SYNOINDEX)
-
-    new_config['NMJv2'] = {}
-    new_config['NMJv2']['use_nmjv2'] = int(USE_NMJv2)
-    new_config['NMJv2']['nmjv2_host'] = NMJv2_HOST
-    new_config['NMJv2']['nmjv2_database'] = NMJv2_DATABASE
-    new_config['NMJv2']['nmjv2_dbloc'] = NMJv2_DBLOC
 
     new_config['Trakt'] = {}
     new_config['Trakt']['use_trakt'] = int(USE_TRAKT)

--- a/sickbeard/image_cache.py
+++ b/sickbeard/image_cache.py
@@ -198,8 +198,8 @@ class ImageCache:
         try:
             for cur_provider in sickbeard.metadata_provider_dict.values():
                 logger.log(u"Checking if we can use the show image from the "+cur_provider.name+" metadata", logger.DEBUG)
-                if ek.ek(os.path.isfile, cur_provider.get_poster_path(show_obj)):
-                    cur_file_name = os.path.abspath(cur_provider.get_poster_path(show_obj))
+                if ek.ek(os.path.isfile, cur_provider.get_show_poster_path(show_obj)):
+                    cur_file_name = os.path.abspath(cur_provider.get_show_poster_path(show_obj))
                     cur_file_type = self.which_type(cur_file_name)
                     
                     if cur_file_type == None:
@@ -212,6 +212,23 @@ class ImageCache:
                         logger.log(u"Found an image in the show dir that doesn't exist in the cache, caching it: "+cur_file_name+", type "+str(cur_file_type), logger.DEBUG)
                         self._cache_image_from_file(cur_file_name, cur_file_type, show_obj.tvdbid)
                         need_images[cur_file_type] = False
+
+                if ek.ek(os.path.isfile, cur_provider.get_show_banner_path(show_obj)):
+                    cur_file_name = os.path.abspath(cur_provider.get_show_banner_path(show_obj))
+                    cur_file_type = self.which_type(cur_file_name)
+
+                    if cur_file_type == None:
+                        logger.log(u"Unable to retrieve image type, not using the image from "+str(cur_file_name), logger.WARNING)
+                        continue
+
+                    logger.log(u"Checking if image "+cur_file_name+" (type "+str(cur_file_type)+" needs metadata: "+str(need_images[cur_file_type]), logger.DEBUG)
+
+                    if cur_file_type in need_images and need_images[cur_file_type]:
+                        logger.log(u"Found an image in the show dir that doesn't exist in the cache, caching it: "+cur_file_name+", type "+str(cur_file_type), logger.DEBUG)
+                        self._cache_image_from_file(cur_file_name, cur_file_type, show_obj.tvdbid)
+                        need_images[cur_file_type] = False
+
+
         except exceptions.ShowDirNotFoundException:
             logger.log(u"Unable to search for images in show dir because it doesn't exist", logger.WARNING)
                     

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['generic', 'helpers', 'xbmc', 'mediabrowser', 'synology', 'ps3', 'wdtv', 'tivo']
+__all__ = ['generic', 'helpers', 'xbmc', 'xbmcorig', 'mediabrowser', 'synology', 'ps3', 'wdtv', 'tivo']
 
 import sys
-import xbmc, mediabrowser, synology, ps3, wdtv, tivo
+import xbmc, xbmcorig, mediabrowser, synology, ps3, wdtv, tivo
 
 def available_generators():
     return filter(lambda x: x not in ('generic', 'helpers'), __all__)

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -15,7 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
-
+# 
+# luxmoggy updated to create metadata in the new xbmc style
+# 
 import os.path
 
 import xml.etree.cElementTree as etree
@@ -38,42 +40,64 @@ class GenericMetadata():
     Base class for all metadata providers. Default behavior is meant to mostly
     follow XBMC metadata standards. Has support for:
     
-    - show poster
-    - show fanart
     - show metadata file
-    - episode thumbnail
+    - show fanart
+    - show poster
+    - show banner
+    - season all fanart
+    - season all poster
+    - season all banner    
+    - season fanart (still needs to be written)
+    - season poster
+    - season banner
     - episode metadata file
-    - season thumbnails
+    - episode thumbnail
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
-        self._show_file_name = "tvshow.nfo"
-        self._ep_nfo_extension = "nfo"
-        
-        self.poster_name = "folder.jpg"
-        self.fanart_name = "fanart.jpg"
-
-        self.generate_show_metadata = True
-        self.generate_ep_metadata = True
-        
         self.name = 'Generic'
+        self._ep_nfo_extension = "nfo"
+
+        self._show_metadata_name = "tvshow.nfo"
+
+        self.show_fanart_name = "fanart.jpg"
+        self.show_poster_name = "poster.jpg"
+        self.show_banner_name = "banner.jpg"
+        self.season_all_fanart_name = "season-all-fanart.jpg"
+        self.season_all_poster_name = "season-all-poster.jpg"
+        self.season_all_banner_name = "season-all-banner.jpg"
 
         self.show_metadata = show_metadata
+        self.show_fanart = show_fanart
+        self.show_poster = show_poster
+        self.show_banner = show_banner
+
+        self.season_all_fanart = season_all_fanart
+        self.season_all_poster = season_all_poster
+        self.season_all_banner = season_all_banner
+        self.season_fanarts = season_fanarts
+        self.season_posters = season_posters
+        self.season_banners = season_banners
+
         self.episode_metadata = episode_metadata
-        self.poster = poster
-        self.fanart = fanart
         self.episode_thumbnails = episode_thumbnails
-        self.season_thumbnails = season_thumbnails
+
     
     def get_config(self):
-        config_list = [self.show_metadata, self.episode_metadata, self.poster, self.fanart, self.episode_thumbnails, self.season_thumbnails]
+        config_list = [self.show_metadata, self.show_fanart, self.show_poster, self.show_banner, self.season_all_fanart, self.season_all_poster, self.season_all_banner, self.season_fanarts, self.season_posters, self.season_banners, self.episode_metadata, self.episode_thumbnails]
         return '|'.join([str(int(x)) for x in config_list])
 
     def get_id(self):
@@ -86,57 +110,148 @@ class GenericMetadata():
     def set_config(self, string):
         config_list = [bool(int(x)) for x in string.split('|')]
         self.show_metadata = config_list[0]
-        self.episode_metadata = config_list[1]
-        self.poster = config_list[2]
-        self.fanart = config_list[3]
-        self.episode_thumbnails = config_list[4]
-        self.season_thumbnails = config_list[5]
+        self.show_fanart = config_list[1]
+        self.show_poster = config_list[2]
+        self.show_banner = config_list[3]
+        self.season_all_fanart = config_list[4]
+        self.season_all_poster = config_list[5]
+        self.season_all_banner = config_list[6]
+        self.season_fanarts = config_list[7]
+        self.season_posters = config_list[8]
+        self.season_banners = config_list[9]
+        self.episode_metadata = config_list[10]
+        self.episode_thumbnails = config_list[11]
     
     def _has_show_metadata(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_show_file_path(show_obj))
-        logger.log("Checking if "+self.get_show_file_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        result = ek.ek(os.path.isfile, self.get_show_metadata_path(show_obj))
+        logger.log("Checking if "+self.get_show_metadata_path(show_obj)+" (Show Metadata) exists: "+str(result), logger.DEBUG)
         return result
     
+    def _has_show_fanart(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_fanart_path(show_obj))
+        logger.log("Checking if "+self.get_show_fanart_path(show_obj)+" (Show Fanart) exists: "+str(result), logger.DEBUG)
+        return result
+    
+    def _has_show_poster(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_poster_path(show_obj))
+        logger.log("Checking if "+self.get_show_poster_path(show_obj)+" (Show Poster) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_show_banner(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_show_banner_path(show_obj))
+        logger.log("Checking if "+self.get_show_banner_path(show_obj)+" (Show Banner) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_all_fanart(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_fanart_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_fanart_path(show_obj)+" (Season All Fanart) exists: "+str(result), logger.DEBUG)
+        return result
+    
+    def _has_season_all_poster(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_poster_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_poster_path(show_obj)+" (Season All Poster) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_all_banner(self, show_obj):
+        result = ek.ek(os.path.isfile, self.get_season_all_banner_path(show_obj))
+        logger.log("Checking if "+self.get_season_all_banner_path(show_obj)+" (Season All Banner) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_fanart(self, show_obj, season):
+        location = self.season_fanart_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" (Season Fanart) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_poster(self, show_obj, season):
+        location = self.season_poster_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" (Season Poster) exists: "+str(result), logger.DEBUG)
+        return result
+
+    def _has_season_banner(self, show_obj, season):
+        location = self.season_banner_path(show_obj, season)
+        result = location != None and ek.ek(os.path.isfile, location)
+        if location:
+            logger.log("Checking if "+location+" (Season Banner) exists: "+str(result), logger.DEBUG)
+        return result
+
     def _has_episode_metadata(self, ep_obj):
         result = ek.ek(os.path.isfile, self.get_episode_file_path(ep_obj))
-        logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def _has_poster(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_poster_path(show_obj))
-        logger.log("Checking if "+self.get_poster_path(show_obj)+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def _has_fanart(self, show_obj):
-        result = ek.ek(os.path.isfile, self.get_fanart_path(show_obj))
-        logger.log("Checking if "+self.get_fanart_path(show_obj)+" exists: "+str(result), logger.DEBUG)
+        logger.log("Checking if "+self.get_episode_file_path(ep_obj)+" (Episode Metadata) exists: "+str(result), logger.DEBUG)
         return result
     
     def _has_episode_thumb(self, ep_obj):
         location = self.get_episode_thumb_path(ep_obj)
         result = location != None and ek.ek(os.path.isfile, location)
         if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
+            logger.log("Checking if "+location+" (Episode Thumbnail) exists: "+str(result), logger.DEBUG)
         return result
     
-    def _has_season_thumb(self, show_obj, season):
-        location = self.get_season_thumb_path(show_obj, season)
-        result = location != None and ek.ek(os.path.isfile, location)
-        if location:
-            logger.log("Checking if "+location+" exists: "+str(result), logger.DEBUG)
-        return result
-    
-    def get_show_file_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self._show_file_name)
+    def get_show_metadata_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self._show_metadata_name)
 
     def get_episode_file_path(self, ep_obj):
         return helpers.replaceExtension(ep_obj.location, self._ep_nfo_extension)
 
-    def get_poster_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.poster_name)
-            
-    def get_fanart_path(self, show_obj):
-        return ek.ek(os.path.join, show_obj.location, self.fanart_name)
+    def get_show_fanart_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_fanart_name)
+
+    def get_show_poster_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_poster_name)
+
+    def get_show_banner_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.show_banner_name)
+
+    def get_season_all_fanart_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_fanart_name)
+
+    def get_season_all_poster_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_poster_name)
+
+    def get_season_all_banner_path(self, show_obj):
+        return ek.ek(os.path.join, show_obj.location, self.season_all_banner_name)
+
+    def get_season_fanart_path(self, show_obj, season):
+        """
+        Returns the full path to the file for a given season thumb.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path+'-fanart.jpg')
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+        
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)        
+        
+        if img_type == 'season':
+           season_pb_file_ext = '-poster.jpg'
+        else:
+           season_pb_file_ext = '-banner.jpg'
+        
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path)            
             
     def get_episode_thumb_path(self, ep_obj):
         """
@@ -151,23 +266,6 @@ class GenericMetadata():
             return None
         
         return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
-        """
-        Returns the full path to the file for a given season thumb.
-        
-        show_obj: a TVShow instance for which to generate the path
-        season: a season number to be used for the path. Note that sesaon 0
-                means specials.
-        """
-
-        # Our specials thumbnail is, well, special
-        if season == 0:
-            season_thumb_file_path = 'season-specials'
-        else:
-            season_thumb_file_path = 'season' + str(season).zfill(2)
-        
-        return ek.ek(os.path.join, show_obj.location, season_thumb_file_path+'.tbn')
     
     def _show_data(self, show_obj):
         """
@@ -188,36 +286,255 @@ class GenericMetadata():
             logger.log("Metadata provider "+self.name+" creating show metadata for "+show_obj.name, logger.DEBUG)
             return self.write_show_file(show_obj)
         return False
+
+    def create_show_fanart(self, show_obj):
+        if self.show_fanart and show_obj and not self._has_show_fanart(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show fanart for "+show_obj.name, logger.DEBUG)
+            fanart_path = self.get_show_fanart_path(show_obj)
+            return self.save_show_fpb(show_obj, "fanart", fanart_path)
+        return False
     
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            return self.save_show_fpb(show_obj, "poster", poster_path)
+        return False
+
+    def create_show_banner(self, show_obj):
+        if self.show_banner and show_obj and not self._has_show_banner(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show banner for "+show_obj.name, logger.DEBUG)
+            banner_path = self.get_show_banner_path(show_obj)
+            return self.save_show_fpb(show_obj, "banner", banner_path)
+        return False
+
+    def create_season_all_fanart(self, show_obj):
+        if self.season_all_fanart and show_obj and not self._has_season_all_fanart(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all fanart for "+show_obj.name, logger.DEBUG)
+            season_all_fanart_path = self.get_season_all_fanart_path(show_obj)
+            return self.save_show_fpb(show_obj, "fanart", season_all_fanart_path)
+        return False
+    
+    def create_season_all_poster(self, show_obj):
+        if self.season_all_poster and show_obj and not self._has_season_all_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all poster for "+show_obj.name, logger.DEBUG)
+            season_all_poster_path = self.get_season_all_poster_path(show_obj)
+            return self.save_show_fpb(show_obj, "poster", season_all_poster_path)
+        return False
+
+    def create_season_all_banner(self, show_obj):
+        if self.season_all_banner and show_obj and not self._has_season_all_banner(show_obj):
+            logger.log("Metadata provider "+self.name+" creating season all banner for "+show_obj.name, logger.DEBUG)
+            season_all_banner_path = self.get_season_all_banner_path(show_obj)
+            return self.save_show_fpb(show_obj, "banner", season_all_banner_path)
+        return False
+
+    def create_season_fanart(self, show_obj):
+        if self.season_fanarts and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season fanart for "+show_obj.name, logger.DEBUG)
+            return self.save_season_fanart(show_obj)
+        return False
+
+    def create_season_poster(self, show_obj):
+        if self.season_posters and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season poster for "+show_obj.name, logger.DEBUG)
+            return self.save_season_pb(show_obj,'season')
+        return False
+
+    def create_season_banner(self, show_obj):
+        if self.season_banners and show_obj:
+            logger.log("Metadata provider "+self.name+" creating season banner for "+show_obj.name, logger.DEBUG)
+            return self.save_season_pb(show_obj,'seasonwide')
+        return False
+
     def create_episode_metadata(self, ep_obj):
         if self.episode_metadata and ep_obj and not self._has_episode_metadata(ep_obj):
             logger.log("Metadata provider "+self.name+" creating episode metadata for "+ep_obj.prettyName(), logger.DEBUG)
             return self.write_ep_file(ep_obj)
         return False
     
-    def create_poster(self, show_obj):
-        if self.poster and show_obj and not self._has_poster(show_obj):
-            logger.log("Metadata provider "+self.name+" creating poster for "+show_obj.name, logger.DEBUG)
-            return self.save_poster(show_obj)
-        return False
-    
-    def create_fanart(self, show_obj):
-        if self.fanart and show_obj and not self._has_fanart(show_obj):
-            logger.log("Metadata provider "+self.name+" creating fanart for "+show_obj.name, logger.DEBUG)
-            return self.save_fanart(show_obj)
-        return False
-    
     def create_episode_thumb(self, ep_obj):
         if self.episode_thumbnails and ep_obj and not self._has_episode_thumb(ep_obj):
-            logger.log("Metadata provider "+self.name+" creating show metadata for "+ep_obj.prettyName(), logger.DEBUG)
-            return self.save_thumbnail(ep_obj)
+            logger.log("Metadata provider "+self.name+" creating episode thumbnail for "+ep_obj.prettyName(), logger.DEBUG)
+            return self.save_episode_thumbnail(ep_obj)
         return  False
     
-    def create_season_thumbs(self, show_obj):
-        if self.season_thumbnails and show_obj:
-            logger.log("Metadata provider "+self.name+" creating season thumbnails for "+show_obj.name, logger.DEBUG)
-            return self.save_season_thumbs(show_obj)
-        return False
+    def write_show_file(self, show_obj):
+        """
+        Generates and writes show_obj's metadata under the given path to the
+        filename given by get_show_file_path()
+        
+        show_obj: TVShow object for which to create the metadata
+        
+        path: An absolute or relative path where we should put the file. Note that
+                the file name will be the default show_file_name.
+        
+        Note that this method expects that _show_data will return an ElementTree
+        object. If your _show_data returns data in another format you'll need to
+        override this method.
+        """
+        
+        data = self._show_data(show_obj)
+        
+        if not data:
+            return False
+        
+        nfo_file_path = self.get_show_metadata_path(show_obj)
+        nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
+
+        try:
+            if not ek.ek(os.path.isdir, nfo_file_dir):
+                logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
+                ek.ek(os.makedirs, nfo_file_dir)
+                helpers.chmodAsParent(nfo_file_dir)
+    
+            logger.log(u"Writing show nfo file to "+nfo_file_path)
+            
+            nfo_file = ek.ek(open, nfo_file_path, 'w')
+    
+            data.write(nfo_file, encoding="utf-8")
+            nfo_file.close()
+            helpers.chmodAsParent(nfo_file_path)
+        except IOError, e:
+            logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+ex(e), logger.ERROR)
+            return False
+        
+        return True
+
+    def save_show_fpb(self, show_obj, img_type, img_path, which=None):
+        """
+        Downloads a image and saves it to the filename specified by img_path
+        inside the show's root folder.
+        
+        show_obj: a TVShow object for which to download fanart/poster/banner 
+        """
+        
+        img_data = self._retrieve_show_image(img_type, show_obj, which)
+
+        if not img_data:
+            logger.log(u"No " + img_type + " image was retrieved, unable to write " + img_type, logger.DEBUG)
+            return False
+
+        return self._write_image(img_data, img_path)
+
+    def _season_fanart_dict(self, show_obj):
+        """
+    	need to write query for this    	
+    	"""
+    	# IRC: TO BE DONE
+	return result	
+
+    def _season_pb_dict(self, show_obj, img_type):
+        """
+        Should return a dict like:
+        
+        result = {<season number>: 
+                    {1: '<url 1>', 2: <url 2>, ...},}
+        """
+
+        # This holds our resulting dictionary of season art
+        result = {}
+    
+        tvdb_lang = show_obj.lang
+
+        try:
+            # There's gotta be a better way of doing this but we don't wanna
+            # change the language value elsewhere
+            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+            if tvdb_lang and not tvdb_lang == 'en':
+                ltvdb_api_parms['language'] = tvdb_lang
+
+            t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
+            tvdb_show_obj = t[show_obj.tvdbid]
+        except (tvdb_exceptions.tvdb_error, IOError), e:
+            logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
+            return result
+    
+        # How many seasons?
+        # num_seasons = len(tvdb_show_obj)
+        # logger.log(u"TV Show has " + str(num_seasons) + " season(s)", logger.DEBUG)
+    
+        # if we have no season banners then just finish
+        if 'season' not in tvdb_show_obj['_banners'] or img_type not in tvdb_show_obj['_banners']['season']:
+            return result
+    
+        # Give us just the normal poster-style season graphics
+        seasonsArtObj = tvdb_show_obj['_banners']['season'][img_type]
+
+        #for seasonArtID in seasonsArtObj.keys():
+        #    if int(seasonsArtObj[seasonArtID]['season']) == 2 and seasonsArtObj[seasonArtID]['language'] == 'en':
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['season'], logger.DEBUG)
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['language'], logger.DEBUG)
+        #        logger.log(u" " + seasonsArtObj[seasonArtID]['_bannerpath'], logger.DEBUG)
+
+        # Returns a nested dictionary of season art with the season
+        # number as primary key. It's really overkill but gives the option
+        # to present to user via ui to pick down the road.
+        # edited the range as not always getting last season
+        #for cur_season in range(num_seasons+1):
+        for cur_season in tvdb_show_obj:
+
+            result[cur_season] = {}
+            
+            # find the correct season in the tvdb object and just copy the dict into our result dict
+            for seasonArtID in seasonsArtObj.keys():
+                if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
+                    result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
+
+            #logger.log(u"Season " + str(cur_season) + " artwork found", logger.DEBUG)
+            
+            if len(result[cur_season]) == 0:
+                continue
+
+        return result
+
+    def save_season_pb(self, show_obj, img_type):
+        """
+        Saves all season poster/banner to disk for the given show.
+        
+        show_obj: a TVShow object for which to save the season poster/banner
+        
+        Cycles through all seasons and saves the season poster/banner if possible. This
+        method should not need to be overridden by implementing classes, changing
+        _season_thumb_dict and get_season_thumb_path should be good enough.
+        """
+    
+        season_dict = self._season_pb_dict(show_obj, img_type)
+        # logger.log(u"Season image list filled", logger.DEBUG)
+   
+        # Returns a nested dictionary of season art with the season
+        # number as primary key. It's really overkill but gives the option
+        # to present to user via ui to pick down the road.
+        for cur_season in season_dict:
+
+            cur_season_art = season_dict[cur_season]
+            
+            if len(cur_season_art) == 0:
+                continue
+
+            # Just grab whatever's there for now
+            art_id, season_url = cur_season_art.popitem() #@UnusedVariable
+            #logger.log(u"Season " + str(cur_season) + " artwork url: " + season_url, logger.DEBUG)
+            season_image_path = self.get_season_pb_path(show_obj, cur_season, img_type)
+            #logger.log(u"Season " + str(cur_season) + " artwork path: " + season_image_path, logger.DEBUG)
+            
+            if not season_image_path:
+                logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
+                continue
+            
+            seasonData = metadata_helpers.getShowImage(season_url)
+            
+            if not seasonData:
+                logger.log(u"No season image data available, skipping this season", logger.DEBUG)
+                continue
+            
+            #logger.log(u"Season " + str(cur_season) + " image data recieved", logger.DEBUG)            
+            result = self._write_image(seasonData, season_image_path)
+            #logger.log(u"Season " + str(cur_season) + " image data saved", logger.DEBUG)
+            
+        #logger.log(u"Season artwork Finished: " + img_type, logger.DEBUG)    
+        return True
     
     def _get_episode_thumb_url(self, ep_obj):
         """
@@ -262,47 +579,6 @@ class GenericMetadata():
 
         return None
     
-    def write_show_file(self, show_obj):
-        """
-        Generates and writes show_obj's metadata under the given path to the
-        filename given by get_show_file_path()
-        
-        show_obj: TVShow object for which to create the metadata
-        
-        path: An absolute or relative path where we should put the file. Note that
-                the file name will be the default show_file_name.
-        
-        Note that this method expects that _show_data will return an ElementTree
-        object. If your _show_data returns data in another format you'll need to
-        override this method.
-        """
-        
-        data = self._show_data(show_obj)
-        
-        if not data:
-            return False
-        
-        nfo_file_path = self.get_show_file_path(show_obj)
-        nfo_file_dir = ek.ek(os.path.dirname, nfo_file_path)
-
-        try:
-            if not ek.ek(os.path.isdir, nfo_file_dir):
-                logger.log("Metadata dir didn't exist, creating it at "+nfo_file_dir, logger.DEBUG)
-                ek.ek(os.makedirs, nfo_file_dir)
-                helpers.chmodAsParent(nfo_file_dir)
-    
-            logger.log(u"Writing show nfo file to "+nfo_file_path)
-            
-            nfo_file = ek.ek(open, nfo_file_path, 'w')
-    
-            data.write(nfo_file, encoding="utf-8")
-            nfo_file.close()
-            helpers.chmodAsParent(nfo_file_path)
-        except IOError, e:
-            logger.log(u"Unable to write file to "+nfo_file_path+" - are you sure the folder is writable? "+ex(e), logger.ERROR)
-            return False
-        
-        return True
 
     def write_ep_file(self, ep_obj):
         """
@@ -381,93 +657,6 @@ class GenericMetadata():
             cur_ep.hastbn = True
     
         return True
-    
-    def save_fanart(self, show_obj, which=None):
-        """
-        Downloads a fanart image and saves it to the filename specified by fanart_name
-        inside the show's root folder.
-        
-        show_obj: a TVShow object for which to download fanart 
-        """
-
-        # use the default fanart name
-        fanart_path = self.get_fanart_path(show_obj)
-        
-        fanart_data = self._retrieve_show_image('fanart', show_obj, which)
-
-        if not fanart_data:
-            logger.log(u"No fanart image was retrieved, unable to write fanart", logger.DEBUG)
-            return False
-
-        return self._write_image(fanart_data, fanart_path)
-
-
-    def save_poster(self, show_obj, which=None):
-        """
-        Downloads a poster image and saves it to the filename specified by poster_name
-        inside the show's root folder.
-        
-        show_obj: a TVShow object for which to download a poster 
-        """
-
-        # use the default poster name
-        poster_path = self.get_poster_path(show_obj)
-        
-        if sickbeard.USE_BANNER:
-            img_type = 'banner'
-        else:
-            img_type = 'poster'
-        
-        poster_data = self._retrieve_show_image(img_type, show_obj, which)
-
-        if not poster_data:
-            logger.log(u"No show folder image was retrieved, unable to write poster", logger.DEBUG)
-            return False
-
-        return self._write_image(poster_data, poster_path)
-
-
-    def save_season_thumbs(self, show_obj):
-        """
-        Saves all season thumbnails to disk for the given show.
-        
-        show_obj: a TVShow object for which to save the season thumbs
-        
-        Cycles through all seasons and saves the season thumbs if possible. This
-        method should not need to be overridden by implementing classes, changing
-        _season_thumb_dict and get_season_thumb_path should be good enough.
-        """
-    
-        season_dict = self._season_thumb_dict(show_obj)
-    
-        # Returns a nested dictionary of season art with the season
-        # number as primary key. It's really overkill but gives the option
-        # to present to user via ui to pick down the road.
-        for cur_season in season_dict:
-
-            cur_season_art = season_dict[cur_season]
-            
-            if len(cur_season_art) == 0:
-                continue
-    
-            # Just grab whatever's there for now
-            art_id, season_url = cur_season_art.popitem() #@UnusedVariable
-
-            season_thumb_file_path = self.get_season_thumb_path(show_obj, cur_season)
-            
-            if not season_thumb_file_path:
-                logger.log(u"Path for season "+str(cur_season)+" came back blank, skipping this season", logger.DEBUG)
-                continue
-    
-            seasonData = metadata_helpers.getShowImage(season_url)
-            
-            if not seasonData:
-                logger.log(u"No season thumb data available, skipping this season", logger.DEBUG)
-                continue
-            
-            self._write_image(seasonData, season_thumb_file_path)
-    
-        return True
 
     def _write_image(self, image_data, image_path):
         """
@@ -477,6 +666,7 @@ class GenericMetadata():
         image_data: binary image data to write to file
         image_path: file location to save the image to
         """
+        #logger.log(u"Creating Image from data:" + image_path, logger.DEBUG)
         
         # don't bother overwriting it
         if ek.ek(os.path.isfile, image_path):
@@ -486,7 +676,7 @@ class GenericMetadata():
         if not image_data:
             logger.log(u"Unable to retrieve image, skipping", logger.WARNING)
             return False
-
+        
         image_dir = ek.ek(os.path.dirname, image_path)
         
         try:
@@ -494,7 +684,7 @@ class GenericMetadata():
                 logger.log("Metadata dir didn't exist, creating it at "+image_dir, logger.DEBUG)
                 ek.ek(os.makedirs, image_dir)
                 helpers.chmodAsParent(image_dir)
-
+            
             outFile = ek.ek(open, image_path, 'wb')
             outFile.write(image_data)
             outFile.close()
@@ -502,7 +692,7 @@ class GenericMetadata():
         except IOError, e:
             logger.log(u"Unable to write image to "+image_path+" - are you sure the show folder is writable? "+ex(e), logger.ERROR)
             return False
-    
+        
         return True
     
     def _retrieve_show_image(self, image_type, show_obj, which=None):
@@ -542,65 +732,12 @@ class GenericMetadata():
 
         return image_data
     
-    def _season_thumb_dict(self, show_obj):
-        """
-        Should return a dict like:
-        
-        result = {<season number>: 
-                    {1: '<url 1>', 2: <url 2>, ...},}
-        """
-
-        # This holds our resulting dictionary of season art
-        result = {}
-    
-        tvdb_lang = show_obj.lang
-
-        try:
-            # There's gotta be a better way of doing this but we don't wanna
-            # change the language value elsewhere
-            ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
-
-            if tvdb_lang and not tvdb_lang == 'en':
-                ltvdb_api_parms['language'] = tvdb_lang
-
-            t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
-            tvdb_show_obj = t[show_obj.tvdbid]
-        except (tvdb_exceptions.tvdb_error, IOError), e:
-            logger.log(u"Unable to look up show on TVDB, not downloading images: "+ex(e), logger.ERROR)
-            return result
-    
-        #  How many seasons?
-        num_seasons = len(tvdb_show_obj)
-    
-        # if we have no season banners then just finish
-        if 'season' not in tvdb_show_obj['_banners'] or 'season' not in tvdb_show_obj['_banners']['season']:
-            return result
-    
-        # Give us just the normal poster-style season graphics
-        seasonsArtObj = tvdb_show_obj['_banners']['season']['season']
-    
-        # Returns a nested dictionary of season art with the season
-        # number as primary key. It's really overkill but gives the option
-        # to present to user via ui to pick down the road.
-        for cur_season in range(num_seasons):
-
-            result[cur_season] = {}
-            
-            # find the correct season in the tvdb object and just copy the dict into our result dict
-            for seasonArtID in seasonsArtObj.keys():
-                if int(seasonsArtObj[seasonArtID]['season']) == cur_season and seasonsArtObj[seasonArtID]['language'] == 'en':
-                    result[cur_season][seasonArtID] = seasonsArtObj[seasonArtID]['_bannerpath']
-            
-            if len(result[cur_season]) == 0:
-                continue
-
-        return result
 
     def retrieveShowMetadata(self, dir):
     
         empty_return = (None, None)
     
-        metadata_path = ek.ek(os.path.join, dir, self._show_file_name)
+        metadata_path = ek.ek(os.path.join, dir, self._show_metadata_name)
     
         if not ek.ek(os.path.isdir, dir) or not ek.ek(os.path.isfile, metadata_path):
             logger.log(u"Can't load the metadata file from "+repr(metadata_path)+", it doesn't exist", logger.DEBUG)

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -41,11 +41,10 @@ class MediaBrowserMetadata(generic.GenericMetadata):
     http://code.google.com/p/sickbeard/issues/detail?id=311
     
     The following file structure is used:
-    
     show_root/series.xml                           (show metadata)
-    show_root/folder.jpg                           (poster)
-    show_root/backdrop.jpg                         (fanart)
-    show_root/Season 01/folder.jpg                 (season thumb)
+    show_root/folder.jpg                           (show poster)
+    show_root/backdrop.jpg                         (show fanart)
+    show_root/Season 01/folder.jpg                 (season poster)
     show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.xml  (episode metadata)
     show_root/metadata/show - 1x01 - episode.jpg   (episode thumb)
@@ -53,32 +52,54 @@ class MediaBrowserMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
-        self.fanart_name = "backdrop.jpg"
-        self._show_file_name = 'series.xml'
-        self._ep_nfo_extension = 'xml'
 
         self.name = 'MediaBrowser'
+        self._ep_nfo_extension = 'xml'
+
+        self.show_fanart_name = "backdrop.jpg"
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
+        self.eg_show_fanart = "backdrop.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "Season##\\folder.jpg"
+        self.eg_season_banners = "<i>not supported</i>"
+
         self.eg_episode_metadata = "Season##\\metadata\\<i>filename</i>.xml"
-        self.eg_fanart = "backdrop.jpg"
-        self.eg_poster = "folder.jpg"
         self.eg_episode_thumbnails = "Season##\\metadata\\<i>filename</i>.jpg"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
+        
     
     def get_episode_file_path(self, ep_obj):
         """
@@ -98,24 +119,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         
         return xml_file_path
 
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns a full show dir/metadata/episode.jpg path for MediaBrowser
-        episode thumbs.
-        
-        ep_obj: a TVEpisode object to get the path from
-        """
-
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
-            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), 'metadata')
-            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
-        else:
-            return None
-        
-        return tbn_file_path
-    
-    def get_season_thumb_path(self, show_obj, season):
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for MediaBrowser go in Show Dir/Season X/folder.jpg
         
@@ -150,6 +154,23 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns a full show dir/metadata/episode.jpg path for MediaBrowser
+        episode thumbs.
+        
+        ep_obj: a TVEpisode object to get the path from
+        """
+
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
+            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), 'metadata')
+            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
+        else:
+            return None
+        
+        return tbn_file_path
 
     def _show_data(self, show_obj):
         """
@@ -401,6 +422,36 @@ class MediaBrowserMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+	
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+	# all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
     
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -27,51 +27,59 @@ class PS3Metadata(generic.GenericMetadata):
     Metadata generation class for Sony PS3.
 
     The following file structure is used:
-    
-    show_root/cover.jpg                                      (poster)
-    show_root/Season 01/show - 1x01 - episode.avi            (existing video)
+    show_root/cover.jpg                                      (show poster)
+    show_root/Season 01/show - 1x01 - episode.avi            (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.avi.cover.jpg  (episode thumb)
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
-        self.poster_name = 'cover.jpg'
+
         self.name = 'Sony PS3'
 
+        self.show_poster_name = 'cover.jpg'
+
         self.eg_show_metadata = "<i>not supported</i>"
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "cover.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "<i>not supported</i>" 
+        self.eg_season_banners = "<i>not supported</i>"
+
         self.eg_episode_metadata = "<i>not supported</i>"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "cover.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.ext.cover.jpg"
-        self.eg_season_thumbnails = "<i>not supported</i>"
-    
-    # all of the following are not supported, so do nothing
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_episode_metadata(self, ep_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def create_season_thumbs(self, show_obj):
-        pass
-    
+
     def get_episode_thumb_path(self, ep_obj):
         """
         Returns the path where the episode thumbnail should be stored. Defaults to
@@ -85,6 +93,48 @@ class PS3Metadata(generic.GenericMetadata):
             return None
         
         return tbn_filename
+
+    # all of the following are not supported, so do nothing
+    def create_show_metadata(self, show_obj):
+        pass
+
+    def create_show_fanart(self, show_obj): 
+        pass
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+    def create_show_banner(self, show_obj): 
+        pass
+
+    def create_season_all_fanart(self, show_obj): 
+        pass
+
+    def create_season_all_poster(self, show_obj): 
+        pass
+
+    def create_season_all_banner(self, show_obj): 
+        pass
+
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_poster(self, show_obj):
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
+
+    def create_episode_metadata(self, ep_obj):
+        pass
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/synology.py
+++ b/sickbeard/metadata/synology.py
@@ -42,11 +42,10 @@ class SynologyMetadata(generic.GenericMetadata):
     http://code.google.com/p/sickbeard/issues/detail?id=311
     
     The following file structure is used:
-    
     show_root/series.xml                           (show metadata)
-    show_root/folder.jpg                           (poster)
-    show_root/backdrop.jpg                         (fanart)
-    show_root/Season 01/folder.jpg                 (season thumb)
+    show_root/folder.jpg                           (show poster)
+    show_root/backdrop.jpg                         (show fanart)
+    show_root/Season 01/folder.jpg                 (season poster)
     show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
     show_root/Season 01/show - 1x01 - episode.xml  (episode metadata)
     show_root/Season 01/show - 1x01 - episode.jpg  (episode thumb)
@@ -54,32 +53,53 @@ class SynologyMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
-        self.fanart_name = "backdrop.jpg"
-        self._show_file_name = 'series.xml'
+        self.name = 'Synology'
         self._ep_nfo_extension = 'xml'
 
-        self.name = 'Synology'
+        self._show_metadata_name = 'series.xml'
+        self.show_fanart_name = "backdrop.jpg"
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "series.xml"
+        self.eg_show_fanart = "backdrop.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "Season##\\folder.jpg" 
+        self.eg_season_banners = "<i>not supported</i>"
+
         self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "backdrop.jpg"
-        self.eg_poster = "folder.jpg"
         self.eg_episode_thumbnails = "Season##\\<i>filename</i>.jpg"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
     
     def get_episode_file_path(self, ep_obj):
         """
@@ -99,24 +119,7 @@ class SynologyMetadata(generic.GenericMetadata):
         
         return xml_file_path
 
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns a full show dir/episode.jpg path for Synology
-        episode thumbs.
-        
-        ep_obj: a TVEpisode object to get the path from
-        """
-
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
-            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), '')
-            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
-        else:
-            return None
-        
-        return tbn_file_path
-    
-    def get_season_thumb_path(self, show_obj, season):
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for Synology go in Show Dir/Season X/folder.jpg
         
@@ -151,6 +154,23 @@ class SynologyMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns a full show dir/episode.jpg path for Synology
+        episode thumbs.
+        
+        ep_obj: a TVEpisode object to get the path from
+        """
+
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_file_name = helpers.replaceExtension(ek.ek(os.path.basename, ep_obj.location), 'jpg')
+            metadata_dir_name = ek.ek(os.path.join, ek.ek(os.path.dirname, ep_obj.location), '')
+            tbn_file_path = ek.ek(os.path.join, metadata_dir_name, tbn_file_name)
+        else:
+            return None
+        
+        return tbn_file_path
 
     def _show_data(self, show_obj):
         """
@@ -256,7 +276,6 @@ class SynologyMetadata(generic.GenericMetadata):
         data = etree.ElementTree(tv_node)
 
         return data
-
 
     def _ep_data(self, ep_obj):
         """
@@ -402,6 +421,36 @@ class SynologyMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+
+	# all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+
+    def create_season_all_fanart(self, show_obj): 
+        pass
+
+    def create_season_all_poster(self, show_obj): 
+        pass
+
+    def create_season_all_banner(self, show_obj): 
+        pass
+
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj): 
+        pass
     
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -35,8 +35,7 @@ class TIVOMetadata(generic.GenericMetadata):
     Metadata generation class for TIVO
 
     The following file structure is used:
-
-    show_root/Season 01/show - 1x01 - episode.avi.txt       (* existing episode)
+    show_root/Season 01/show - 1x01 - episode.avi           (* example of existing ep of course)
     show_root/Season 01/.meta/show - 1x01 - episode.avi.txt (episode metadata)
     
     This class only generates episode specific metadata files, it does NOT generated a default.txt file.
@@ -44,48 +43,49 @@ class TIVOMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
-        
-        self._ep_nfo_extension = "txt"
-        
-        self.generate_ep_metadata = True
+                                         episode_thumbnails)
         
         self.name = 'TIVO'
+        self._ep_nfo_extension = "txt"
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "<i>not supported</i>"
-        self.eg_episode_thumbnails = "<i>not supported</i>"
-        self.eg_season_thumbnails = "<i>not supported</i>"
-    
-    # Override with empty methods for unsupported features.
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def get_episode_thumb_path(self, ep_obj):
-        pass
-    
-    def get_season_thumb_path(self, show_obj, season):
-        pass
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "<i>not supported</i>"
+        self.eg_show_banner = "<i>not supported</i>"
 
-    def retrieveShowMetadata(self, dir):
-        return (None, None)
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "<i>not supported</i>" 
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\.meta\\<i>filename</i>.txt"
+        self.eg_episode_thumbnails = "<i>not supported</i>"
         
     # Override and implement features for Tivo.
     def get_episode_file_path(self, ep_obj):
@@ -107,6 +107,11 @@ class TIVOMetadata(generic.GenericMetadata):
             logger.log(u"Episode location doesn't exist: "+str(ep_obj.location), logger.DEBUG)
             return ''
         return metadata_file_path
+
+    # Override with empty methods for unsupported features.
+    def get_episode_thumb_path(self, ep_obj):
+        pass
+
 
     def _ep_data(self, ep_obj):
         """
@@ -271,9 +276,42 @@ class TIVOMetadata(generic.GenericMetadata):
             # vGuestStar, vDirector, vExecProducer, vProducer, vWriter, vHost, vChoreographer
             # partCount
             # partIndex
-            
         
         return data
+
+    # Override with empty methods for unsupported features.
+    def create_show_metadata(self, show_obj):
+        pass
+    
+    def create_show_fanart(self, show_obj):
+        pass
+
+    def create_show_poster(self, show_obj):
+        pass
+
+    def create_show_banner(self, show_obj):
+        pass
+
+    def create_season_all_fanart(self, show_obj):
+        pass
+
+    def create_season_all_poster(self, show_obj):
+        pass
+
+    def create_season_all_banner(self, show_obj):
+        pass
+
+    def create_season_fanart(self, show_obj):
+        pass
+
+    def create_season_thumbs(self, show_obj):
+        pass
+
+    def create_season_banner(self, show_obj):
+        pass
+
+    def create_episode_thumb(self, ep_obj):
+        pass
 
     def write_ep_file(self, ep_obj):
         """
@@ -314,6 +352,9 @@ class TIVOMetadata(generic.GenericMetadata):
             return False
         
         return True
+
+    def retrieveShowMetadata(self, dir):
+        return (None, None)
 
 # present a standard "interface"
 metadata_class = TIVOMetadata

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -36,62 +36,61 @@ class WDTVMetadata(generic.GenericMetadata):
     Metadata generation class for WDTV
 
     The following file structure is used:
-    
-    show_root/folder.jpg                                     (poster)
-    show_root/Season 01/folder.jpg                           (season thumb)
+    show_root/folder.jpg                                     (show poster)
+    show_root/Season 01/folder.jpg                           (season poster)
     show_root/Season 01/show - 1x01 - episode.metathumb      (episode thumb)
     show_root/Season 01/show - 1x01 - episode.xml            (episode metadata)
     """
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
-        
-        self._ep_nfo_extension = 'xml'
+                                         episode_thumbnails)
 
         self.name = 'WDTV'
+        self._ep_nfo_extension = 'xml'
+
+        self.show_poster_name = "folder.jpg"
 
         self.eg_show_metadata = "<i>not supported</i>"
-        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
-        self.eg_fanart = "<i>not supported</i>"
-        self.eg_poster = "folder.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
-        self.eg_season_thumbnails = "Season##\\folder.jpg"
-    
-    # all of the following are not supported, so do nothing
-    def create_show_metadata(self, show_obj):
-        pass
-    
-    def create_fanart(self, show_obj):
-        pass
-    
-    def get_episode_thumb_path(self, ep_obj):
-        """
-        Returns the path where the episode thumbnail should be stored. Defaults to
-        the same path as the episode file but with a .metathumb extension.
-        
-        ep_obj: a TVEpisode instance for which to create the thumbnail
-        """
-        if ek.ek(os.path.isfile, ep_obj.location):
-            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
-        else:
-            return None
+        self.eg_show_fanart = "<i>not supported</i>"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
 
-        return tbn_filename
-    
-    def get_season_thumb_path(self, show_obj, season):
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "Season##\\folder.jpg"
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.xml"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.metathumb"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
         """
         Season thumbs for WDTV go in Show Dir/Season X/folder.jpg
         
@@ -126,6 +125,20 @@ class WDTVMetadata(generic.GenericMetadata):
         logger.log(u"Using "+str(season_dir)+"/folder.jpg as season dir for season "+str(season), logger.DEBUG)
 
         return ek.ek(os.path.join, show_obj.location, season_dir, 'folder.jpg')
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .metathumb extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'metathumb')
+        else:
+            return None
+
+        return tbn_filename
 
     def _ep_data(self, ep_obj):
         """
@@ -224,6 +237,43 @@ class WDTVMetadata(generic.GenericMetadata):
             data = etree.ElementTree(rootNode)
 
         return data
+
+
+    # all of the following are not supported, so do nothing
+    def create_show_metadata(self, show_obj): 
+        pass
+        
+    def create_show_fanart(self, show_obj): 
+        pass
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+        
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj):  
+        pass
 
     def retrieveShowMetadata(self, dir):
         return (None, None)

--- a/sickbeard/metadata/xbmc.py
+++ b/sickbeard/metadata/xbmc.py
@@ -34,29 +34,49 @@ class XBMCMetadata(generic.GenericMetadata):
     
     def __init__(self,
                  show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
                  episode_metadata=False,
-                 poster=False,
-                 fanart=False,
-                 episode_thumbnails=False,
-                 season_thumbnails=False):
+                 episode_thumbnails=False):
 
         generic.GenericMetadata.__init__(self,
                                          show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
                                          episode_metadata,
-                                         poster,
-                                         fanart,
-                                         episode_thumbnails,
-                                         season_thumbnails)
+                                         episode_thumbnails)
         
         self.name = 'XBMC'
 
         self.eg_show_metadata = "tvshow.nfo"
+        self.eg_show_fanart = "fanart.jpg"
+        self.eg_show_poster = "poster.jpg"
+        self.eg_show_banner = "banner.jpg"
+
+        self.eg_season_all_fanart = "season-all-fanart.jpg"
+        self.eg_season_all_poster = "season-all-poster.jpg"
+        self.eg_season_all_banner = "season-all-banner.jpg"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "season##-poster.jpg"
+        self.eg_season_banners = "season##-banner.jpg"
+
         self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
-        self.eg_fanart = "fanart.jpg"
-        self.eg_poster = "folder.jpg"
-        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
-        self.eg_season_thumbnails = "season##.tbn"
-    
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>-thumb.jpg"
+
     def _show_data(self, show_obj):
         """
         Creates an elementTree XML structure for an XBMC-style tvshow.nfo and
@@ -313,6 +333,10 @@ class XBMCMetadata(generic.GenericMetadata):
         data = etree.ElementTree( rootNode )
 
         return data
+
+    # all of the following are not supported, so do nothing
+    def create_season_fanart(self, show_obj): 
+        pass
 
 # present a standard "interface" from the module
 metadata_class = XBMCMetadata

--- a/sickbeard/metadata/xbmcorig.py
+++ b/sickbeard/metadata/xbmcorig.py
@@ -1,0 +1,417 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import os
+
+import sickbeard
+
+import generic
+
+from sickbeard.common import XML_NSMAP
+from sickbeard import logger, exceptions, helpers
+from sickbeard import encodingKludge as ek
+from lib.tvdb_api import tvdb_api, tvdb_exceptions
+from sickbeard.exceptions import ex
+
+import xml.etree.cElementTree as etree
+
+class XBMCOrigMetadata(generic.GenericMetadata):
+    """
+    Metadata generation class for XBMCOrig
+
+    The following file structure is used:
+    Metadata generation class for WDTV
+
+    The following file structure is used:
+    show_root/tvshow.nfo                           (show metadata)
+    show_root/folder.jpg                           (show poster)
+    show_root/fanart.jpg                           (show fanart)
+    show_root/SeasonXX.tbn                         (season poster)
+    show_root/Season 01/show - 1x01 - episode.avi  (* example of existing ep of course)
+    show_root/Season 01/show - 1x01 - episode.tnb  (episode thumb)
+    show_root/Season 01/show - 1x01 - episode.nfo  (episode metadata)
+    """
+    def __init__(self,
+                 show_metadata=False,
+                 show_fanart=False,
+                 show_poster=False,
+                 show_banner=False,
+                 season_all_fanart=False,
+                 season_all_poster=False,
+                 season_all_banner=False,
+                 season_fanarts=False,
+                 season_posters=False,
+                 season_banners=False,
+                 episode_metadata=False,
+                 episode_thumbnails=False):
+
+        generic.GenericMetadata.__init__(self,
+                                         show_metadata,
+                                         show_fanart,
+                                         show_poster,
+                                         show_banner,
+                                         season_all_fanart,
+                                         season_all_poster,
+                                         season_all_banner,
+                                         season_fanarts,
+                                         season_posters,
+                                         season_banners,
+                                         episode_metadata,
+                                         episode_thumbnails)
+        
+        self.name = 'XBMCOrig'
+
+        self.show_poster_name = "folder.jpg"
+
+        self.eg_show_metadata = "tvshow.nfo"
+        self.eg_show_fanart = "fanart.jpg"
+        self.eg_show_poster = "folder.jpg"
+        self.eg_show_banner = "<i>not supported</i>"
+
+        self.eg_season_all_fanart = "<i>not supported</i>"
+        self.eg_season_all_poster = "<i>not supported</i>"
+        self.eg_season_all_banner = "<i>not supported</i>"
+        self.eg_season_fanarts = "<i>not supported</i>"
+        self.eg_season_posters = "season##.tbn"
+        self.eg_season_banners = "<i>not supported</i>"
+
+        self.eg_episode_metadata = "Season##\\<i>filename</i>.nfo"
+        self.eg_episode_thumbnails = "Season##\\<i>filename</i>.tbn"
+
+    def get_season_pb_path(self, show_obj, season, img_type):
+        """
+        Returns the full path to the file for a given season poster/banner.
+
+        show_obj: a TVShow instance for which to generate the path
+        season: a season number to be used for the path. Note that sesaon 0
+                means specials.
+        """
+        # Our specials thumbnail is, well, special
+        if season == 0:
+            season_pb_file_path = 'season-specials'
+        else:
+            season_pb_file_path = 'season' + str(season).zfill(2)
+        
+        season_pb_file_ext = '.tbn'
+        season_pb_file_path = season_pb_file_path + season_pb_file_ext        
+        return ek.ek(os.path.join, show_obj.location, season_pb_file_path)
+
+    def get_episode_thumb_path(self, ep_obj):
+        """
+        Returns the path where the episode thumbnail should be stored. Defaults to
+        the same path as the episode file but with a .metathumb extension.
+        
+        ep_obj: a TVEpisode instance for which to create the thumbnail
+        """
+        if ek.ek(os.path.isfile, ep_obj.location):
+            tbn_filename = helpers.replaceExtension(ep_obj.location, 'tbn')
+        else:
+            return None
+
+        return tbn_filename
+
+    def _show_data(self, show_obj):
+        """
+        Creates an elementTree XML structure for an XBMC-style tvshow.nfo and
+        returns the resulting data object.
+        
+        show_obj: a TVShow instance to create the NFO for
+        """
+
+        show_ID = show_obj.tvdbid
+
+        tvdb_lang = show_obj.lang
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+        if tvdb_lang and not tvdb_lang == 'en':
+            ltvdb_api_parms['language'] = tvdb_lang
+
+        t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+    
+        tv_node = etree.Element("tvshow")
+        for ns in XML_NSMAP.keys():
+            tv_node.set(ns, XML_NSMAP[ns])
+    
+        try:
+            myShow = t[int(show_ID)]
+        except tvdb_exceptions.tvdb_shownotfound:
+            logger.log(u"Unable to find show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+            raise
+    
+        except tvdb_exceptions.tvdb_error:
+            logger.log(u"TVDB is down, can't use its data to add this show", logger.ERROR)
+            raise
+    
+        # check for title and id
+        try:
+            if myShow["seriesname"] == None or myShow["seriesname"] == "" or myShow["id"] == None or myShow["id"] == "":
+                logger.log(u"Incomplete info for show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+    
+                return False
+        except tvdb_exceptions.tvdb_attributenotfound:
+            logger.log(u"Incomplete info for show with id " + str(show_ID) + " on tvdb, skipping it", logger.ERROR)
+    
+            return False
+    
+        title = etree.SubElement(tv_node, "title")
+        if myShow["seriesname"] != None:
+            title.text = myShow["seriesname"]
+    
+        rating = etree.SubElement(tv_node, "rating")
+        if myShow["rating"] != None:
+            rating.text = myShow["rating"]
+    
+        plot = etree.SubElement(tv_node, "plot")
+        if myShow["overview"] != None:
+            plot.text = myShow["overview"]
+    
+        episodeguide = etree.SubElement(tv_node, "episodeguide")
+        episodeguideurl = etree.SubElement( episodeguide, "url")
+        episodeguideurl2 = etree.SubElement(tv_node, "episodeguideurl")
+        if myShow["id"] != None:
+            showurl = sickbeard.TVDB_BASE_URL + '/series/' + myShow["id"] + '/all/en.zip'
+            episodeguideurl.text = showurl
+            episodeguideurl2.text = showurl
+    
+        mpaa = etree.SubElement(tv_node, "mpaa")
+        if myShow["contentrating"] != None:
+            mpaa.text = myShow["contentrating"]
+    
+        tvdbid = etree.SubElement(tv_node, "id")
+        if myShow["id"] != None:
+            tvdbid.text = myShow["id"]
+    
+        genre = etree.SubElement(tv_node, "genre")
+        if myShow["genre"] != None:
+            genre.text = " / ".join([x for x in myShow["genre"].split('|') if x])
+    
+        premiered = etree.SubElement(tv_node, "premiered")
+        if myShow["firstaired"] != None:
+            premiered.text = myShow["firstaired"]
+    
+        studio = etree.SubElement(tv_node, "studio")
+        if myShow["network"] != None:
+            studio.text = myShow["network"]
+    
+        for actor in myShow['_actors']:
+    
+            cur_actor = etree.SubElement(tv_node, "actor")
+    
+            cur_actor_name = etree.SubElement( cur_actor, "name")
+            cur_actor_name.text = actor['name']
+            cur_actor_role = etree.SubElement( cur_actor, "role")
+            cur_actor_role_text = actor['role']
+    
+            if cur_actor_role_text != None:
+                cur_actor_role.text = cur_actor_role_text
+    
+            cur_actor_thumb = etree.SubElement( cur_actor, "thumb")
+            cur_actor_thumb_text = actor['image']
+    
+            if cur_actor_thumb_text != None:
+                cur_actor_thumb.text = cur_actor_thumb_text
+    
+        # Make it purdy
+        helpers.indentXML(tv_node)
+
+        data = etree.ElementTree(tv_node)
+
+        return data
+    
+    def _ep_data(self, ep_obj):
+        """
+        Creates an elementTree XML structure for an XBMC-style episode.nfo and
+        returns the resulting data object.
+        
+        show_obj: a TVEpisode instance to create the NFO for
+        """
+
+        eps_to_write = [ep_obj] + ep_obj.relatedEps
+
+        tvdb_lang = ep_obj.show.lang
+        # There's gotta be a better way of doing this but we don't wanna
+        # change the language value elsewhere
+        ltvdb_api_parms = sickbeard.TVDB_API_PARMS.copy()
+
+        if tvdb_lang and not tvdb_lang == 'en':
+            ltvdb_api_parms['language'] = tvdb_lang
+
+        try:
+            t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
+            myShow = t[ep_obj.show.tvdbid]
+        except tvdb_exceptions.tvdb_shownotfound, e:
+            raise exceptions.ShowNotFoundException(e.message)
+        except tvdb_exceptions.tvdb_error, e:
+            logger.log(u"Unable to connect to TVDB while creating meta files - skipping - "+ex(e), logger.ERROR)
+            return
+
+        if len(eps_to_write) > 1:
+            rootNode = etree.Element( "xbmcmultiepisode" )
+        else:
+            rootNode = etree.Element( "episodedetails" )
+
+        # Set our namespace correctly
+        for ns in XML_NSMAP.keys():
+            rootNode.set(ns, XML_NSMAP[ns])
+
+        # write an NFO containing info for all matching episodes
+        for curEpToWrite in eps_to_write:
+
+            try:
+                myEp = myShow[curEpToWrite.season][curEpToWrite.episode]
+            except (tvdb_exceptions.tvdb_episodenotfound, tvdb_exceptions.tvdb_seasonnotfound):
+                logger.log(u"Unable to find episode " + str(curEpToWrite.season) + "x" + str(curEpToWrite.episode) + " on tvdb... has it been removed? Should I delete from db?")
+                return None
+
+            if not myEp["firstaired"]:
+                myEp["firstaired"] = str(datetime.date.fromordinal(1))
+
+            if not myEp["episodename"]:
+                logger.log(u"Not generating nfo because the ep has no title", logger.DEBUG)
+                return None
+
+            logger.log(u"Creating metadata for episode "+str(ep_obj.season)+"x"+str(ep_obj.episode), logger.DEBUG)
+
+            if len(eps_to_write) > 1:
+                episode = etree.SubElement( rootNode, "episodedetails" )
+            else:
+                episode = rootNode
+
+            title = etree.SubElement( episode, "title" )
+            if curEpToWrite.name != None:
+                title.text = curEpToWrite.name
+
+            season = etree.SubElement( episode, "season" )
+            season.text = str(curEpToWrite.season)
+
+            episodenum = etree.SubElement( episode, "episode" )
+            episodenum.text = str(curEpToWrite.episode)
+
+            aired = etree.SubElement( episode, "aired" )
+            if curEpToWrite.airdate != datetime.date.fromordinal(1):
+                aired.text = str(curEpToWrite.airdate)
+            else:
+                aired.text = ''
+
+            plot = etree.SubElement( episode, "plot" )
+            if curEpToWrite.description != None:
+                plot.text = curEpToWrite.description
+
+            displayseason = etree.SubElement( episode, "displayseason" )
+            if myEp.has_key('airsbefore_season'):
+                displayseason_text = myEp['airsbefore_season']
+                if displayseason_text != None:
+                    displayseason.text = displayseason_text
+
+            displayepisode = etree.SubElement( episode, "displayepisode" )
+            if myEp.has_key('airsbefore_episode'):
+                displayepisode_text = myEp['airsbefore_episode']
+                if displayepisode_text != None:
+                    displayepisode.text = displayepisode_text
+
+            thumb = etree.SubElement( episode, "thumb" )
+            thumb_text = myEp['filename']
+            if thumb_text != None:
+                thumb.text = thumb_text
+
+            watched = etree.SubElement( episode, "watched" )
+            watched.text = 'false'
+
+            credits = etree.SubElement( episode, "credits" )
+            credits_text = myEp['writer']
+            if credits_text != None:
+                credits.text = credits_text
+
+            director = etree.SubElement( episode, "director" )
+            director_text = myEp['director']
+            if director_text != None:
+                director.text = director_text
+
+            rating = etree.SubElement( episode, "rating" )
+            rating_text = myEp['rating']
+            if rating_text != None:
+                rating.text = rating_text
+
+            gueststar_text = myEp['gueststars']
+            if gueststar_text != None:
+                for actor in gueststar_text.split('|'):
+                    cur_actor = etree.SubElement( episode, "actor" )
+                    cur_actor_name = etree.SubElement(
+                        cur_actor, "name"
+                        )
+                    cur_actor_name.text = actor
+
+            for actor in myShow['_actors']:
+                cur_actor = etree.SubElement( episode, "actor" )
+
+                cur_actor_name = etree.SubElement( cur_actor, "name" )
+                cur_actor_name.text = actor['name']
+
+                cur_actor_role = etree.SubElement( cur_actor, "role" )
+                cur_actor_role_text = actor['role']
+                if cur_actor_role_text != None:
+                    cur_actor_role.text = cur_actor_role_text
+
+                cur_actor_thumb = etree.SubElement( cur_actor, "thumb" )
+                cur_actor_thumb_text = actor['image']
+                if cur_actor_thumb_text != None:
+                    cur_actor_thumb.text = cur_actor_thumb_text
+
+        #
+        # Make it purdy
+        helpers.indentXML( rootNode )
+
+        data = etree.ElementTree( rootNode )
+
+        return data
+
+    def create_show_poster(self, show_obj):
+        if self.show_poster and show_obj and not self._has_show_poster(show_obj):
+            logger.log("Metadata provider "+self.name+" creating show poster for "+show_obj.name, logger.DEBUG)
+            poster_path = self.get_show_poster_path(show_obj)
+            if sickbeard.USE_BANNER:
+                img_type = 'banner'
+            else:
+                img_type = 'poster'
+            return self.save_show_fpb(show_obj, img_type, poster_path)
+        return False
+        
+    # all of the following are not supported, so do nothing
+    def create_show_banner(self, show_obj): 
+        pass
+        
+    def create_season_all_fanart(self, show_obj): 
+        pass
+        
+    def create_season_all_poster(self, show_obj): 
+        pass
+        
+    def create_season_all_banner(self, show_obj): 
+        pass
+        
+    def create_season_fanart(self, show_obj): 
+        pass
+
+    def create_season_banner(self, show_obj):  
+        pass
+        
+# present a standard "interface" from the module
+metadata_class = XBMCOrigMetadata

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -396,15 +396,23 @@ class TVShow(object):
 
     def getImages(self, fanart=None, poster=None):
 
-        poster_result = fanart_result = season_thumb_result = False
+        show_fanart_result = show_poster_result = show_banner_result = season_all_fanart_result = season_all_poster_result = season_all_banner_result = season_fanarts_result = season_posters_result = season_banners_result = False
 
         for cur_provider in sickbeard.metadata_provider_dict.values():
-            logger.log("Running season folders for "+cur_provider.name, logger.DEBUG)
-            poster_result = cur_provider.create_poster(self) or poster_result
-            fanart_result = cur_provider.create_fanart(self) or fanart_result
-            season_thumb_result = cur_provider.create_season_thumbs(self) or season_thumb_result
+            logger.log("Getting Show images for "+cur_provider.name, logger.DEBUG)
+            show_fanart_result = cur_provider.create_show_fanart(self) or show_fanart_result
+            show_poster_result = cur_provider.create_show_poster(self) or show_poster_result
+            show_banner_result = cur_provider.create_show_banner(self) or show_banner_result
+            logger.log("Getting season all images for "+cur_provider.name, logger.DEBUG)
+            season_all_fanart_result = cur_provider.create_season_all_fanart(self) or season_all_fanart_result
+            season_all_poster_result = cur_provider.create_season_all_poster(self) or season_all_poster_result
+            season_all_banner_result = cur_provider.create_season_all_banner(self) or season_all_banner_result
+            logger.log("Getting season images for "+cur_provider.name, logger.DEBUG)
+            season_fanarts_result = cur_provider.create_season_fanart(self) or season_fanarts_result
+            season_posters_result = cur_provider.create_season_poster(self) or season_posters_result
+            season_banners_result = cur_provider.create_season_banner(self) or season_banners_result
 
-        return poster_result or fanart_result or season_thumb_result
+        return show_fanart_result or show_poster_result or show_banner_result or season_all_fanart_result or season_all_poster_result or season_all_banner_result or season_fanarts_result or season_posters_result or season_banners_result
 
     def loadLatestFromTVRage(self):
 
@@ -917,11 +925,9 @@ class TVShow(object):
                 maxBestQuality = None
 
             epStatus, curQuality = Quality.splitCompositeStatus(epStatus)
-    
-            if epStatus in (SNATCHED, SNATCHED_PROPER):
-                return Overview.SNATCHED
+
             # if they don't want re-downloads then we call it good if they have anything
-            elif maxBestQuality == None:
+            if maxBestQuality == None:
                 return Overview.GOOD
             # if they have one but it's not the best they want then mark it as qual
             elif curQuality < maxBestQuality:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -78,7 +78,7 @@ class PageTemplate (Template):
 
         if sickbeard.NZBS and sickbeard.NZBS_UID and sickbeard.NZBS_HASH:
             logger.log(u"NZBs.org has been replaced, please check the config to configure the new provider!", logger.ERROR)
-            ui.notifications.error("NZBs.org Config Update", "NZBs.org has a new site. Please <a href=\""+sickbeard.WEB_ROOT+"/config/providers\">update your config</a> with the api key from <a href=\"http://nzbs.org/login\">http://nzbs.org</a> and then disable the old NZBs.org provider.")
+            ui.notifications.error("NZBs.org Config Update", "NZBs.org has a new site. Please <a href=\""+sickbeard.WEB_ROOT+"/config/providers\">update your config</a> with the api key from <a href=\"http://beta.nzbs.org/login\">http://beta.nzbs.org</a> and then disable the old NZBs.org provider.")
 
         if "X-Forwarded-Host" in cherrypy.request.headers:
             self.sbHost = cherrypy.request.headers['X-Forwarded-Host']
@@ -215,19 +215,19 @@ class Manage:
         status_list = [int(whichStatus)]
         if status_list[0] == SNATCHED:
             status_list = Quality.SNATCHED + Quality.SNATCHED_PROPER
-
+        
         cur_show_results = myDB.select("SELECT season, episode, name FROM tv_episodes WHERE showid = ? AND season != 0 AND status IN ("+','.join(['?']*len(status_list))+")", [int(tvdb_id)] + status_list)
-
+        
         result = {}
         for cur_result in cur_show_results:
             cur_season = int(cur_result["season"])
             cur_episode = int(cur_result["episode"])
-
+            
             if cur_season not in result:
                 result[cur_season] = {}
-
+            
             result[cur_season][cur_episode] = cur_result["name"]
-
+        
         return json.dumps(result)
 
     @cherrypy.expose
@@ -240,7 +240,7 @@ class Manage:
                 status_list = Quality.SNATCHED + Quality.SNATCHED_PROPER
         else:
             status_list = []
-
+        
         t = PageTemplate(file="manage_episodeStatuses.tmpl")
         t.submenu = ManageMenu
         t.whichStatus = whichStatus
@@ -248,7 +248,7 @@ class Manage:
         # if we have no status then this is as far as we need to go
         if not status_list:
             return _munge(t)
-
+        
         myDB = db.DBConnection()
         status_results = myDB.select("SELECT show_name, tv_shows.tvdb_id as tvdb_id FROM tv_episodes, tv_shows WHERE tv_episodes.status IN ("+','.join(['?']*len(status_list))+") AND season != 0 AND tv_episodes.showid = tv_shows.tvdb_id ORDER BY show_name", status_list)
 
@@ -261,11 +261,11 @@ class Manage:
                 ep_counts[cur_tvdb_id] = 1
             else:
                 ep_counts[cur_tvdb_id] += 1
-
+        
             show_names[cur_tvdb_id] = cur_status_result["show_name"]
             if cur_tvdb_id not in sorted_show_ids:
                 sorted_show_ids.append(cur_tvdb_id)
-
+        
         t.show_names = show_names
         t.ep_counts = ep_counts
         t.sorted_show_ids = sorted_show_ids
@@ -273,26 +273,26 @@ class Manage:
 
     @cherrypy.expose
     def changeEpisodeStatuses(self, oldStatus, newStatus, *args, **kwargs):
-
+        
         status_list = [int(oldStatus)]
         if status_list[0] == SNATCHED:
             status_list = Quality.SNATCHED + Quality.SNATCHED_PROPER
 
         to_change = {}
-
+        
         # make a list of all shows and their associated args
         for arg in kwargs:
             tvdb_id, what = arg.split('-')
-
+            
             # we don't care about unchecked checkboxes
             if kwargs[arg] != 'on':
                 continue
-
+            
             if tvdb_id not in to_change:
                 to_change[tvdb_id] = []
-
+            
             to_change[tvdb_id].append(what)
-
+        
         myDB = db.DBConnection()
 
         for cur_tvdb_id in to_change:
@@ -304,19 +304,19 @@ class Manage:
                 to_change[cur_tvdb_id] = all_eps
 
             Home().setStatus(cur_tvdb_id, '|'.join(to_change[cur_tvdb_id]), newStatus, direct=True)
-
+            
         redirect('/manage/episodeStatuses')
 
     @cherrypy.expose
     def backlogShow(self, tvdb_id):
-
+        
         show_obj = helpers.findCertainShow(sickbeard.showList, int(tvdb_id))
-
+        
         if show_obj:
             sickbeard.backlogSearchScheduler.action.searchBacklog([show_obj]) #@UndefinedVariable
-
+        
         redirect("/manage/backlogOverview")
-
+        
     @cherrypy.expose
     def backlogOverview(self):
 
@@ -338,7 +338,6 @@ class Manage:
             epCounts[Overview.QUAL] = 0
             epCounts[Overview.GOOD] = 0
             epCounts[Overview.UNAIRED] = 0
-            epCounts[Overview.SNATCHED] = 0
 
             sqlResults = myDB.select("SELECT * FROM tv_episodes WHERE showid = ? ORDER BY season DESC, episode DESC", [curShow.tvdbid])
 
@@ -387,11 +386,11 @@ class Manage:
         root_dir_list = []
 
         for curShow in showList:
-
+            
             cur_root_dir = ek.ek(os.path.dirname, curShow._location)
             if cur_root_dir not in root_dir_list:
-                root_dir_list.append(cur_root_dir)
-
+                root_dir_list.append(cur_root_dir) 
+            
             # if we know they're not all the same then no point even bothering
             if paused_all_same:
                 # if we had a value already and this value is different then they're not all the same
@@ -447,7 +446,7 @@ class Manage:
                 logger.log(u"For show "+showObj.name+" changing dir from "+showObj._location+" to "+new_show_dir)
             else:
                 new_show_dir = showObj._location
-
+            
             if paused == 'keep':
                 new_paused = showObj.paused
             else:
@@ -462,7 +461,7 @@ class Manage:
 
             if quality_preset == 'keep':
                 anyQualities, bestQualities = Quality.splitQuality(showObj.quality)
-
+            
             curErrors += Home().editShow(curShow, new_show_dir, anyQualities, bestQualities, new_flatten_folders, new_paused, directCall=True)
 
             if curErrors:
@@ -632,7 +631,7 @@ class ConfigGeneral:
     @cherrypy.expose
     def saveRootDirs(self, rootDirString=None):
         sickbeard.ROOT_DIRS = rootDirString
-
+    
     @cherrypy.expose
     def saveAddShowDefaults(self, defaultFlattenFolders, defaultStatus, anyQualities, bestQualities):
 
@@ -647,7 +646,7 @@ class ConfigGeneral:
             bestQualities = []
 
         newQuality = Quality.combineQualities(map(int, anyQualities), map(int, bestQualities))
-
+        
         sickbeard.STATUS_DEFAULT = int(defaultStatus)
         sickbeard.QUALITY_DEFAULT = int(newQuality)
 
@@ -667,14 +666,14 @@ class ConfigGeneral:
             from hashlib import md5
         except ImportError:
             from md5 import md5
-
+        
         # Create some values to seed md5
         t = str(time.time())
         r = str(random.random())
-
+        
         # Create the md5 instance and give it the current time
         m = md5(t)
-
+        
         # Update the md5 instance with the random variable
         m.update(r)
 
@@ -727,14 +726,14 @@ class ConfigGeneral:
 
         sickbeard.USE_API = use_api
         sickbeard.API_KEY = api_key
-
+        
         if enable_https == "on":
             enable_https = 1
         else:
             enable_https = 0
-
+        
         sickbeard.ENABLE_HTTPS = enable_https
-
+        
         if not config.change_HTTPS_CERT(https_cert):
             results += ["Unable to create directory " + os.path.normpath(https_cert) + ", https cert dir not changed."]
 
@@ -847,7 +846,7 @@ class ConfigPostProcessing:
 
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
-                    xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
+                    xbmc_data=None,  xbmcorig_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
                     use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
@@ -893,12 +892,13 @@ class ConfigPostProcessing:
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd
 
         sickbeard.metadata_provider_dict['XBMC'].set_config(xbmc_data)
+        sickbeard.metadata_provider_dict['XBMCOrig'].set_config(xbmcorig_data)
         sickbeard.metadata_provider_dict['MediaBrowser'].set_config(mediabrowser_data)
         sickbeard.metadata_provider_dict['Synology'].set_config(synology_data)
         sickbeard.metadata_provider_dict['Sony PS3'].set_config(sony_ps3_data)
         sickbeard.metadata_provider_dict['WDTV'].set_config(wdtv_data)
         sickbeard.metadata_provider_dict['TIVO'].set_config(tivo_data)
-
+        
         if self.isNamingValid(naming_pattern, naming_multi_ep) != "invalid":
             sickbeard.NAMING_PATTERN = naming_pattern
             sickbeard.NAMING_MULTI_EP = int(naming_multi_ep)
@@ -933,16 +933,16 @@ class ConfigPostProcessing:
 
         result = naming.test_name(pattern, multi, abd)
 
-        result = ek.ek(os.path.join, result['dir'], result['name'])
+        result = ek.ek(os.path.join, result['dir'], result['name']) 
 
         return result
-
+    
     @cherrypy.expose
     def isNamingValid(self, pattern=None, multi=None, abd=False):
         if pattern == None:
             return "invalid"
-
-        # air by date shows just need one check, we don't need to worry about season folders
+        
+        # air by date shows just need one check, we don't need to worry about season folders 
         if abd:
             is_valid = naming.check_valid_abd_naming(pattern)
             require_season_folders = False
@@ -950,7 +950,7 @@ class ConfigPostProcessing:
         else:
             # check validity of single and multi ep cases for the whole path
             is_valid = naming.check_valid_naming(pattern, multi)
-
+    
             # check validity of single and multi ep cases for only the file name
             require_season_folders = naming.check_force_season_folders(pattern, multi)
 
@@ -961,7 +961,7 @@ class ConfigPostProcessing:
         else:
             return "invalid"
 
-
+        
 class ConfigProviders:
 
     @cherrypy.expose
@@ -1031,11 +1031,9 @@ class ConfigProviders:
 
     @cherrypy.expose
     def saveProviders(self, nzbmatrix_username=None, nzbmatrix_apikey=None,
-                      nzbs_r_us_uid=None, nzbs_r_us_hash=None, newznab_string='',
-                      omgwtfnzbs_uid=None, omgwtfnzbs_key=None,
+                      nzbs_r_us_uid=None, nzbs_r_us_hash=None, newznab_string=None,
                       tvtorrents_digest=None, tvtorrents_hash=None,
-                      torrentleech_key=None,
-                      btn_api_key=None,
+ 					  btn_api_key=None,
                       newzbin_username=None, newzbin_password=None,
                       provider_order=None):
 
@@ -1049,32 +1047,31 @@ class ConfigProviders:
         finishedNames = []
 
         # add all the newznab info we got into our list
-        if newznab_string:
-            for curNewznabProviderStr in newznab_string.split('!!!'):
-    
-                if not curNewznabProviderStr:
-                    continue
-    
-                curName, curURL, curKey = curNewznabProviderStr.split('|')
-    
-                newProvider = newznab.NewznabProvider(curName, curURL, curKey)
-    
-                curID = newProvider.getID()
-    
-                # if it already exists then update it
-                if curID in newznabProviderDict:
-                    newznabProviderDict[curID].name = curName
-                    newznabProviderDict[curID].url = curURL
-                    newznabProviderDict[curID].key = curKey
-                else:
-                    sickbeard.newznabProviderList.append(newProvider)
-    
-                finishedNames.append(curID)
-    
-            # delete anything that is missing
-            for curProvider in sickbeard.newznabProviderList:
-                if curProvider.getID() not in finishedNames:
-                    sickbeard.newznabProviderList.remove(curProvider)
+        for curNewznabProviderStr in newznab_string.split('!!!'):
+
+            if not curNewznabProviderStr:
+                continue
+
+            curName, curURL, curKey = curNewznabProviderStr.split('|')
+
+            newProvider = newznab.NewznabProvider(curName, curURL, curKey)
+
+            curID = newProvider.getID()
+
+            # if it already exists then update it
+            if curID in newznabProviderDict:
+                newznabProviderDict[curID].name = curName
+                newznabProviderDict[curID].url = curURL
+                newznabProviderDict[curID].key = curKey
+            else:
+                sickbeard.newznabProviderList.append(newProvider)
+
+            finishedNames.append(curID)
+
+        # delete anything that is missing
+        for curProvider in sickbeard.newznabProviderList:
+            if curProvider.getID() not in finishedNames:
+                sickbeard.newznabProviderList.remove(curProvider)
 
         # do the enable/disable
         for curProviderStr in provider_str_list:
@@ -1095,35 +1092,24 @@ class ConfigProviders:
                 sickbeard.BINREQ = curEnabled
             elif curProvider == 'womble_s_index':
                 sickbeard.WOMBLE = curEnabled
-            elif curProvider == 'nzbx':
-                sickbeard.NZBX = curEnabled
-            elif curProvider == 'omgwtfnzbs':
-                sickbeard.OMGWTFNZBS = curEnabled
             elif curProvider == 'ezrss':
                 sickbeard.EZRSS = curEnabled
             elif curProvider == 'tvtorrents':
                 sickbeard.TVTORRENTS = curEnabled
-            elif curProvider == 'torrentleech':
-                sickbeard.TORRENTLEECH = curEnabled
             elif curProvider == 'btn':
                 sickbeard.BTN = curEnabled
             elif curProvider in newznabProviderDict:
                 newznabProviderDict[curProvider].enabled = bool(curEnabled)
             else:
-                logger.log(u"don't know what " + curProvider + " is, skipping")
+                logger.log(u"don't know what "+curProvider+" is, skipping")
 
         sickbeard.TVTORRENTS_DIGEST = tvtorrents_digest.strip()
         sickbeard.TVTORRENTS_HASH = tvtorrents_hash.strip()
-
-        sickbeard.TORRENTLEECH_KEY = torrentleech_key.strip()
 
         sickbeard.BTN_API_KEY = btn_api_key.strip()
 
         sickbeard.NZBSRUS_UID = nzbs_r_us_uid.strip()
         sickbeard.NZBSRUS_HASH = nzbs_r_us_hash.strip()
-
-        sickbeard.OMGWTFNZBS_UID = omgwtfnzbs_uid.strip()
-        sickbeard.OMGWTFNZBS_KEY = omgwtfnzbs_key.strip()
 
         sickbeard.PROVIDER_ORDER = provider_list
 
@@ -1139,7 +1125,6 @@ class ConfigProviders:
 
         redirect("/config/providers/")
 
-
 class ConfigNotifications:
 
     @cherrypy.expose
@@ -1149,21 +1134,20 @@ class ConfigNotifications:
         return _munge(t)
 
     @cherrypy.expose
-    def saveNotifications(self, use_xbmc=None, xbmc_notify_onsnatch=None, xbmc_notify_ondownload=None, xbmc_update_onlyfirst=None,
+    def saveNotifications(self, use_xbmc=None, xbmc_notify_onsnatch=None, xbmc_notify_ondownload=None,
                           xbmc_update_library=None, xbmc_update_full=None, xbmc_host=None, xbmc_username=None, xbmc_password=None,
                           use_plex=None, plex_notify_onsnatch=None, plex_notify_ondownload=None, plex_update_library=None,
                           plex_server_host=None, plex_host=None, plex_username=None, plex_password=None,
-                          use_growl=None, growl_notify_onsnatch=None, growl_notify_ondownload=None, growl_host=None, growl_password=None,
-                          use_prowl=None, prowl_notify_onsnatch=None, prowl_notify_ondownload=None, prowl_api=None, prowl_priority=0,
-                          use_twitter=None, twitter_notify_onsnatch=None, twitter_notify_ondownload=None,
+                          use_growl=None, growl_notify_onsnatch=None, growl_notify_ondownload=None, growl_host=None, growl_password=None, 
+                          use_prowl=None, prowl_notify_onsnatch=None, prowl_notify_ondownload=None, prowl_api=None, prowl_priority=0, 
+                          use_twitter=None, twitter_notify_onsnatch=None, twitter_notify_ondownload=None, 
                           use_notifo=None, notifo_notify_onsnatch=None, notifo_notify_ondownload=None, notifo_username=None, notifo_apisecret=None,
                           use_boxcar=None, boxcar_notify_onsnatch=None, boxcar_notify_ondownload=None, boxcar_username=None,
                           use_pushover=None, pushover_notify_onsnatch=None, pushover_notify_ondownload=None, pushover_userkey=None,
                           use_libnotify=None, libnotify_notify_onsnatch=None, libnotify_notify_ondownload=None,
                           use_nmj=None, nmj_host=None, nmj_database=None, nmj_mount=None, use_synoindex=None,
-                          use_nmjv2=None, nmjv2_host=None, nmjv2_dbloc=None, nmjv2_database=None,
                           use_trakt=None, trakt_username=None, trakt_password=None, trakt_api=None,
-                          use_pytivo=None, pytivo_notify_onsnatch=None, pytivo_notify_ondownload=None, pytivo_update_library=None,
+                          use_pytivo=None, pytivo_notify_onsnatch=None, pytivo_notify_ondownload=None, pytivo_update_library=None, 
                           pytivo_host=None, pytivo_share_name=None, pytivo_tivo_name=None,
                           use_nma=None, nma_notify_onsnatch=None, nma_notify_ondownload=None, nma_api=None, nma_priority=0 ):
 
@@ -1188,11 +1172,6 @@ class ConfigNotifications:
             xbmc_update_full = 1
         else:
             xbmc_update_full = 0
-
-        if xbmc_update_onlyfirst == "on":
-            xbmc_update_onlyfirst = 1
-        else:
-            xbmc_update_onlyfirst = 0
 
         if use_xbmc == "on":
             use_xbmc = 1
@@ -1233,7 +1212,7 @@ class ConfigNotifications:
             use_growl = 1
         else:
             use_growl = 0
-
+            
         if prowl_notify_onsnatch == "on":
             prowl_notify_onsnatch = 1
         else:
@@ -1314,11 +1293,6 @@ class ConfigNotifications:
         else:
             use_synoindex = 0
 
-        if use_nmjv2 == "on":
-            use_nmjv2 = 1
-        else:
-            use_nmjv2 = 0
-
         if use_trakt == "on":
             use_trakt = 1
         else:
@@ -1328,7 +1302,7 @@ class ConfigNotifications:
             use_pytivo = 1
         else:
             use_pytivo = 0
-
+            
         if pytivo_notify_onsnatch == "on":
             pytivo_notify_onsnatch = 1
         else:
@@ -1364,7 +1338,6 @@ class ConfigNotifications:
         sickbeard.XBMC_NOTIFY_ONDOWNLOAD = xbmc_notify_ondownload
         sickbeard.XBMC_UPDATE_LIBRARY = xbmc_update_library
         sickbeard.XBMC_UPDATE_FULL = xbmc_update_full
-        sickbeard.XBMC_UPDATE_ONLYFIRST = xbmc_update_onlyfirst
         sickbeard.XBMC_HOST = xbmc_host
         sickbeard.XBMC_USERNAME = xbmc_username
         sickbeard.XBMC_PASSWORD = xbmc_password
@@ -1421,11 +1394,6 @@ class ConfigNotifications:
 
         sickbeard.USE_SYNOINDEX = use_synoindex
 
-        sickbeard.USE_NMJv2 = use_nmjv2
-        sickbeard.NMJv2_HOST = nmjv2_host
-        sickbeard.NMJv2_DATABASE = nmjv2_database
-        sickbeard.NMJv2_DBLOC = nmjv2_dbloc
-
         sickbeard.USE_TRAKT = use_trakt
         sickbeard.TRAKT_USERNAME = trakt_username
         sickbeard.TRAKT_PASSWORD = trakt_password
@@ -1433,7 +1401,7 @@ class ConfigNotifications:
 
         sickbeard.USE_PYTIVO = use_pytivo
         sickbeard.PYTIVO_NOTIFY_ONSNATCH = pytivo_notify_onsnatch == "off"
-        sickbeard.PYTIVO_NOTIFY_ONDOWNLOAD = pytivo_notify_ondownload == "off"
+        sickbeard.PYTIVO_NOTIFY_ONDOWNLOAD = pytivo_notify_ondownload ==  "off"
         sickbeard.PYTIVO_UPDATE_LIBRARY = pytivo_update_library
         sickbeard.PYTIVO_HOST = pytivo_host
         sickbeard.PYTIVO_SHARE_NAME = pytivo_share_name
@@ -1444,7 +1412,7 @@ class ConfigNotifications:
         sickbeard.NMA_NOTIFY_ONDOWNLOAD = nma_notify_ondownload
         sickbeard.NMA_API = nma_api
         sickbeard.NMA_PRIORITY = nma_priority
-
+        
         sickbeard.save_config()
 
         if len(results) > 0:
@@ -1470,7 +1438,7 @@ class Config:
     general = ConfigGeneral()
 
     search = ConfigSearch()
-
+    
     postProcessing = ConfigPostProcessing()
 
     providers = ConfigProviders()
@@ -1603,16 +1571,16 @@ class NewHomeAddShows:
     def massAddTable(self, rootDir=None):
         t = PageTemplate(file="home_massAddTable.tmpl")
         t.submenu = HomeMenu()
-
+        
         myDB = db.DBConnection()
 
         if not rootDir:
-            return "No folders selected."
+            return "No folders selected." 
         elif type(rootDir) != list:
             root_dirs = [rootDir]
         else:
             root_dirs = rootDir
-
+        
         root_dirs = [urllib.unquote_plus(x) for x in root_dirs]
 
         default_index = int(sickbeard.ROOT_DIRS.split('|')[0])
@@ -1621,9 +1589,9 @@ class NewHomeAddShows:
             if tmp in root_dirs:
                 root_dirs.remove(tmp)
                 root_dirs = [tmp]+root_dirs
-
+        
         dir_list = []
-
+        
         for root_dir in root_dirs:
             try:
                 file_list = ek.ek(os.listdir, root_dir)
@@ -1635,36 +1603,36 @@ class NewHomeAddShows:
                 cur_path = ek.ek(os.path.normpath, ek.ek(os.path.join, root_dir, cur_file))
                 if not ek.ek(os.path.isdir, cur_path):
                     continue
-
+                
                 cur_dir = {
                            'dir': cur_path,
                            'display_dir': '<b>'+ek.ek(os.path.dirname, cur_path)+os.sep+'</b>'+ek.ek(os.path.basename, cur_path),
                            }
-
+                
                 # see if the folder is in XBMC already
                 dirResults = myDB.select("SELECT * FROM tv_shows WHERE location = ?", [cur_path])
-
+                
                 if dirResults:
                     cur_dir['added_already'] = True
                 else:
                     cur_dir['added_already'] = False
-
+                
                 dir_list.append(cur_dir)
-
+                
                 tvdb_id = ''
                 show_name = ''
                 for cur_provider in sickbeard.metadata_provider_dict.values():
                     (tvdb_id, show_name) = cur_provider.retrieveShowMetadata(cur_path)
                     if tvdb_id and show_name:
                         break
-
+                
                 cur_dir['existing_info'] = (tvdb_id, show_name)
-
+                
                 if tvdb_id and helpers.findCertainShow(sickbeard.showList, tvdb_id):
-                    cur_dir['added_already'] = True
+                    cur_dir['added_already'] = True 
 
         t.dirList = dir_list
-
+        
         return _munge(t)
 
     @cherrypy.expose
@@ -1675,38 +1643,38 @@ class NewHomeAddShows:
         """
         t = PageTemplate(file="home_newShow.tmpl")
         t.submenu = HomeMenu()
-
+        
         show_dir, tvdb_id, show_name = self.split_extra_show(show_to_add)
-
+        
         if tvdb_id and show_name:
             use_provided_info = True
         else:
             use_provided_info = False
-
+        
         # tell the template whether we're giving it show name & TVDB ID
         t.use_provided_info = use_provided_info
-
-        # use the given show_dir for the tvdb search if available
+        
+        # use the given show_dir for the tvdb search if available 
         if not show_dir:
             t.default_show_name = ''
         elif not show_name:
             t.default_show_name = ek.ek(os.path.basename, ek.ek(os.path.normpath, show_dir)).replace('.',' ')
         else:
             t.default_show_name = show_name
-
+        
         # carry a list of other dirs if given
         if not other_shows:
             other_shows = []
         elif type(other_shows) != list:
             other_shows = [other_shows]
-
+        
         if use_provided_info:
             t.provided_tvdb_id = tvdb_id
             t.provided_tvdb_name = show_name
-
+            
         t.provided_show_dir = show_dir
         t.other_shows = other_shows
-
+        
         return _munge(t)
 
     @cherrypy.expose
@@ -1717,52 +1685,52 @@ class NewHomeAddShows:
         Receive tvdb id, dir, and other options and create a show from them. If extra show dirs are
         provided then it forwards back to newShow, if not it goes to /home.
         """
-
+        
         # grab our list of other dirs if given
         if not other_shows:
             other_shows = []
         elif type(other_shows) != list:
             other_shows = [other_shows]
-
-        def finishAddShow():
+            
+        def finishAddShow(): 
             # if there are no extra shows then go home
             if not other_shows:
                 redirect('/home')
-
+            
             # peel off the next one
             next_show_dir = other_shows[0]
             rest_of_show_dirs = other_shows[1:]
-
+            
             # go to add the next show
             return self.newShow(next_show_dir, rest_of_show_dirs)
-
+        
         # if we're skipping then behave accordingly
         if skipShow:
             return finishAddShow()
-
+        
         # sanity check on our inputs
         if (not rootDir and not fullShowPath) or not whichSeries:
             return "Missing params, no tvdb id or folder:"+repr(whichSeries)+" and "+repr(rootDir)+"/"+repr(fullShowPath)
-
+        
         # figure out what show we're adding and where
         series_pieces = whichSeries.partition('|')
         if len(series_pieces) < 3:
             return "Error with show selection."
-
+        
         tvdb_id = int(series_pieces[0])
         show_name = series_pieces[2]
-
+        
         # use the whole path if it's given, or else append the show name to the root dir to get the full show path
         if fullShowPath:
             show_dir = ek.ek(os.path.normpath, fullShowPath)
         else:
             show_dir = ek.ek(os.path.join, rootDir, helpers.sanitizeFileName(show_name))
-
+        
         # blanket policy - if the dir exists you should have used "add existing show" numbnuts
         if ek.ek(os.path.isdir, show_dir) and not fullShowPath:
             ui.notifications.error("Unable to add show", "Folder "+show_dir+" exists already")
             redirect('/home/addShows/existingShows')
-
+        
         # don't create show dir if config says not to
         if sickbeard.ADD_SHOWS_WO_DIR:
             logger.log(u"Skipping initial creation of "+show_dir+" due to config.ini setting")
@@ -1780,7 +1748,7 @@ class NewHomeAddShows:
             flatten_folders = 1
         else:
             flatten_folders = 0
-
+        
         if not anyQualities:
             anyQualities = []
         if not bestQualities:
@@ -1790,22 +1758,22 @@ class NewHomeAddShows:
         if type(bestQualities) != list:
             bestQualities = [bestQualities]
         newQuality = Quality.combineQualities(map(int, anyQualities), map(int, bestQualities))
-
+        
         # add the show
         sickbeard.showQueueScheduler.action.addShow(tvdb_id, show_dir, int(defaultStatus), newQuality, flatten_folders, tvdbLang) #@UndefinedVariable
         ui.notifications.message('Show added', 'Adding the specified show into '+show_dir)
 
         return finishAddShow()
-
+        
 
     @cherrypy.expose
     def existingShows(self):
         """
-        Prints out the page to add existing shows from a root dir
+        Prints out the page to add existing shows from a root dir 
         """
         t = PageTemplate(file="home_addExistingShow.tmpl")
         t.submenu = HomeMenu()
-
+        
         return _munge(t)
 
     def split_extra_show(self, extra_show):
@@ -1817,7 +1785,7 @@ class NewHomeAddShows:
         show_dir = split_vals[0]
         tvdb_id = split_vals[1]
         show_name = '|'.join(split_vals[2:])
-
+        
         return (show_dir, tvdb_id, show_name)
 
     @cherrypy.expose
@@ -1832,14 +1800,14 @@ class NewHomeAddShows:
             shows_to_add = []
         elif type(shows_to_add) != list:
             shows_to_add = [shows_to_add]
-
+        
         shows_to_add = [urllib.unquote_plus(x) for x in shows_to_add]
-
+        
         if promptForSettings == "on":
             promptForSettings = 1
         else:
             promptForSettings = 0
-
+        
         tvdb_id_given = []
         dirs_only = []
         # separate all the ones with TVDB IDs
@@ -1856,7 +1824,7 @@ class NewHomeAddShows:
         # if they want me to prompt for settings then I will just carry on to the newShow page
         if promptForSettings and shows_to_add:
             return self.newShow(shows_to_add[0], shows_to_add[1:])
-
+        
         # if they don't want me to prompt for settings then I can just add all the nfo shows now
         num_added = 0
         for cur_show in tvdb_id_given:
@@ -1865,7 +1833,7 @@ class NewHomeAddShows:
             # add the show
             sickbeard.showQueueScheduler.action.addShow(tvdb_id, show_dir, SKIPPED, sickbeard.QUALITY_DEFAULT, sickbeard.FLATTEN_FOLDERS_DEFAULT) #@UndefinedVariable
             num_added += 1
-
+         
         if num_added:
             ui.notifications.message("Shows Added", "Automatically added "+str(num_added)+" from their existing metadata files")
 
@@ -2142,25 +2110,6 @@ class Home:
             return '{"message": "Failed! Make sure your Popcorn is on and NMJ is running. (see Log & Errors -> Debug for detailed info)", "database": "", "mount": ""}'
 
     @cherrypy.expose
-    def testNMJv2(self, host=None):
-        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
-
-        result = notifiers.nmjv2_notifier.test_notify(urllib.unquote_plus(host))
-        if result:
-            return "Test notice sent successfully to " + urllib.unquote_plus(host)
-        else:
-            return "Test notice failed to " + urllib.unquote_plus(host)
-
-    @cherrypy.expose
-    def settingsNMJv2(self, host=None, dbloc=None, instance=None):
-        cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
-        result = notifiers.nmjv2_notifier.notify_settings(urllib.unquote_plus(host), dbloc, instance)
-        if result:
-            return '{"message": "NMJ Database found at: %(host)s", "database": "%(database)s"}' % {"host": host, "database": sickbeard.NMJv2_DATABASE}
-        else:
-            return '{"message": "Unable to find NMJ Database at location: %(dbloc)s. Is the right location selected and PCH running?", "database": ""}' % {"dbloc": dbloc}
-
-    @cherrypy.expose
     def testTrakt(self, api=None, username=None, password=None):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
 
@@ -2173,7 +2122,7 @@ class Home:
     @cherrypy.expose
     def testNMA(self, nma_api=None, nma_priority=0):
         cherrypy.response.headers['Cache-Control'] = "max-age=0,no-cache,no-store"
-
+        
         result = notifiers.nma_notifier.test_notify(nma_api, nma_priority)
         if result:
             return "Test NMA notice sent successfully"
@@ -2291,7 +2240,6 @@ class Home:
         epCounts[Overview.QUAL] = 0
         epCounts[Overview.GOOD] = 0
         epCounts[Overview.UNAIRED] = 0
-        epCounts[Overview.SNATCHED] = 0
 
         for curResult in sqlResults:
 
@@ -2501,20 +2449,17 @@ class Home:
         # just give it some time
         time.sleep(3)
 
-        redirect("/home/displayShow?show=" + str(showObj.tvdbid))
+        redirect("/home/displayShow?show="+str(showObj.tvdbid))
 
     @cherrypy.expose
     def updateXBMC(self, showName=None):
-        if sickbeard.XBMC_UPDATE_ONLYFIRST:
-            # only send update to first host in the list -- workaround for xbmc sql backend users
-            host = sickbeard.XBMC_HOST.split(",")[0].strip()
-        else:
-            host = sickbeard.XBMC_HOST
-
+        # TODO: configure that each host can have different options / username / pw
+        # only send update to first host in the list -- workaround for xbmc sql backend users
+        firstHost = sickbeard.XBMC_HOST.split(",")[0].strip()
         if notifiers.xbmc_notifier.update_library(showName=showName):
-            ui.notifications.message("Library update command sent to XBMC host(s): " + host)
+            ui.notifications.message("Library update command sent to XBMC host: " + firstHost)
         else:
-            ui.notifications.error("Unable to contact one or more XBMC host(s): " + host)
+            ui.notifications.error("Unable to contact XBMC host: " + firstHost)
         redirect('/home')
 
     @cherrypy.expose
@@ -2572,7 +2517,7 @@ class Home:
                         ep_segment = str(epObj.airdate)[:7]
                     else:
                         ep_segment = epObj.season
-
+    
                     if ep_segment not in segment_list:
                         segment_list.append(ep_segment)
 
@@ -2677,18 +2622,18 @@ class Home:
 
         if eps == None:
             redirect("/home/displayShow?show=" + show)
-
+            
         for curEp in eps.split('|'):
 
             epInfo = curEp.split('x')
-
+            
             # this is probably the worst possible way to deal with double eps but I've kinda painted myself into a corner here with this stupid database
             ep_result = myDB.select("SELECT * FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ? AND 5=5", [show, epInfo[0], epInfo[1]])
             if not ep_result:
                 logger.log(u"Unable to find an episode for "+curEp+", skipping", logger.WARNING)
                 continue
             related_eps_result = myDB.select("SELECT * FROM tv_episodes WHERE location = ? AND episode != ?", [ep_result[0]["location"], epInfo[1]])
-
+            
             root_ep_obj = show_obj.getEpisode(int(epInfo[0]), int(epInfo[1]))
             for cur_related_ep in related_eps_result:
                 related_ep_obj = show_obj.getEpisode(int(cur_related_ep["season"]), int(cur_related_ep["episode"]))
@@ -2702,7 +2647,7 @@ class Home:
     @cherrypy.expose
     def searchEpisode(self, show=None, season=None, episode=None):
 
-        # retrieve the episode object and fail if we can't get one
+        # retrieve the episode object and fail if we can't get one 
         ep_obj = _getEpisode(show, season, episode)
         if isinstance(ep_obj, str):
             return json.dumps({'result': 'failure'})
@@ -2722,13 +2667,13 @@ class Home:
         return json.dumps({'result': 'failure'})
 
 class UI:
-
+    
     @cherrypy.expose
     def add_message(self):
-
+        
         ui.notifications.message('Test 1', 'This is test number 1')
         ui.notifications.error('Test 2', 'This is test number 2')
-
+        
         return "ok"
 
     @cherrypy.expose
@@ -2807,32 +2752,32 @@ class WebInterface:
     def setComingEpsLayout(self, layout):
         if layout not in ('poster', 'banner', 'list'):
             layout = 'banner'
-
+        
         sickbeard.COMING_EPS_LAYOUT = layout
-
+        
         redirect("/comingEpisodes")
 
     @cherrypy.expose
     def toggleComingEpsDisplayPaused(self):
-
+        
         sickbeard.COMING_EPS_DISPLAY_PAUSED = not sickbeard.COMING_EPS_DISPLAY_PAUSED
-
+        
         redirect("/comingEpisodes")
 
     @cherrypy.expose
     def setComingEpsSort(self, sort):
         if sort not in ('date', 'network', 'show'):
             sort = 'date'
-
+        
         sickbeard.COMING_EPS_SORT = sort
-
+        
         redirect("/comingEpisodes")
 
     @cherrypy.expose
     def comingEpisodes(self, layout="None"):
 
         myDB = db.DBConnection()
-
+        
         today = datetime.date.today().toordinal()
         next_week = (datetime.date.today() + datetime.timedelta(days=7)).toordinal()
         recently = (datetime.date.today() - datetime.timedelta(days=3)).toordinal()
@@ -2886,7 +2831,7 @@ class WebInterface:
             t.layout = layout
         else:
             t.layout = sickbeard.COMING_EPS_LAYOUT
-
+                
 
         return _munge(t)
 
@@ -2897,11 +2842,11 @@ class WebInterface:
     config = Config()
 
     home = Home()
-
+    
     api = Api()
 
     browser = browser.WebFileBrowser()
 
     errorlogs = ErrorLogs()
-
+    
     ui = UI()


### PR DESCRIPTION
The code for the new version of the metadata. Can be used to generate the XMBC in both the new and old format.

Have tested the generation of all metadata providers. 
config.ini is updating correctly.
The PostProcessing screen is showing the new options.

The code for Season Fanart isn't working and is skipped in all Metadata providers

The reason that I change all of the files is that generic was based on the old XBMC format and I wanted to extend this to the new XBMC format and have the same ability to change configuration that is currently there. e.g. turn on and off season banners or season posters. Which can't be done with a new provider as the is only the option season thumbnails yes or no (4 possible setting vs 2).
