### PR TITLE
Add unit testing of webserve.py

### DIFF
--- a/tests/cptestcase.py
+++ b/tests/cptestcase.py
@@ -1,0 +1,105 @@
+# Grabbed from:
+# https://bitbucket.org/Lawouach/cherrypy-recipes/src/50aff88dc4e2/testing/unit/serverless?at=default
+# -*- coding: utf-8 -*-
+from StringIO import StringIO
+import unittest
+import urllib
+
+import cherrypy
+
+# Not strictly speaking mandatory but just makes sense
+cherrypy.config.update({'environment': "test_suite"})
+
+# This is mandatory so that the HTTP server isn't started
+# if you need to actually start (why would you?), simply
+# subscribe it back.
+cherrypy.server.unsubscribe()
+
+# simulate fake socket address... they are irrelevant in our context
+local = cherrypy.lib.httputil.Host('127.0.0.1', 50000, "")
+remote = cherrypy.lib.httputil.Host('127.0.0.1', 50001, "")
+
+__all__ = ['BaseCherryPyTestCase']
+
+class BaseCherryPyTestCase(unittest.TestCase):
+    def request(self, path='/', method='GET', app_path='', scheme='http',
+                proto='HTTP/1.1', data=None, headers=None, **kwargs):
+        """
+        CherryPy does not have a facility for serverless unit testing.
+        However this recipe demonstrates a way of doing it by
+        calling its internal API to simulate an incoming request.
+        This will exercise the whole stack from there.
+
+        Remember a couple of things:
+
+        * CherryPy is multithreaded. The response you will get
+          from this method is a thread-data object attached to
+          the current thread. Unless you use many threads from
+          within a unit test, you can mostly forget
+          about the thread data aspect of the response.
+
+        * Responses are dispatched to a mounted application's
+          page handler, if found. This is the reason why you
+          must indicate which app you are targetting with
+          this request by specifying its mount point.
+
+        You can simulate various request settings by setting
+        the `headers` parameter to a dictionary of headers,
+        the request's `scheme` or `protocol`.
+
+        .. seealso: http://docs.cherrypy.org/stable/refman/_cprequest.html#cherrypy._cprequest.Response
+        """
+        # This is a required header when running HTTP/1.1
+        h = {'Host': '127.0.0.1'}
+
+        if headers is not None:
+            h.update(headers)
+
+        # If we have a POST/PUT request but no data
+        # we urlencode the named arguments in **kwargs
+        # and set the content-type header
+        if method in ('POST', 'PUT') and not data:
+            data = urllib.urlencode(kwargs)
+            kwargs = None
+            h['content-type'] = 'application/x-www-form-urlencoded'
+
+        # If we did have named arguments, let's
+        # urlencode them and use them as a querystring
+        qs = None
+        if kwargs:
+            qs = urllib.urlencode(kwargs)
+
+        # if we had some data passed as the request entity
+        # let's make sure we have the content-length set
+        fd = None
+        if data is not None:
+            h['content-length'] = '%d' % len(data)
+            fd = StringIO(data)
+
+        # Get our application and run the request against it
+        app = cherrypy.tree.apps.get(app_path)
+        if not app:
+            # XXX: perhaps not the best exception to raise?
+            raise AssertionError("No application mounted at '%s'" % app_path)
+
+        # Cleanup any previous returned response
+        # between calls to this method
+        app.release_serving()
+
+        # Let's fake the local and remote addresses
+        request, response = app.get_serving(local, remote, scheme, proto)
+        try:
+            h = [(k, v) for k, v in h.iteritems()]
+            response = request.run(method, path, qs, proto, h, fd)
+        finally:
+            if fd:
+                fd.close()
+                fd = None
+
+        if response.output_status.startswith('500'):
+            print response.body[0]
+            raise AssertionError("Unexpected error")
+
+        # collapse the response into a bytestring
+        response.collapse_body()
+        return response

--- a/tests/cptestcase.py
+++ b/tests/cptestcase.py
@@ -21,6 +21,7 @@ remote = cherrypy.lib.httputil.Host('127.0.0.1', 50001, "")
 
 __all__ = ['BaseCherryPyTestCase']
 
+
 class BaseCherryPyTestCase(unittest.TestCase):
     def request(self, path='/', method='GET', app_path='', scheme='http',
                 proto='HTTP/1.1', data=None, headers=None, **kwargs):

