### PR TITLE
Add missing runtime from thetvdb

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -654,6 +654,9 @@ class TVShow(object):
         if myEp["status"] != None:
             self.status = myEp["status"]
 
+        if myEp["runtime"] != None:
+            self.runtime = int(myEp["runtime"])
+
         if self.status == None:
             self.status = ""
 


### PR DESCRIPTION
The runtime wasn't imported from the tvdb.

Is Field will be needed for new timezone sensitive Coming Episodes Page. If the time (localized start time + runtime) is later as now the TV Show will be shown as Missed.
