### PR TITLE
Issue 284: modify SickBeard to clean up and remove old episodes

### DIFF
--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -86,6 +86,13 @@ replace with: <b><%=", ".join([Quality.qualityStrings[x] for x in sorted(bestQua
 #end if
     </td></tr>
     <tr><td class="showLegend">Language:</td><td><img src="$sbRoot/images/flags/${show.lang}.png" width="16" height="11" alt="" /> $show.lang</td></tr>
+#if $show.episode_management == $sickbeard.EPISODE_MANAGEMENT_OFF
+    <tr><td class="showLegend">Episode Management:</td><td>Off</td></tr>
+#else if $show.episode_management == $sickbeard.EPISODE_MANAGEMENT_SEASON
+    <tr><td class="showLegend">Episode Management:</td><td>Current Season</td></tr>
+#else if $show.episode_management in range(1,11)
+    <tr><td class="showLegend">Episode Management:</td><td>$show.episode_management Episode(s)</td></tr>
+#end if
     <tr><td class="showLegend">Flatten Folders: </td><td><img src="$sbRoot/images/#if $show.flatten_folders == 1 or $sickbeard.NAMING_FORCE_FOLDERS then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Paused: </td><td><img src="$sbRoot/images/#if int($show.paused) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>
     <tr><td class="showLegend">Air-by-Date: </td><td><img src="$sbRoot/images/#if int($show.air_by_date) == 1 then "yes16.png\" alt=\"Y" else "no16.png\" alt=\"N"#" width="16" height="16" /></td></tr>

--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -71,7 +71,18 @@ Paused: <input type="checkbox" name="paused" #if $show.paused == 1 then "checked
 Air by date: 
 <input type="checkbox" name="air_by_date" #if $show.air_by_date == 1 then "checked=\"checked\"" else ""# /><br />
 (check this if the show is released as Show.03.02.2010 rather than Show.S02E03) 
-<br /><br />
+<br />
+<br />
+Episode management:<br />
+<select name="episode_management" id="episode_management">
+    <option value="0" #if $show.episode_management == 0 then 'selected="selected"' else ''#>All</option>
+    <option value="11" #if $show.episode_management == 11 then 'selected="selected"' else ''#>Current Season</option>
+#for $opt in range(1,11):
+    <option value="$opt" #if $show.episode_management == $opt then 'selected="selected"' else ''#>$opt episodes</option>
+#end for
+</select><br />
+Number of episodes to keep at any given time<br />
+<br />
 <input class="btn" type="submit" value="Submit" />
 </form>
 

--- a/data/interfaces/default/inc_addShowOptions.tmpl
+++ b/data/interfaces/default/inc_addShowOptions.tmpl
@@ -27,6 +27,22 @@
         #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_qualityChooser.tmpl")
 
         <div class="field-pair alt">
+            <label for="episode_management" class="nocheck clearfix">
+                <span class="component-title">
+                    <select name="episode_management" id="episode_management">
+                        <option value="0" #if $sickbeard.EPISODE_MANAGEMENT_DEFAULT == 0 then 'selected="selected"' else ''#>All</option>
+                        <option value="11" #if $sickbeard.EPISODE_MANAGEMENT_DEFAULT == 11 then 'selected="selected"' else ''#>Current Season</option>
+                    #for $opt in range(1,11):
+                        <option value="$opt" #if $sickbeard.EPISODE_MANAGEMENT_DEFAULT == $opt then 'selected="selected"' else ''#>$opt episodes</option>
+                    #end for
+                    </select>
+                </span>
+                <span class="component-desc">Maximum number of episodes to keep at any given time<br />
+                Note: choosing a value other than 'Any' gives SickBeard the permission to delete old episodes!</span>
+            </label>
+        </div>
+
+        <div class="field-pair">
             <label for="saveDefaultsButton" class="nocheck clearfix">
                 <span class="component-title"><input class="btn" type="button" id="saveDefaultsButton" value="Save Defaults" disabled="disabled" /></span>
                 <span class="component-desc">Persist current values as the defaults</span>

--- a/data/interfaces/default/manage_massEdit.tmpl
+++ b/data/interfaces/default/manage_massEdit.tmpl
@@ -93,8 +93,24 @@
 </div>
 
 <div class="optionWrapper clearfix">
+    <span class="selectTitle">Maximum number of episodes <span class="separator">**</span></span>
+    <div class="selectChoices">
+        <select id="edit_episode_management" name="episode_management">
+            <option value="keep">&lt; keep &gt;</option>
+            <option value="0" #if $episode_management_value == 0 then 'selected="selected"' else ''#>All</option>
+            <option value="11" #if $episode_management_value == 11 then 'selected="selected"' else ''#>Current Season</option>
+        #for $opt in range(1,11):
+            <option value="$opt" #if $episode_management_value == $opt then 'selected="selected"' else ''#>$opt episodes</option>
+        #end for
+        </select>
+    </div><br />
+</div>
+
+<div class="optionWrapper clearfix">
     <br /><span class="separator" style="font-size: 1.2em; font-weight: 700;">*</span>
     Changing these settings will cause the selected shows to be refreshed.
+    <br /><span class="separator" style="font-size: 1.2em; font-weight: 700;">**</span>
+    Changing this setting may result in episodes being deleted.
 </div>
 
 <div class="optionWrapper clearfix" style="text-align: center;">

--- a/data/js/addShowOptions.js
+++ b/data/js/addShowOptions.js
@@ -9,7 +9,8 @@ $(document).ready(function () {
         $.get(sbRoot + '/config/general/saveAddShowDefaults', {defaultStatus: $('#statusSelect').val(),
                                                              anyQualities: anyQualArray.join(','),
                                                              bestQualities: bestQualArray.join(','),
-                                                             defaultFlattenFolders: $('#flatten_folders').prop('checked')});
+                                                             defaultFlattenFolders: $('#flatten_folders').prop('checked'),
+                                                             default_episode_management: $('#episode_management').val()});
         $(this).attr('disabled', true);
         $.pnotify({
             pnotify_title: 'Saved Defaults',
@@ -18,7 +19,7 @@ $(document).ready(function () {
         });
     });
 
-    $('#statusSelect, #qualityPreset, #flatten_folders, #anyQualities, #bestQualities').change(function () {
+    $('#statusSelect, #qualityPreset, #flatten_folders, #anyQualities, #bestQualities, #episode_management').change(function () {
         $('#saveDefaultsButton').attr('disabled', false);
     });
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -126,6 +126,9 @@ METADATA_SYNOLOGY = None
 QUALITY_DEFAULT = None
 STATUS_DEFAULT = None
 FLATTEN_FOLDERS_DEFAULT = None
+EPISODE_MANAGEMENT_DEFAULT = None
+EPISODE_MANAGEMENT_OFF = 0
+EPISODE_MANAGEMENT_SEASON = 11
 PROVIDER_ORDER = []
 
 NAMING_MULTI_EP = None
@@ -336,7 +339,7 @@ def initialize(consoleLogging=True):
                 NZBS, NZBS_UID, NZBS_HASH, EZRSS, TVTORRENTS, TVTORRENTS_DIGEST, TVTORRENTS_HASH, BTN, BTN_API_KEY, TORRENTLEECH, TORRENTLEECH_KEY, \
                 TORRENT_DIR, USENET_RETENTION, SOCKET_TIMEOUT, \
                 SEARCH_FREQUENCY, DEFAULT_SEARCH_FREQUENCY, BACKLOG_SEARCH_FREQUENCY, \
-                QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, STATUS_DEFAULT, \
+                QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, EPISODE_MANAGEMENT_DEFAULT, EPISODE_MANAGEMENT_OFF, EPISODE_MANAGEMENT_SEASON, STATUS_DEFAULT, \
                 GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, \
                 USE_GROWL, GROWL_HOST, GROWL_PASSWORD, USE_PROWL, PROWL_NOTIFY_ONSNATCH, PROWL_NOTIFY_ONDOWNLOAD, PROWL_API, PROWL_PRIORITY, PROG_DIR, NZBMATRIX, NZBMATRIX_USERNAME, \
                 USE_PYTIVO, PYTIVO_NOTIFY_ONSNATCH, PYTIVO_NOTIFY_ONDOWNLOAD, PYTIVO_UPDATE_LIBRARY, PYTIVO_HOST, PYTIVO_SHARE_NAME, PYTIVO_TIVO_NAME, \
@@ -430,6 +433,7 @@ def initialize(consoleLogging=True):
         STATUS_DEFAULT = check_setting_int(CFG, 'General', 'status_default', SKIPPED)
         VERSION_NOTIFY = check_setting_int(CFG, 'General', 'version_notify', 1)
         FLATTEN_FOLDERS_DEFAULT = bool(check_setting_int(CFG, 'General', 'flatten_folders_default', 0))
+        EPISODE_MANAGEMENT_DEFAULT = check_setting_int(CFG, 'General', 'episode_management_default', EPISODE_MANAGEMENT_OFF)
 
         PROVIDER_ORDER = check_setting_str(CFG, 'General', 'provider_order', '').split()
 
@@ -997,6 +1001,7 @@ def save_config():
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)
     new_config['General']['flatten_folders_default'] = int(FLATTEN_FOLDERS_DEFAULT)
+    new_config['General']['episode_management_default'] = int(EPISODE_MANAGEMENT_DEFAULT)
     new_config['General']['provider_order'] = ' '.join([x.getID() for x in providers.sortedProviderList()])
     new_config['General']['version_notify'] = int(VERSION_NOTIFY)
     new_config['General']['naming_pattern'] = NAMING_PATTERN

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -25,7 +25,7 @@ from sickbeard.providers.generic import GenericProvider
 from sickbeard import encodingKludge as ek
 from sickbeard.name_parser.parser import NameParser, InvalidNameException
 
-MAX_DB_VERSION = 12
+MAX_DB_VERSION = 13
 
 
 class MainSanityCheck(db.DBSanityCheck):
@@ -542,7 +542,6 @@ class RenameSeasonFolders(AddSizeAndSceneNameFields):
 
         self.incDBVersion()
 
-
 class Add1080pAndRawHDQualities(RenameSeasonFolders):
     """Add support for 1080p related qualities along with RawHD
 
@@ -666,3 +665,12 @@ class Add1080pAndRawHDQualities(RenameSeasonFolders):
         # cleanup and reduce db if any previous data was removed
         logger.log(u"Performing a vacuum on the database.", logger.DEBUG)
         self.connection.action("VACUUM")
+
+class AddEpisodeManagementFields(Add1080pAndRawHDQualities):
+    def test(self):
+        return self.checkDBVersion() >= 13
+
+    def execute(self):
+        self.addColumn("tv_shows", "episode_management", "NUMERIC", 0)
+        self.incDBVersion()
+    

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -115,8 +115,8 @@ class ShowQueue(generic_queue.GenericQueue):
 
         return queueItemObj
 
-    def addShow(self, tvdb_id, showDir, default_status=None, quality=None, flatten_folders=None, lang="en"):
-        queueItemObj = QueueItemAdd(tvdb_id, showDir, default_status, quality, flatten_folders, lang)
+    def addShow(self, tvdb_id, showDir, default_status=None, quality=None, flatten_folders=None, episode_management=None, lang="en"):
+        queueItemObj = QueueItemAdd(tvdb_id, showDir, default_status, quality, flatten_folders, episode_management, lang)
 
         self.add_item(queueItemObj)
 
@@ -167,13 +167,14 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 
 class QueueItemAdd(ShowQueueItem):
-    def __init__(self, tvdb_id, showDir, default_status, quality, flatten_folders, lang):
+    def __init__(self, tvdb_id, showDir, default_status, quality, flatten_folders, episode_management, lang):
 
         self.tvdb_id = tvdb_id
         self.showDir = showDir
         self.default_status = default_status
         self.quality = quality
         self.flatten_folders = flatten_folders
+        self.episode_management = episode_management
         self.lang = lang
 
         self.show = None
@@ -251,6 +252,7 @@ class QueueItemAdd(ShowQueueItem):
             self.show.location = self.showDir
             self.show.quality = self.quality if self.quality else sickbeard.QUALITY_DEFAULT
             self.show.flatten_folders = self.flatten_folders if self.flatten_folders != None else sickbeard.FLATTEN_FOLDERS_DEFAULT
+            self.show.episode_management = self.episode_management if self.episode_management != None else sickbeard.EPISODE_MANAGEMENT_DEFAULT
             self.show.paused = 0
 
             # be smartish about this

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -18,6 +18,7 @@
 
 from __future__ import with_statement
 
+import os
 import os.path
 import datetime
 import threading
@@ -60,6 +61,7 @@ class TVShow(object):
         self.runtime = 0
         self.quality = int(sickbeard.QUALITY_DEFAULT)
         self.flatten_folders = int(sickbeard.FLATTEN_FOLDERS_DEFAULT)
+        self.episode_management = int(sickbeard.EPISODE_MANAGEMENT_DEFAULT)
 
         self.status = ""
         self.airs = ""
@@ -604,6 +606,7 @@ class TVShow(object):
 
             self.quality = int(sqlResults[0]["quality"])
             self.flatten_folders = int(sqlResults[0]["flatten_folders"])
+            self.episode_management = int(sqlResults[0]["episode_management"])
             self.paused = int(sqlResults[0]["paused"])
 
             self._location = sqlResults[0]["location"]
@@ -824,7 +827,8 @@ class TVShow(object):
                         "air_by_date": self.air_by_date,
                         "startyear": self.startyear,
                         "tvr_name": self.tvrname,
-                        "lang": self.lang
+                        "lang": self.lang,
+                        "episode_management": self.episode_management,
                         }
 
         myDB.upsert("tv_shows", newValueDict, controlValueDict)
@@ -845,6 +849,7 @@ class TVShow(object):
         toReturn += "genre: " + self.genre + "\n"
         toReturn += "runtime: " + str(self.runtime) + "\n"
         toReturn += "quality: " + str(self.quality) + "\n"
+        toReturn += "episodemanagement: " + str(self.episode_management) + "\n"
         return toReturn
 
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1750,3 +1750,26 @@ class TVEpisode(object):
             self.saveToDB()
             for relEp in self.relatedEps:
                 relEp.saveToDB()
+
+    def deleteMedia(self):
+        """
+        Removes the current media file and all related files from the filesystem
+        """
+
+        # attempt to remove myself from the filesystem
+        success = False
+        with self.lock:
+            try:
+                os.unlink(self._location)
+            except OSError, e:
+                logger.log(u"Deleting "+self.show.name+" "+str(self.season)+"x"+str(self.episode)+" failed: "+ex(e), logger.ERROR)
+                # TODO: turn off episode management for this series - user intervention required
+            else:
+                logger.log(u"Removing " + self.show.name+" "+str(self.season)+"x"+str(self.episode)+" from filesystem. Episode given status of IGNORED", logger.MESSAGE)
+                self.location = ""
+                self.status = IGNORED
+                self.saveToDB()
+                success = True
+
+        return success
+

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1727,8 +1727,8 @@ class NewHomeAddShows:
 
     @cherrypy.expose
     def addNewShow(self, whichSeries=None, tvdbLang="en", rootDir=None, defaultStatus=None,
-                   anyQualities=None, bestQualities=None, flatten_folders=None, fullShowPath=None,
-                   other_shows=None, skipShow=None):
+                   anyQualities=None, bestQualities=None, flatten_folders=None, episode_management=None,
+                   fullShowPath=None, other_shows=None, skipShow=None):
         """
         Receive tvdb id, dir, and other options and create a show from them. If extra show dirs are
         provided then it forwards back to newShow, if not it goes to /home.
@@ -1808,7 +1808,7 @@ class NewHomeAddShows:
         newQuality = Quality.combineQualities(map(int, anyQualities), map(int, bestQualities))
 
         # add the show
-        sickbeard.showQueueScheduler.action.addShow(tvdb_id, show_dir, int(defaultStatus), newQuality, flatten_folders, tvdbLang) #@UndefinedVariable
+        sickbeard.showQueueScheduler.action.addShow(tvdb_id, show_dir, int(defaultStatus), newQuality, flatten_folders, int(episode_management), tvdbLang) #@UndefinedVariable
         ui.notifications.message('Show added', 'Adding the specified show into '+show_dir)
 
         return finishAddShow()
@@ -1879,7 +1879,7 @@ class NewHomeAddShows:
             show_dir, tvdb_id, show_name = cur_show
 
             # add the show
-            sickbeard.showQueueScheduler.action.addShow(tvdb_id, show_dir, SKIPPED, sickbeard.QUALITY_DEFAULT, sickbeard.FLATTEN_FOLDERS_DEFAULT) #@UndefinedVariable
+            sickbeard.showQueueScheduler.action.addShow(tvdb_id, show_dir, SKIPPED, sickbeard.QUALITY_DEFAULT, sickbeard.FLATTEN_FOLDERS_DEFAULT, sickbeard.EPISODE_MANAGEMENT_DEFAULT) #@UndefinedVariable
             num_added += 1
 
         if num_added:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2336,7 +2336,7 @@ class Home:
         return result['description'] if result else 'Episode not found.'
 
     @cherrypy.expose
-    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, directCall=False, air_by_date=None, tvdbLang=None):
+    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, episode_management=None, directCall=False, air_by_date=None, tvdbLang=None):
 
         if show == None:
             errString = "Invalid show ID: "+str(show)
@@ -2401,6 +2401,7 @@ class Home:
         with showObj.lock:
             newQuality = Quality.combineQualities(map(int, anyQualities), map(int, bestQualities))
             showObj.quality = newQuality
+            showObj.episode_management = int(episode_management)
 
             # reversed for now
             if bool(showObj.flatten_folders) != bool(flatten_folders):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -649,7 +649,7 @@ class ConfigGeneral:
         sickbeard.ROOT_DIRS = rootDirString
 
     @cherrypy.expose
-    def saveAddShowDefaults(self, defaultFlattenFolders, defaultStatus, anyQualities, bestQualities):
+    def saveAddShowDefaults(self, defaultFlattenFolders, defaultStatus, anyQualities, bestQualities, default_episode_management):
 
         if anyQualities:
             anyQualities = anyQualities.split(',')
@@ -672,6 +672,7 @@ class ConfigGeneral:
             defaultFlattenFolders = 0
 
         sickbeard.FLATTEN_FOLDERS_DEFAULT = int(defaultFlattenFolders)
+        sickbeard.EPISODE_MANAGEMENT_DEFAULT = int(default_episode_management)
 
     @cherrypy.expose
     def generateKey(self):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -384,6 +384,9 @@ class Manage:
         quality_all_same = True
         last_quality = None
 
+        episode_management_all_same = True
+        last_episode_management = None
+
         root_dir_list = []
 
         for curShow in showList:
@@ -412,17 +415,24 @@ class Manage:
                 else:
                     last_quality = curShow.quality
 
+            if episode_management_all_same:
+                if last_episode_management not in (curShow.episode_management, None):
+                    episode_management_all_same = False
+                else:
+                    last_episode_management = curShow.episode_management
+
         t.showList = toEdit
         t.paused_value = last_paused if paused_all_same else None
         t.flatten_folders_value = last_flatten_folders if flatten_folders_all_same else None
         t.quality_value = last_quality if quality_all_same else None
+        t.episode_management_value = last_episode_management if episode_management_all_same else None
         t.root_dir_list = root_dir_list
 
         return _munge(t)
 
     @cherrypy.expose
     def massEditSubmit(self, paused=None, flatten_folders=None, quality_preset=False,
-                       anyQualities=[], bestQualities=[], toEdit=None, *args, **kwargs):
+                       anyQualities=[], bestQualities=[], episode_management=None, toEdit=None, *args, **kwargs):
 
         dir_map = {}
         for cur_arg in kwargs:
@@ -463,7 +473,12 @@ class Manage:
             if quality_preset == 'keep':
                 anyQualities, bestQualities = Quality.splitQuality(showObj.quality)
 
-            curErrors += Home().editShow(curShow, new_show_dir, anyQualities, bestQualities, new_flatten_folders, new_paused, directCall=True)
+            if episode_management == 'keep':
+                new_episode_management = showObj.episode_management
+            else:
+                new_episode_management = int(episode_management)
+
+            curErrors += Home().editShow(curShow, new_show_dir, anyQualities, bestQualities, new_flatten_folders, new_paused, new_episode_management, directCall=True)
 
             if curErrors:
                 logger.log(u"Errors: "+str(curErrors), logger.ERROR)


### PR DESCRIPTION
Modified SB to support defining episode manage settings per show. User can choose to keep all, the current season, or a range of 1-10 episodes. When an episode is identified as stale it's status is set to ignored and all associated media is removed from the filesystem.

This first pass solution does not:
- alert notifiers of removed media
- remove any files generated by the metadata providers
- clean up the edit show template

Note: I do plan on addressing these issues in the future