--- a/tests/fixtures/history.yaml
+++ b/tests/fixtures/history.yaml
@@ -1,0 +1,9 @@
+one:
+    action: 1604
+    date: 20111111134506
+    showid: 82066
+    season: 1
+    episode: 1
+    quality: -1
+    resource: "/path/to/stuff/Fringe/Season 01/episode1.mkv"
+    provider: -1

--- a/tests/fixtures/lolo_rss_fixture.txt
+++ b/tests/fixtures/lolo_rss_fixture.txt
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/" encoding="utf-8">
+<channel>
+<atom:link href="http://lolo.sickbeard.com/api" rel="self" type="application/rss+xml" />
+<title>Sick Beard Index</title>
+<description>Sick Beard Index API Results</description>
+<link>http://lolo.sickbeard.com/</link>
+<language>en-gb</language>
+<webMaster>midgetspy@sickbeard.com (Sick Beard Index)</webMaster>
+<category></category>
+<image>
+	<url>http://lolo.sickbeard.com/theme/nzbsu/images/banner.jpg</url>
+	<title>Sick Beard Index</title>
+	<link>http://lolo.sickbeard.com/</link>
+	<description>Visit Sick Beard Index - API TV Index</description>
+</image>
+<newznab:response offset="0" total="17" />
+<item>
+	<title>Justified.S04E05.PROPER.HDTV.x264-2HD</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/174b0bbec90ea54a239e210f03042ee1</guid>
+	<link>http://lolo.sickbeard.com/getnzb/174b0bbec90ea54a239e210f03042ee1.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/174b0bbec90ea54a239e210f03042ee1#comments</comments> 	
+	<pubDate>Thu, 07 Feb 2013 16:43:27 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Justified.S04E05.PROPER.HDTV.x264-2HD</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/174b0bbec90ea54a239e210f03042ee1.nzb&amp;i=0&amp;r=" length="443846458" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="443846458" />
+</item>
+<item>
+	<title>Justified.S04E05.PROPER.720p.HDTV.x264-EVOLVE</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/6327f1d7ec9331bb9b897d84c5bde44e</guid>
+	<link>http://lolo.sickbeard.com/getnzb/6327f1d7ec9331bb9b897d84c5bde44e.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/6327f1d7ec9331bb9b897d84c5bde44e#comments</comments> 	
+	<pubDate>Thu, 07 Feb 2013 16:31:03 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Justified.S04E05.PROPER.720p.HDTV.x264-EVOLVE</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/6327f1d7ec9331bb9b897d84c5bde44e.nzb&amp;i=0&amp;r=" length="1494677514" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="1494677514" />
+</item>
+<item>
+	<title>Kroll.Show.S01E04.PROPER.720p.HDTV.x264-EVOLVE</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/5017882477804a8c45d23cb1dbdb4970</guid>
+	<link>http://lolo.sickbeard.com/getnzb/5017882477804a8c45d23cb1dbdb4970.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/5017882477804a8c45d23cb1dbdb4970#comments</comments> 	
+	<pubDate>Thu, 07 Feb 2013 06:28:17 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Kroll.Show.S01E04.PROPER.720p.HDTV.x264-EVOLVE</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/5017882477804a8c45d23cb1dbdb4970.nzb&amp;i=0&amp;r=" length="1287465478" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="1287465478" />
+</item>
+<item>
+	<title>Kroll.Show.S01E04.PROPER.HDTV.x264-EVOLVE</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/6e168cb3583edc6b1a0c97d361dd09a3</guid>
+	<link>http://lolo.sickbeard.com/getnzb/6e168cb3583edc6b1a0c97d361dd09a3.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/6e168cb3583edc6b1a0c97d361dd09a3#comments</comments> 	
+	<pubDate>Thu, 07 Feb 2013 06:28:24 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Kroll.Show.S01E04.PROPER.HDTV.x264-EVOLVE</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/6e168cb3583edc6b1a0c97d361dd09a3.nzb&amp;i=0&amp;r=" length="384938884" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="384938884" />
+</item>
+<item>
+	<title>Justified.S04E05.PROPER.720p.HDTV.x264-EVOLVE</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/01de67113151cc1db1282c45beb5ab98</guid>
+	<link>http://lolo.sickbeard.com/getnzb/01de67113151cc1db1282c45beb5ab98.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/01de67113151cc1db1282c45beb5ab98#comments</comments> 	
+	<pubDate>Wed, 06 Feb 2013 06:13:50 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Justified.S04E05.PROPER.720p.HDTV.x264-EVOLVE</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/01de67113151cc1db1282c45beb5ab98.nzb&amp;i=0&amp;r=" length="1557400362" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="1557400362" />
+</item>
+<item>
+	<title>Justified.S04E05.PROPER.HDTV.x264-2HD</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/646c4fb0188f61520a6289da12c3b7cf</guid>
+	<link>http://lolo.sickbeard.com/getnzb/646c4fb0188f61520a6289da12c3b7cf.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/646c4fb0188f61520a6289da12c3b7cf#comments</comments> 	
+	<pubDate>Wed, 06 Feb 2013 06:14:20 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Justified.S04E05.PROPER.HDTV.x264-2HD</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/646c4fb0188f61520a6289da12c3b7cf.nzb&amp;i=0&amp;r=" length="427936065" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="427936065" />
+</item>
+<item>
+	<title>Craig.Ferguson.2013.02.04.Zooey.Deschanel.PROPER.HDTV.x264-2HD</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/95bdfe44f3a3cb101b1d231a21be45e1</guid>
+	<link>http://lolo.sickbeard.com/getnzb/95bdfe44f3a3cb101b1d231a21be45e1.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/95bdfe44f3a3cb101b1d231a21be45e1#comments</comments> 	
+	<pubDate>Tue, 05 Feb 2013 10:37:12 +0100</pubDate> 
+	<category>TV &gt; HD</category> 	
+	<description>Craig.Ferguson.2013.02.04.Zooey.Deschanel.PROPER.HDTV.x264-2HD</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/95bdfe44f3a3cb101b1d231a21be45e1.nzb&amp;i=0&amp;r=" length="395951506" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5040" />
+	<newznab:attr name="size" value="395951506" />
+</item>
+<item>
+	<title>The.Pacific.E10.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/9ef390be2ab66609a84d9ab8b2002602</guid>
+	<link>http://lolo.sickbeard.com/getnzb/9ef390be2ab66609a84d9ab8b2002602.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/9ef390be2ab66609a84d9ab8b2002602#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:13:43 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E10.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/9ef390be2ab66609a84d9ab8b2002602.nzb&amp;i=0&amp;r=" length="702305076" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="702305076" />
+</item>
+<item>
+	<title>The.Pacific.E09.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/778c58c4e068a2fb520dcdf1f858cf02</guid>
+	<link>http://lolo.sickbeard.com/getnzb/778c58c4e068a2fb520dcdf1f858cf02.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/778c58c4e068a2fb520dcdf1f858cf02#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:01 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E09.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/778c58c4e068a2fb520dcdf1f858cf02.nzb&amp;i=0&amp;r=" length="699474944" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="699474944" />
+</item>
+<item>
+	<title>The.Pacific.E08.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/ff76e854ac54e89e10a3cd1bd5f20318</guid>
+	<link>http://lolo.sickbeard.com/getnzb/ff76e854ac54e89e10a3cd1bd5f20318.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/ff76e854ac54e89e10a3cd1bd5f20318#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:28 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E08.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/ff76e854ac54e89e10a3cd1bd5f20318.nzb&amp;i=0&amp;r=" length="675269891" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="675269891" />
+</item>
+<item>
+	<title>The.Pacific.E07.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/4a14879e1f43669db65fe4543072180a</guid>
+	<link>http://lolo.sickbeard.com/getnzb/4a14879e1f43669db65fe4543072180a.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/4a14879e1f43669db65fe4543072180a#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:22 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E07.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/4a14879e1f43669db65fe4543072180a.nzb&amp;i=0&amp;r=" length="678207359" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="678207359" />
+</item>
+<item>
+	<title>The.Pacific.E06.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/c5b052253360a09d6df44d90e54ff0ea</guid>
+	<link>http://lolo.sickbeard.com/getnzb/c5b052253360a09d6df44d90e54ff0ea.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/c5b052253360a09d6df44d90e54ff0ea#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:35 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E06.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/c5b052253360a09d6df44d90e54ff0ea.nzb&amp;i=0&amp;r=" length="673740594" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="673740594" />
+</item>
+<item>
+	<title>The.Pacific.E05.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/95388fdf68579e8de8c473bb70fa1502</guid>
+	<link>http://lolo.sickbeard.com/getnzb/95388fdf68579e8de8c473bb70fa1502.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/95388fdf68579e8de8c473bb70fa1502#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:13 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E05.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/95388fdf68579e8de8c473bb70fa1502.nzb&amp;i=0&amp;r=" length="673780021" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="673780021" />
+</item>
+<item>
+	<title>The.Pacific.E04.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/794c2bdc7c75505a589e160dc7b280e7</guid>
+	<link>http://lolo.sickbeard.com/getnzb/794c2bdc7c75505a589e160dc7b280e7.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/794c2bdc7c75505a589e160dc7b280e7#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:13:49 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E04.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/794c2bdc7c75505a589e160dc7b280e7.nzb&amp;i=0&amp;r=" length="683621115" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="683621115" />
+</item>
+<item>
+	<title>The.Pacific.E03.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/f7959f69242dbd49ba6f792e16a5aafa</guid>
+	<link>http://lolo.sickbeard.com/getnzb/f7959f69242dbd49ba6f792e16a5aafa.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/f7959f69242dbd49ba6f792e16a5aafa#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:13:55 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E03.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/f7959f69242dbd49ba6f792e16a5aafa.nzb&amp;i=0&amp;r=" length="685454709" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="685454709" />
+</item>
+<item>
+	<title>The.Pacific.E02.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/47ead73e3e7376b4630f505e7ec8fe66</guid>
+	<link>http://lolo.sickbeard.com/getnzb/47ead73e3e7376b4630f505e7ec8fe66.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/47ead73e3e7376b4630f505e7ec8fe66#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:07 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E02.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/47ead73e3e7376b4630f505e7ec8fe66.nzb&amp;i=0&amp;r=" length="684795356" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="684795356" />
+</item>
+<item>
+	<title>The.Pacific.E01.PROPER.BDRiP.XviD-QCF</title>
+	<guid isPermaLink="true">http://lolo.sickbeard.com/details/b679b8fcc09de869f1fe036efb53f7d3</guid>
+	<link>http://lolo.sickbeard.com/getnzb/b679b8fcc09de869f1fe036efb53f7d3.nzb&amp;i=0&amp;r=</link>
+	<comments>http://lolo.sickbeard.com/details/b679b8fcc09de869f1fe036efb53f7d3#comments</comments> 	
+	<pubDate>Mon, 04 Feb 2013 13:14:36 +0100</pubDate> 
+	<category>TV &gt; SD</category> 	
+	<description>The.Pacific.E01.PROPER.BDRiP.XviD-QCF</description>
+	<enclosure url="http://lolo.sickbeard.com/getnzb/b679b8fcc09de869f1fe036efb53f7d3.nzb&amp;i=0&amp;r=" length="675399341" type="application/x-nzb" />
+
+	<newznab:attr name="category" value="5000" />
+	<newznab:attr name="category" value="5030" />
+	<newznab:attr name="size" value="675399341" />
+</item>
+
+</channel>
+</rss>

