### PR TITLE
Bugfix :: Providers : Fixed TypeError when failed (error) provider search returns empty json data.

### DIFF
--- a/sickbeard/providers/nzbx.py
+++ b/sickbeard/providers/nzbx.py
@@ -71,6 +71,9 @@ class NzbXProvider(generic.NZBProvider):
         logger.log(u"nzbX search url: " + url, logger.DEBUG)
 
         data = self.getURL(url)
+        if not data:
+            logger.log(u"nzbX returned no json data", logger.DEBUG)
+            return[]
         try:
             items = json.loads(data)
         except ValueError:

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -71,6 +71,9 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
         url = 'https://api.omgwtfnzbs.org/json?' + urllib.urlencode(params)
         logger.log(u"omgwtfnzbs search url: " + url, logger.DEBUG)
         data = self.getURL(url)
+        if not data:
+            logger.log(u"omgwtfnzbs returned no json data", logger.DEBUG)
+            return[]
         try:
             items = json.loads(data)
         except ValueError:


### PR DESCRIPTION
If provider search should fail (e.g. http error), variable "data" would remain a none object and subsequently fail on json.loads:

`File "C:\Sick-Beard\sickbeard\search.py", line 338, in findSeason
    curResults = curProvider.findSeasonResults(show, season)
  File "C:\Sick-Beard\sickbeard\providers\generic.py", line 285, in findSeasonResults
    itemList += self._doSearch(curString)
  File "C:\Sick-Beard\sickbeard\providers\nzbx.py", line 75, in _doSearch
    items = json.loads(data)
  File "C:\PROGRA~2\Python27\lib\json\__init__.py", line 326, in loads
    return _default_decoder.decode(s)
  File "C:\PROGRA~2\Python27\lib\json\decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: expected string or buffer`
