### PR TITLE
Cosmetic :: manage_episodeStatuses.tmpl : Restructured layout of "Episode Status Management" web page to decrease chance of accidental status change.

### DIFF
--- a/data/interfaces/default/manage_episodeStatuses.tmpl
+++ b/data/interfaces/default/manage_episodeStatuses.tmpl
@@ -9,33 +9,39 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-#if not $whichStatus or ($whichStatus and not $ep_counts):
-
-#if $whichStatus:
-<h3>None of your episodes have status $common.statusStrings[$int($whichStatus)]</h3>
-<br />
-#end if
-
 <form action="$sbRoot/manage/episodeStatuses" method="get">
 Manage episodes with status <select name="whichStatus">
 #for $curStatus in [$common.SKIPPED, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]:
-<option value="$curStatus">$common.statusStrings[$curStatus]</option>
+<option value="$curStatus"#if $curStatus == $whichStatus then " selected=\"selected\"" else ""#>$common.statusStrings[$curStatus]</option>
 #end for
 </select>
 <input class="btn" type="submit" value="Manage" /> 
 </form>
 
-#else
+#if $whichStatus and not $ep_counts:
+<br />
 
-<script type="text/javascript" src="$sbRoot/js/manageEpisodeStatuses.js?$sbPID"></script>
-
-<form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
-<input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus" />
+<h3>None of your episodes have status $common.statusStrings[$int($whichStatus)]</h3>
+#elif $whichStatus and $ep_counts:
+<br />
 
 <h3>Shows containing $common.statusStrings[$int($whichStatus)] episodes</h3>
 
+<script type="text/javascript" src="$sbRoot/js/manageEpisodeStatuses.js?$sbPID"></script>
+
+<table class="sickbeardTable" cellspacing="1" border="0" cellpadding="0">
+    #for $cur_tvdb_id in $sorted_show_ids:
+<tr id="$cur_tvdb_id">
+<th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all" checked="checked" /></th>
+<th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="btn get_more_eps" id="$cur_tvdb_id" value="Expand" /></th>
+</tr>
+    #end for
+</table>
+
 <br />
 
+<form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
+<input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus" />
 #if $whichStatus in ($common.ARCHIVED, $common.IGNORED, $common.SNATCHED):
 #set $row_class = "good"
 #else
@@ -54,17 +60,6 @@ $statusList.remove($int($whichStatus))
 #end for
 </select>
 <input class="btn" type="submit" value="Go" />
-
-<br /><br /><br />
-
-<table class="sickbeardTable" cellspacing="1" border="0" cellpadding="0">
-#for $cur_tvdb_id in $sorted_show_ids:
- <tr id="$cur_tvdb_id">
-  <th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all" checked="checked" /></th>
-  <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="btn get_more_eps" id="$cur_tvdb_id" value="Expand" /></th>
- </tr>
-#end for
-</table>
 </form>
 
 #end if


### PR DESCRIPTION
On the "Episode Status Management" page, the form for choosing and the one for changing status are visually fairly similar, yet have drastically different outcomes. I have more than once applied a status change when all I meant to do was display a different status.

This patch restructures the layout to decrease chances of such mishaps.

Before image:
![SickbBeard-Episode_Overview-Before](https://f.cloud.github.com/assets/3500686/212226/7bc0e17e-82d9-11e2-96bb-5453875f99df.png)
After image:
![SickbBeard-Episode_Overview-After](https://f.cloud.github.com/assets/3500686/212228/949697d4-82d9-11e2-813d-221071b07f83.png)