--- a/tests/fixtures/tv_episodes.yaml
+++ b/tests/fixtures/tv_episodes.yaml
@@ -1,0 +1,12 @@
+fringe_ep_115:
+  episode_id: 115
+  showid: 82066
+  name: An Enemy of Fate
+  season: 5
+  episode: 13
+  description: Peter, Olivia, Walter, Astrid and Broyles face off against the Observers in one final and extraordinary battle for the fate of mankind.
+  airdate: 733773
+  hasnfo: false
+  hastbn: false
+  status: 1
+  tvdbid: 4429604

--- a/tests/fixtures/tv_show_fixtures.yaml
+++ b/tests/fixtures/tv_show_fixtures.yaml
@@ -1,0 +1,13 @@
+show_one:
+  show_id: 82066
+  show_name: Fringe
+  tvdb_id: 82066
+  genre: Drama,Science-Fiction
+  runtime: 40
+  airs: Monday 9:00 PM
+  flatten_folders: False
+  paused: False
+  startyear: '2008-08-26'
+  quality: 29
+  tvr_id: 18388
+  location: ''

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -18,7 +18,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-
+import yaml
 import sqlite3
 
 import sys, os.path
@@ -116,12 +116,38 @@ class SickbeardTestDBCase(unittest.TestCase):
         tearDown_test_episode_file()
         tearDown_test_show_dir()
 
