### PR TITLE
Added open-file by clicking on the filename in displayShow

### DIFF
--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -158,6 +158,32 @@
                     </fieldset>
                 </div><!-- /component-group2 //-->
 
+                <div id="core-component-group3" class="component-group clearfix">
+
+                    <div class="component-group-desc">
+                        <h3>Playback</h3>
+                        <p>Click on a path to open the file with your mediaplayer</p>
+                        <p><b>Be sure to enter an executable under location</b></p>
+                    </div>
+
+                    <fieldset class="component-group-list">
+
+                        <div class="field-pair">
+                            <input type="checkbox" name="web_play" id="web_play" #if $sickbeard.WEB_PLAY then "checked=\"checked\"" else ""#/>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Enable open player from web.</span>
+                            </label>
+                            <label class="nocheck clearfix" for="web_play_path">
+                                <span class="component-title">Mediaplayer location</span>
+                                <input type="text" name="web_play_path" id="web_play_path" value="$sickbeard.WEB_PLAY_PATH" size="35" />
+                            </label>
+                        </div>
+
+                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                    </fieldset>
+                </div><!-- /component-group3 //-->
+
                 <div id="core-component-group4" class="component-group clearfix">
 
                     <div class="component-group-desc">
@@ -204,6 +230,7 @@
 <script type="text/javascript" charset="utf-8">
 <!--
     jQuery('#log_dir').fileBrowser({ title: 'Select Log Directory' });
+    jQuery('#web_play_path').fileBrowser({ title: 'Select Mediaplayer Executable' });
 //-->
 </script>
 

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -3,6 +3,7 @@
 #from sickbeard.common import *
 #import os.path, os
 #import datetime
+#import urllib
 #set global $title=$show.name
 #set global $header = '<a href="http://thetvdb.com/?tab=series&amp;id=%d" target="_new">%s</a>' % ($show.tvdbid, $show.name)
 
@@ -158,7 +159,12 @@ Change selected episodes to
     <td align="center" class="nowrap">#if int($epResult["airdate"]) == 1 then "never" else $datetime.date.fromordinal(int($epResult["airdate"]))#</td>
     <td>
 #if $epLoc and $show._location and $epLoc.lower().startswith($show._location.lower()):
+#if $sickbeard.WEB_PLAY
+#set $fileLoc = urllib.quote_plus($showLoc[0] + '\\' + $epLoc[len($show._location)+1:])
+<a href="openFile?show=$show.tvdbid&amp;path=&quot;$fileLoc&quot;"> $epLoc[len($show._location)+1:]</a>
+#else
 $epLoc[len($show._location)+1:]
+#end if
 #elif $epLoc and (not $epLoc.lower().startswith($show._location.lower()) or not $show._location):
 $epLoc
 #end if

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -94,6 +94,9 @@ started = False
 
 LOG_DIR = None
 
+WEB_PLAY = None
+WEB_PLAY_PATH = None
+
 WEB_PORT = None
 WEB_LOG = None
 WEB_ROOT = None
@@ -355,7 +358,7 @@ def initialize(consoleLogging=True):
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
-                ADD_SHOWS_WO_DIR
+                ADD_SHOWS_WO_DIR, WEB_PLAY_PATH, WEB_PLAY
 
         if __INITIALIZED__:
             return False
@@ -389,6 +392,9 @@ def initialize(consoleLogging=True):
         ENABLE_HTTPS = bool(check_setting_int(CFG, 'General', 'enable_https', 0))
         HTTPS_CERT = check_setting_str(CFG, 'General', 'https_cert', 'server.crt')
         HTTPS_KEY = check_setting_str(CFG, 'General', 'https_key', 'server.key')
+
+        WEB_PLAY = bool(check_setting_int(CFG, 'General', 'web_play', 0))
+        WEB_PLAY_PATH = check_setting_str(CFG, 'General', 'web_play_path', '')
 
         ACTUAL_CACHE_DIR = check_setting_str(CFG, 'General', 'cache_dir', 'cache')
         # fix bad configs due to buggy code
@@ -983,6 +989,8 @@ def save_config():
     new_config['General']['web_root'] = WEB_ROOT
     new_config['General']['web_username'] = WEB_USERNAME
     new_config['General']['web_password'] = WEB_PASSWORD
+    new_config['General']['web_play'] = int(WEB_PLAY)
+    new_config['General']['web_play_path'] = WEB_PLAY_PATH
     new_config['General']['use_api'] = int(USE_API)
     new_config['General']['api_key'] = API_KEY
     new_config['General']['enable_https'] = int(ENABLE_HTTPS)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -90,6 +90,14 @@ def change_LOG_DIR(log_dir):
 
     return True
 
+def change_WEB_PLAY_PATH(web_play_path):
+    
+    # Should include a check on whether the file exists and is executable
+    sickbeard.WEB_PLAY_PATH = web_play_path
+    logger.log(u"Changed mediaplayer to" + web_play_path)
+
+    return True
+
 def change_NZB_DIR(nzb_dir):
 
     if nzb_dir == '':


### PR DESCRIPTION
Gives the user the possibility to choose an executable and enable the
function.
Once enabled the user can click on a filename of an episode in the
displayShow page to open the executable with the filename as a
parameter.
It should be extended to give the user the possibility to customize the
parameters given to the exec for broader compatibility.
Build on and tested with win8 and VLC, windows media player and mediaplayer classic.
