### PR TITLE
WindowsError is a subclass of OSError and need not be excepted

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -532,7 +532,7 @@ def delete_empty_folders(check_empty_dir, keep_dir=None):
                 ek.ek(os.rmdir, check_empty_dir)
                 # do the library update for synoindex
                 notifiers.synoindex_notifier.deleteFolder(check_empty_dir)
-            except (WindowsError, OSError), e:
+            except OSError, e:
                 logger.log(u"Unable to delete " + check_empty_dir + ": " + repr(e) + " / " + str(e), logger.WARNING)
                 break
             check_empty_dir = ek.ek(os.path.dirname, check_empty_dir)

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -127,7 +127,7 @@ class SBRotatingLogHandler(object):
                     os.remove(cur_file_name)
                 else:
                     os.rename(cur_file_name, self._log_file_name(i+1))
-            except WindowsError:
+            except OSError:
                 pass
         
         # the new log handler will always be on the un-numbered .log file


### PR DESCRIPTION
This fixes bug 2254: https://code.google.com/p/sickbeard/issues/detail?id=2254