+    def loadFixtures(self):
+        ep_data = yaml.load(
+            open(
+                os.path.join(TESTDIR, 'fixtures/tv_episodes.yaml')).read())
+        show_data = yaml.load(
+            open(
+                os.path.join(TESTDIR, 'fixtures/tv_show_fixtures.yaml')).read())
+        history_data = yaml.load(
+            open(
+                os.path.join(TESTDIR, 'fixtures/history.yaml')).read())
+
+        myDB = db.DBConnection()
+        for show in show_data:
+          myDB.insert('tv_shows', show_data[show])
+
+        for ep in ep_data:
+          myDB.insert('tv_episodes', ep_data[ep])
+
+        for history in history_data:
+          myDB.insert('history', history_data[history])
+
 
 class TestDBConnection(db.DBConnection, object):
 
-    def __init__(self, dbFileName=TESTDBNAME):
+    def __init__(self, dbFileName=TESTDBNAME, row_type=None):
         dbFileName = os.path.join(TESTDIR, dbFileName)
-        super(TestDBConnection, self).__init__(dbFileName)
+        super(TestDBConnection, self).__init__(dbFileName, row_type=row_type)
+
+    def insert(self, table_name, valueDict):
+      query = ("INSERT INTO "+table_name+" (" + ", ".join(valueDict.keys()) + ")" +
+               " VALUES (" + ", ".join(["?"] * len(valueDict.keys())) + ")")
+      self.action(query, valueDict.values())
 
 
 class TestCacheDBConnection(TestDBConnection, object):

