### PR TITLE
Prevent infinite post processing with Keep Original Files enabled and ...

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -833,6 +833,10 @@ class PostProcessor(object):
             # move the episode and associated files to the show dir
             if sickbeard.KEEP_PROCESSED_DIR:
                 self._copy(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+
+                # create an empty helper file to indicate that this video has been processed
+                helper_file = helpers.replaceExtension(self.file_path, "processed")
+                open(helper_file, 'w')
             else:
                 self._move(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
         except (OSError, IOError):

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -30,6 +30,7 @@ from sickbeard.exceptions import ex
 
 from sickbeard import logger
 
+
 def logHelper (logMessage, logLevel=logger.MESSAGE):
     logger.log(logMessage, logLevel)
     return logMessage + u"\n"
@@ -86,6 +87,7 @@ def processDir (dirName, nzbName=None, recurse=False):
     # split the list into video files and folders
     folders = filter(lambda x: ek.ek(os.path.isdir, ek.ek(os.path.join, dirName, x)), fileList)
     videoFiles = filter(helpers.isMediaFile, fileList)
+    _checkOrphanedProcessedFiles(dirName, fileList)
 
     # recursively process all the folders
     for curFolder in folders:
@@ -105,7 +107,7 @@ def processDir (dirName, nzbName=None, recurse=False):
 
         # prevent infinite auto process loop when KEEP_PROCESSED_DIR = true, by marking videos as processed
         if sickbeard.KEEP_PROCESSED_DIR:
-            # check if file has already been processed - an empty helper file will exist
+            # check if file has already been processed - a .processed file will exist
             helper_file = helpers.replaceExtension(cur_video_file_path, "processed")
 
             if ek.ek(os.path.isfile, helper_file):
@@ -142,3 +144,26 @@ def processDir (dirName, nzbName=None, recurse=False):
             returnStr += logHelper(u"Processing failed for "+cur_video_file_path+": "+process_fail_message, logger.WARNING)
 
     return returnStr
+
+def _checkOrphanedProcessedFiles(baseDir, fileList):
+    processedFiles = filter(_isProcessedHelperFile, fileList)
+
+    # check for orphaned .processed files and delete them
+    for processedFile in processedFiles:
+        # get filename without extension
+        baseName = processedFile.rpartition(".")[0]
+
+        # search the file list for all the files starting with baseName
+        matches = [file for file in fileList if file.startswith(baseName)]
+
+        # if only one matches, this is the current .processed file and it is orphaned; so it can be deleted
+        if len(matches) == 1:
+            os.remove(ek.ek(os.path.join, baseDir, processedFile))
+
+def _isProcessedHelperFile(file):
+    sepFile = file.rpartition(".")
+
+    if sepFile[0] == "":
+        return False
+    else:
+        return sepFile[2] == "processed"

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -103,6 +103,15 @@ def processDir (dirName, nzbName=None, recurse=False):
 
         cur_video_file_path = ek.ek(os.path.join, dirName, cur_video_file_path)
 
+        # prevent infinite auto process loop when KEEP_PROCESSED_DIR = true, by marking videos as processed
+        if sickbeard.KEEP_PROCESSED_DIR:
+            # check if file has already been processed - an empty helper file will exist
+            helper_file = helpers.replaceExtension(cur_video_file_path, "processed")
+
+            if ek.ek(os.path.isfile, helper_file):
+                logHelper(u"Processing skipped for " + cur_video_file_path + ": .processed file detected.")
+                continue
+
         try:
             processor = postProcessor.PostProcessor(cur_video_file_path, nzbName)
             process_result = processor.process()


### PR DESCRIPTION
Issue 1538 - 'Keep Original Files' + 'Scan and Process' = infinite processing/notification loop
https://code.google.com/p/sickbeard/issues/detail?id=1538

If the Keep Original Files option is used and when the post processor copies a found video to the new location, this change will also create an empty file with the same name as the video - but ending in .processed.

In turn, when ProcessTV.processDir() checks videos for processing it will ignore the videos already having that empty helper file, thus not post process that file again. 

This change is very important for users running a black hole torrent setup, with a torrent provider which requires them to keep seeding for good ratios. Without it the post process will process all the found videos again and again, every run.
