### PR TITLE
Enable users to change the frequency for Scan and Process

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -92,6 +92,17 @@
                             </label>
                         </div>
 
+                        <div class="field-pair">
+                            <label class="nocheck clearfix">
+                                <span class="component-title">Scan and Process Frequency</span>
+                                <input type="number" name="auto_post_process_frequency" value="$sickbeard.AUTO_POST_PROCESS_FREQUENCY" size="5" min="1" class="input-small" />
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Time in minutes between scans (eg. 10)</span>
+                            </label>
+                        </div>
+
                         <div class="clearfix"></div>
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -170,6 +170,7 @@ ADD_SHOWS_WO_DIR = None
 CREATE_MISSING_SHOW_DIRS = None
 RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
+AUTO_POST_PROCESS_FREQUENCY = 10
 KEEP_PROCESSED_DIR = False
 MOVE_ASSOCIATED_FILES = False
 TV_DOWNLOAD_DIR = None
@@ -341,7 +342,7 @@ def initialize(consoleLogging=True):
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 USE_PYTIVO, PYTIVO_NOTIFY_ONSNATCH, PYTIVO_NOTIFY_ONDOWNLOAD, PYTIVO_UPDATE_LIBRARY, PYTIVO_HOST, PYTIVO_SHARE_NAME, PYTIVO_TIVO_NAME, \
                 USE_NMA, NMA_NOTIFY_ONSNATCH, NMA_NOTIFY_ONDOWNLOAD, NMA_API, NMA_PRIORITY, \
-                NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, \
+                NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, AUTO_POST_PROCESS_FREQUENCY, \
                 KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 NAMING_PATTERN, NAMING_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, \
@@ -452,8 +453,10 @@ def initialize(consoleLogging=True):
         if SEARCH_FREQUENCY < MIN_SEARCH_FREQUENCY:
             SEARCH_FREQUENCY = MIN_SEARCH_FREQUENCY
 
+
         TV_DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'tv_download_dir', '')
         PROCESS_AUTOMATICALLY = check_setting_int(CFG, 'General', 'process_automatically', 0)
+        AUTO_POST_PROCESS_FREQUENCY = check_setting_int(CFG, 'General', 'auto_post_process_frequency', 10)
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
@@ -753,7 +756,7 @@ def initialize(consoleLogging=True):
                                                      runImmediately=False)
 
         autoPostProcesserScheduler = scheduler.Scheduler(autoPostProcesser.PostProcesser(),
-                                                     cycleTime=datetime.timedelta(minutes=10),
+                                                     cycleTime=datetime.timedelta(minutes=AUTO_POST_PROCESS_FREQUENCY),
                                                      threadName="POSTPROCESSER",
                                                      runImmediately=True)
 
@@ -1020,6 +1023,7 @@ def save_config():
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
+    new_config['General']['auto_post_process_frequency'] = int(AUTO_POST_PROCESS_FREQUENCY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
     new_config['General']['create_missing_show_dirs'] = CREATE_MISSING_SHOW_DIRS
     new_config['General']['add_shows_wo_dir'] = ADD_SHOWS_WO_DIR

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -848,7 +848,7 @@ class ConfigPostProcessing:
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                     xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
-                    use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
+                    use_banner=None, keep_processed_dir=None, process_automatically=None, auto_post_process_frequency=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
         results = []
@@ -865,6 +865,9 @@ class ConfigPostProcessing:
             process_automatically = 1
         else:
             process_automatically = 0
+
+        if auto_post_process_frequency == '' or auto_post_process_frequency is None:
+            auto_post_process_frequency = 10
 
         if rename_episodes == "on":
             rename_episodes = 1
@@ -887,6 +890,7 @@ class ConfigPostProcessing:
             naming_custom_abd = 0
 
         sickbeard.PROCESS_AUTOMATICALLY = process_automatically
+        sickbeard.AUTO_POST_PROCESS_FREQUENCY = int(auto_post_process_frequency)
         sickbeard.KEEP_PROCESSED_DIR = keep_processed_dir
         sickbeard.RENAME_EPISODES = rename_episodes
         sickbeard.MOVE_ASSOCIATED_FILES = move_associated_files


### PR DESCRIPTION
The default interval for auto process is 10 minutes. This high frequency causes problems for users with Sick-Beard on NAS devices that want to use deep sleep, like Synology. Deep sleep is only possible when there is no hard drive activity, which will reset the inactivity counter. So every time SB does a scan on the hard drive, the device will wake up from deep sleep if it can go to sleep at all.

Being able to lower the frequency to something like 120 minutes or even less will solve this issue.