--- a/tests/webserve_tests.py
+++ b/tests/webserve_tests.py
@@ -28,14 +28,17 @@ import sickbeard
 from sickbeard import tv
 from sickbeard import webserve, scheduler, searchBacklog
 
+
 def setUpModule():
     cherrypy.tree.mount(webserve.WebInterface(), '/')
     cherrypy.engine.start()
 setup_module = setUpModule
 
+
 def tearDownModule():
     cherrypy.engine.exit()
 teardown_module = tearDownModule
+
 
 class WebserveTests(test.SickbeardTestDBCase, cptestcase.BaseCherryPyTestCase):
     def setUp(self):
@@ -46,10 +49,11 @@ class WebserveTests(test.SickbeardTestDBCase, cptestcase.BaseCherryPyTestCase):
         self.mox = mox.Mox()
         mock_sched = self.mox.CreateMock(scheduler.Scheduler)
         mock_sched.timeLeft().AndReturn('')
-        mock_backlog_sched = self.mox.CreateMock(searchBacklog.BacklogSearchScheduler)
+        mock_backlog_sched = self.mox.CreateMock(
+            searchBacklog.BacklogSearchScheduler)
         mock_backlog_sched.nextRun().AndReturn(datetime.datetime.today())
-        sickbeard.currentSearchScheduler=mock_sched
-        sickbeard.backlogSearchScheduler=mock_backlog_sched
+        sickbeard.currentSearchScheduler = mock_sched
+        sickbeard.backlogSearchScheduler = mock_backlog_sched
 
     def tearDown(self):
         test.SickbeardTestDBCase.tearDown(self)
@@ -144,5 +148,5 @@ if __name__ == '__main__':
     print "=================="
     print "STARTING - Webserve TESTS"
     print "=================="
-    print "######################################################################"
+    print "###################################################################"
     unittest.main()

