### PR TITLE
Updated init.freebsd

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -1,24 +1,28 @@
 #!/bin/sh
 #
 # PROVIDE: sickbeard
-# REQUIRE: DAEMON sabnzbd
+# REQUIRE: wget
 # KEYWORD: shutdown
 #
 # Add the following lines to /etc/rc.conf.local or /etc/rc.conf
 # to enable this service:
 #
-# sickbeard_enable (bool):	Set to NO by default.
-#			Set it to YES to enable it.
-# sickbeard_user:  The user account Sick Beard daemon runs as what
-#			you want it to be. It uses '_sabnzbd' user by
-#			default. Do not sets it as empty or it will run
-#			as root.
-# sickbeard_dir:	Directory where Sick Beard lives.
-#			Default: /usr/local/sickbeard
-# sickbeard_chdir:  Change to this directory before running Sick Beard.
-#     Default is same as sickbeard_dir.
-# sickbeard_pid:  The name of the pidfile to create.
-#     Default is sickbeard.pid in sickbeard_dir.
+# sickbeard_enable (bool):			Set to NO by default.
+#						Set it to YES to enable it.
+# sickbeard_user:				The user account SickBeard daemon runs as what
+#						you want it to be. It uses '_sabnzbd' user by
+#						default. Do not set it as empty or it will run
+#						as root.
+# sickbeard_dir:				Directory where Sick Beard lives.
+#						Default: /usr/local/sickbeard
+# sickbeard_chdir:				Change to this directory before running Sick Beard.
+#						Default is same as sickbeard_dir.
+# sickbeard_pid:				The name of the pidfile to create.
+#						Default is sickbeard.pid in sickbeard_dir.
+# sickbeard_flags:				Change or add startup arguments for sickbeard.
+#						Default: --quiet --nolaunch
+#
+			
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 
 . /etc/rc.subr
@@ -33,18 +37,17 @@ load_rc_config ${name}
 : ${sickbeard_dir:="/usr/local/sickbeard"}
 : ${sickbeard_chdir:="${sickbeard_dir}"}
 : ${sickbeard_pid:="${sickbeard_dir}/sickbeard.pid"}
+: ${sickbeard_flags:="--quiet --nolaunch"}
+
+required_dirs=${sickbeard_dir}
 
 WGET="/usr/local/bin/wget" # You need wget for this script to safely shutdown Sick Beard.
-HOST="127.0.0.1" # Set Sick Beard address here.
-PORT="8081" # Set Sick Beard port here.
-SBUSR="" # Set Sick Beard username (if you use one) here.
-SBPWD="" # Set Sick Beard password (if you use one) here.
 
 status_cmd="${name}_status"
 stop_cmd="${name}_stop"
 
-command="/usr/sbin/daemon"
-command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py ${sickbeard_flags} --quiet --nolaunch"
+command="${sickbeard_dir}/SickBeard.py"
+command_args="--daemon --pidfile=${sickbeard_pid}"
 
 # Check for wget and refuse to start without it.
 if [ ! -x "${WGET}" ]; then
@@ -58,26 +61,50 @@ if [ `id -u` != "0" ]; then
   exit 1
 fi
 
-verify_sickbeard_pid() {
-    # Make sure the pid corresponds to the Sick Beard process.
-    pid=`cat ${sickbeard_pid} 2>/dev/null`
-    ps -p ${pid} | grep -q "python ${sickbeard_dir}/SickBeard.py"
-    return $?
-}
-
 # Try to stop Sick Beard cleanly by calling shutdown over http.
 sickbeard_stop() {
     echo "Stopping $name"
-    verify_sickbeard_pid
-    ${WGET} -O - -q --user=${SBUSR} --password=${SBPWD} "http://${HOST}:${PORT}/home/shutdown/" >/dev/null
-    if [ -n "${pid}" ]; then
-      wait_for_pids ${pid}
-      echo "Stopped"
-    fi
+	if [ -f ${sickbeard_pid} ]; then
+		pid=`cat ${sickbeard_pid} 2>/dev/null`
+	else 
+		pid=`ps -U ${sickbeard_user} | grep "python.*SickBeard.py.*--daemon" | grep -v 'grep' | awk '{print $1}'`
+	fi
+	
+	if [ -n "${pid}" ]; then
+		if [ -f "${sickbeard_dir}/config.ini" ]; then
+			host=`grep -m1 -E '^web_host\ =\ [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' ${sickbeard_dir}/config.ini | tr -dc '[0-9].'`
+			port=`grep -m1 ^web_port ${sickbeard_dir}/config.ini | tr -dc '[0-9]'`
+			sbusr=`grep -m1 ^web_username ${sickbeard_dir}/config.ini | /usr/bin/awk '{print $3}'`	
+			sbpwd=`grep -m1 ^web_password ${sickbeard_dir}/config.ini | /usr/bin/awk '{print $3}'`
+			if [ ${sbusr} = '""' ]; then
+				sbusr=""
+			fi		
+			if [ ${sbpwd} = '""' ]; then
+				sbpwd=""
+			fi		
+			${WGET} -O - -q --user=${sbusr} --password=${sbpwd} "http://${host}:${port}/home/shutdown/?pid=${pid}" >/dev/null
+		else
+			kill ${pid}
+		fi
+		wait_for_pids ${pid}
+		echo "Stopped"
+    else 
+		echo "Stopping $name failed. $name is not running"
+	fi
 }
 
 sickbeard_status() {
-    verify_sickbeard_pid && echo "$name is running as ${pid}" || echo "$name is not running"
+	if [ -f ${sickbeard_pid} ]; then
+		pid=`cat ${sickbeard_pid} 2>/dev/null`
+		echo "$name is running as ${pid}"
+	else
+		pid=`ps -U ${sickbeard_user} | grep "python.*SickBeard.py.*--daemon" | grep -v 'grep' | awk '{print $1}'`
+		if [ -n "${pid}" ]; then
+			echo "No PID file found for $name. $name is running as ${pid}"
+		else
+			echo "$name is not running"
+		fi
+	fi
 }
 
 run_rc_command "$1"


### PR DESCRIPTION
- Removed the use of daemon to daemonize Sickbeard and made more use of
  the default functions of FreeBSD and Sickbeard.
- Also removed the need to edit the init file. The file gets it's settings
  directly from the sickbeard config file. All configuration is done trough `/etc/rc.conf.local` or `/etc/rc.conf`. You only need to  add `sickbeard_enable=YES` and an optional user `sickbeard_user="someuser"` in `/etc/rc.conf.local` or `/etc/rc.conf`. For more configurable options check the file itself.
- Changed the `sickbeard_stop()` and `sickbeard_status()` functions to be a bit more resilient when
  faced with strange situations.
