### PR TITLE
Better handling Show Update Status "Ended"

### DIFF
--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -23,6 +23,7 @@ import sickbeard
 from sickbeard import logger
 from sickbeard import exceptions
 from sickbeard import ui
+from sickbeard import db
 from sickbeard.exceptions import ex
 
 class ShowUpdater():
@@ -45,13 +46,43 @@ class ShowUpdater():
         else:
             return
 
+        myDB = db.DBConnection()
+
         piList = []
+
+        # Shows where the last Episodes airdate is unknown, update them for 365 days (1 year) after the last known Airdate
+        unknown_aired_min = (datetime.date.today() - datetime.timedelta(days=365)).toordinal()
+        # Shows where the last Episodes airdate is known, update them for 90 days after the last known Airdate
+        last_aired_min = (datetime.date.today() - datetime.timedelta(days=90)).toordinal()
 
         for curShow in sickbeard.showList:
 
+            sqlResults = {}
+            last_known_airdate = 0
+            last_ep_airdate = 0
+
+            try:
+                sqlResults = myDB.select("SELECT * FROM tv_episodes WHERE showid = ? ORDER BY airdate DESC", [curShow.tvdbid])
+            except:
+                pass
+
+            try:
+                if sqlResults != None and len(sqlResults) > 0:
+                    sortedsql = sorted(sqlResults, key=lambda x: (-x['season'], -x['episode']))
+                    # get last known airdate
+                    last_known_airdate = sqlResults[0]['airdate']
+                    # get airdate for the last episode
+                    last_ep_airdate = sortedsql[0]['airdate']
+                else:
+                    last_known_airdate = 0
+                    last_ep_airdate = 0
+            except:
+                last_known_airdate = 0
+                last_ep_airdate = 0
+
             try:
 
-                if curShow.status != "Ended":
+                if curShow.status != "Ended" or (last_ep_airdate <= 1 and last_known_airdate >= unknown_aired_min) or (last_ep_airdate > 1 and last_known_airdate >= last_aired_min):
                     curQueueItem = sickbeard.showQueueScheduler.action.updateShow(curShow, True) #@UndefinedVariable
                 else:
                     #TODO: maybe I should still update specials?


### PR DESCRIPTION
Since the "Ended" Status is set on the tvdb many times as soon as the TV Shows is canceled, there are still Episodes left to air. So stopping to do Updates for "Ended" Shows is not a good idea. I changed that.

Now the last known Airdate and the the Airdate of the last Episode is read from the db. If a Show is marked "Ended" the Show is still updated if:
1. The last Episodes Airdate is known = up to 90 days after the last known Airdate a normal Update is done.
2. The last Episodes Airdate is unknown = up to 365 days after the last known Airdate a normal Update is done.

Both is necessary to avoid the need of a manual Forced Update for Shows that are marked "Ended", but not all Episodes have been aired yet.