--- a/tests/webserve_tests.py
+++ b/tests/webserve_tests.py
@@ -1,0 +1,148 @@
+# coding=UTF-8
+# Author: Daniel Hobe <hobeonekenobi@gmail.com>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import unittest
+import test_lib as test
+import mox
+import cptestcase
+import cherrypy
+
+import sickbeard
+from sickbeard import tv
+from sickbeard import webserve, scheduler, searchBacklog
+
+def setUpModule():
+    cherrypy.tree.mount(webserve.WebInterface(), '/')
+    cherrypy.engine.start()
+setup_module = setUpModule
+
+def tearDownModule():
+    cherrypy.engine.exit()
+teardown_module = tearDownModule
+
+class WebserveTests(test.SickbeardTestDBCase, cptestcase.BaseCherryPyTestCase):
+    def setUp(self):
+        test.SickbeardTestDBCase.setUp(self)
+        sickbeard.USE_API = True
+        sickbeard.API_KEY = 'testing'
+        sickbeard.COMING_EPS_SORT = 'date'
+        self.mox = mox.Mox()
+        mock_sched = self.mox.CreateMock(scheduler.Scheduler)
+        mock_sched.timeLeft().AndReturn('')
+        mock_backlog_sched = self.mox.CreateMock(searchBacklog.BacklogSearchScheduler)
+        mock_backlog_sched.nextRun().AndReturn(datetime.datetime.today())
+        sickbeard.currentSearchScheduler=mock_sched
+        sickbeard.backlogSearchScheduler=mock_backlog_sched
+
+    def tearDown(self):
+        test.SickbeardTestDBCase.tearDown(self)
+        self.mox.UnsetStubs()
+
+    def test_ComingEpisodes(self):
+        self.loadFixtures()
+        s = tv.TVShow(82066)
+        e = tv.TVEpisode(s, 5, 13)
+        e.loadFromDB(5, 13)
+        e.airdate = (datetime.date.today() +
+                     datetime.timedelta(days=3))
+        e.saveToDB(forceSave=True)
+
+        self.mox.ReplayAll()
+        response = self.request('/comingEpisodes/')
+        self.assertEqual(response.output_status, '200 OK')
+        self.assertIn('5x13 - An Enemy of Fate', response.body[0])
+
+    def test_Api(self):
+        response = self.request('/api/testing/', cmd='logs', min_level='debug')
+        self.assertIn('success', response.body[0])
+
+    def test_future_Api(self):
+        response = self.request('/api/testing/', cmd='future')
+        self.assertIn('success', response.body[0])
+
+    def test_history_Api(self):
+        self.loadFixtures()
+        response = self.request('/api/testing/', cmd='history', debug=1)
+        self.assertIn('Fringe', response.body[0])
+        response = self.request('/api/testing/', cmd='history',
+                                limit=100, debug=1)
+        self.assertIn('Fringe', response.body[0])
+
+    def test_exceptions_Api(self):
+        self.loadFixtures()
+        response = self.request('/api/testing/', cmd='exceptions')
+        self.assertIn('success', response.body[0])
+
+        sickbeard.showList = [tv.TVShow(82066)]
+        response = self.request('/api/testing/',
+                                cmd='exceptions', tvdbid='82066', debug=1)
+        self.assertIn('success', response.body[0])
+
+    def test_show_season_list_api(self):
+        self.loadFixtures()
+        sickbeard.showList = [tv.TVShow(82066)]
+        response = self.request('/api/testing/',
+                                cmd='show.seasonlist',
+                                tvdbid=82066,
+                                debug=1)
+        self.assertIn('success', response.body[0])
+
+    def test_show_seasons(self):
+        self.loadFixtures()
+        sickbeard.showList = [tv.TVShow(82066)]
+        response = self.request('/api/testing/',
+                                cmd='show.seasons',
+                                tvdbid=82066,
+                                debug=1)
+        self.assertIn('success', response.body[0])
+
+        response = self.request('/api/testing/',
+                                cmd='show.seasons',
+                                tvdbid=82066,
+                                season=5,
+                                debug=1)
+        self.assertIn('success', response.body[0])
+
+    def test_show_stats(self):
+        self.loadFixtures()
+        sickbeard.showList = [tv.TVShow(82066)]
+        response = self.request('/api/testing/',
+                                cmd='show.stats',
+                                tvdbid=82066,
+                                debug=1)
+        self.assertIn('success', response.body[0])
+
+    def test_shows_stats(self):
+        self.loadFixtures()
+        sickbeard.showList = [tv.TVShow(82066)]
+        response = self.request('/api/testing/',
+                                cmd='shows.stats',
+                                debug=1)
+        self.assertIn('success', response.body[0])
+        self.assertIn('"ep_total": 1', response.body[0])
+
+
+if __name__ == '__main__':
+
+    print "=================="
+    print "STARTING - Webserve TESTS"
+    print "=================="
+    print "######################################################################"
+    unittest.main()


### PR DESCRIPTION
Broken out from my peewee db change, this adds unit tests for webserve.py file.
- Adds the testing hooks for cherrypy in cptestcase.py (snagged from the interwebs)
- Adds database fixtures and a process to load them before each test case

I'd like to add a bunch more tests but I'm unsure how you'd like to proceed with these?  One large pull requests or lots of small ones (and if lots of small ones how to do that).  Any guidance appreciated.
