### PR TITLE
Update to fix paths no longer updating properly in Frodo.  Without this ...

### DIFF
--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -414,7 +414,7 @@ class XBMCNotifier:
                 return False
 
             logger.log(u"XBMC Updating " + showName + " on " + host + " at " + path, logger.DEBUG)
-            updateCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":%s},"id":1}' % (json.dumps("\"" + path + "\"")) # yes we really have to wrap the path in escaped "
+            updateCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":%s},"id":1}' % (json.dumps("" + path + ""))
             request = self._send_to_xbmc_json(updateCommand, host)
             if not request:
                 logger.log(u"Update of show directory failed on " + showName + " on " + host + " at " + path, logger.ERROR)


### PR DESCRIPTION
...fix I

get the following error in xbmc:
WARNING: Process directory '"/path/to/show/"' does not exist -
skipping scan and clean.

Signed-off-by: Matthew Schick matt@excentral.org
