### PR TITLE
Bugfix :: searchForNeededEpisodes : Fixed NoneType AttributeError exception.

### DIFF
--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -180,6 +180,11 @@ def searchForNeededEpisodes():
 
             bestResult = pickBestResult(curFoundResults[curEp])
 
+            # if all results were rejected move on to the next episode
+            if not bestResult:
+                logger.log(u"All found results for "+curEp.prettyName()+" were rejected.", logger.DEBUG)
+                continue
+
             # if it's already in the list (from another provider) and the newly found quality is no better then skip it
             if curEp in foundResults and bestResult.quality <= foundResults[curEp].quality:
                 continue


### PR DESCRIPTION
Don't store None value bestResult (occurs when all results are rejected) in foundResults list. Quality comparisons with results from other providers throws an exception and prevents completion of the search.

I believe that findSeason() may suffer from the same problem (NoneType in return list), though that was on @Tolstyak's branch I discovered it. At the time I just threw a rough fix on it (Conjuro@19770dd6285686365cefc3ecb65b3c3af34d982b), but it would probably be better to find the root cause. findSeason() is somewhat larger to muddle through and right now I'm hungry, tired and got a headache, so I'll have to get back to it later, unless someone else wants to give it a whack.
