### PR TITLE
Force git to output status on pull

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -369,7 +369,7 @@ class GitUpdateManager(UpdateManager):
         on the call's success.
         """
 
-        output, err = self._run_git('pull origin '+self.branch) #@UnusedVariable
+        output, err = self._run_git('pull --summary origin '+self.branch) #@UnusedVariable
 
         if not output:
             return self._git_error()


### PR DESCRIPTION
This prevents settings in a global .gitconfig from breaking update.
