### PR TITLE
Increased support for seeding torrents after rename.

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -53,10 +53,25 @@
                         </div>
 
                         <div class="field-pair">
-                            <input type="checkbox" name="keep_processed_dir" id="keep_processed_dir" #if $sickbeard.KEEP_PROCESSED_DIR == True then "checked=\"checked\"" else ""# />
-                            <label class="clearfix" for="keep_processed_dir">
-                                <span class="component-title">Keep Original Files</span>
-                                <span class="component-desc">Keep original files after they've been processed?</span>
+                            <label class="nocheck clearfix" for="process_method">
+                                <span class="component-title">Process Episode Method:</span>
+                                <span class="component-desc">
+                                    <select name="process_method" id="process_method" class="input-medium" >
+                                        #set $process_method_text = {'copy': "Copy", 'move': "Move", 'hardlink': "Physical Link", 'symlink' : "Symbolic Link"}
+                                        #for $curAction in ('copy', 'move', 'hardlink', 'symlink'):
+                                          #if $sickbeard.PROCESS_METHOD == $curAction:
+                                            #set $process_method = "selected=\"selected\""
+                                          #else
+                                            #set $process_method = ""
+                                          #end if
+                                        <option value="$curAction" $process_method>$process_method_text[$curAction]</option>
+                                        #end for
+                                    </select>                                
+                                </span>
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">What method should be used to put the renamed file in the TV directory?</span>
                             </label>
                         </div>
 

--- a/lib/linktastic/README.txt
+++ b/lib/linktastic/README.txt
@@ -1,0 +1,19 @@
+Linktastic
+
+Linktastic is an extension of the os.link and os.symlink functionality provided
+by the python language since version 2.  Python only supports file linking on
+*NIX-based systems, even though it is relatively simple to engineer a solution
+to utilize NTFS's built-in linking functionality.  Linktastic attempts to unify
+linking on the windows platform with linking on *NIX-based systems.
+
+Usage
+
+Linktastic is a single python module and can be imported as such.  Examples:
+
+# Hard linking src to dest
+import linktastic
+linktastic.link(src, dest)
+
+# Symlinking src to dest
+import linktastic
+linktastic.symlink(src, dest)

--- a/lib/linktastic/linktastic.py
+++ b/lib/linktastic/linktastic.py
@@ -1,0 +1,76 @@
+# Linktastic Module
+# - A python2/3 compatible module that can create hardlinks/symlinks on windows-based systems
+#
+# Linktastic is distributed under the MIT License.  The follow are the terms and conditions of using Linktastic.
+#
+# The MIT License (MIT)
+#  Copyright (c) 2012 Solipsis Development
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+# associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial
+# portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+# LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import subprocess
+from subprocess import CalledProcessError
+import os
+
+
+# Prevent spaces from messing with us!
+def _escape_param(param):
+	return '"%s"' % param
+
+
+# Private function to create link on nt-based systems
+def _link_windows(src, dest):
+	try:
+		subprocess.check_output(
+			'cmd /C mklink /H %s %s' % (_escape_param(dest), _escape_param(src)),
+			stderr=subprocess.STDOUT)
+	except CalledProcessError as err:
+
+		raise IOError(err.output.decode('utf-8'))
+
+	# TODO, find out what kind of messages Windows sends us from mklink
+	# print(stdout)
+	# assume if they ret-coded 0 we're good
+
+
+def _symlink_windows(src, dest):
+	try:
+		subprocess.check_output(
+			'cmd /C mklink %s %s' % (_escape_param(dest), _escape_param(src)),
+			stderr=subprocess.STDOUT)
+	except CalledProcessError as err:
+		raise IOError(err.output.decode('utf-8'))
+
+	# TODO, find out what kind of messages Windows sends us from mklink
+	# print(stdout)
+	# assume if they ret-coded 0 we're good
+
+
+# Create a hard link to src named as dest
+# This version of link, unlike os.link, supports nt systems as well
+def link(src, dest):
+	if os.name == 'nt':
+		_link_windows(src, dest)
+	else:
+		os.link(src, dest)
+
+
+# Create a symlink to src named as dest, but don't fail if you're on nt
+def symlink(src, dest):
+	if os.name == 'nt':
+		_symlink_windows(src, dest)
+	else:
+		os.symlink(src, dest)

--- a/lib/linktastic/setup.py
+++ b/lib/linktastic/setup.py
@@ -1,0 +1,13 @@
+from distutils.core import setup
+
+setup(
+	name='Linktastic',
+	version='0.1.0',
+	author='Jon "Berkona" Monroe',
+	author_email='solipsis.dev@gmail.com',
+	py_modules=['linktastic'],
+	url="http://github.com/berkona/linktastic",
+	license='MIT License - See http://opensource.org/licenses/MIT for details',
+	description='Truly platform-independent file linking',
+	long_description=open('README.txt').read(),
+)

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -171,6 +171,7 @@ CREATE_MISSING_SHOW_DIRS = None
 RENAME_EPISODES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
+PROCESS_METHOD = None
 MOVE_ASSOCIATED_FILES = False
 TV_DOWNLOAD_DIR = None
 
@@ -342,7 +343,7 @@ def initialize(consoleLogging=True):
                 USE_PYTIVO, PYTIVO_NOTIFY_ONSNATCH, PYTIVO_NOTIFY_ONDOWNLOAD, PYTIVO_UPDATE_LIBRARY, PYTIVO_HOST, PYTIVO_SHARE_NAME, PYTIVO_TIVO_NAME, \
                 USE_NMA, NMA_NOTIFY_ONSNATCH, NMA_NOTIFY_ONDOWNLOAD, NMA_API, NMA_PRIORITY, \
                 NZBMATRIX_APIKEY, versionCheckScheduler, VERSION_NOTIFY, PROCESS_AUTOMATICALLY, \
-                KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
+                KEEP_PROCESSED_DIR, PROCESS_METHOD, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 NAMING_PATTERN, NAMING_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, \
                 RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
@@ -456,6 +457,7 @@ def initialize(consoleLogging=True):
         PROCESS_AUTOMATICALLY = check_setting_int(CFG, 'General', 'process_automatically', 0)
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
+        PROCESS_METHOD = check_setting_str(CFG, 'General', 'process_method', 'copy' if KEEP_PROCESSED_DIR else 'move')
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
         CREATE_MISSING_SHOW_DIRS = check_setting_int(CFG, 'General', 'create_missing_show_dirs', 0)
         ADD_SHOWS_WO_DIR = check_setting_int(CFG, 'General', 'add_shows_wo_dir', 0)
@@ -1018,6 +1020,7 @@ def save_config():
     new_config['General']['root_dirs'] = ROOT_DIRS if ROOT_DIRS else ''
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
+    new_config['General']['process_method'] = PROCESS_METHOD
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -39,6 +39,7 @@ from sickbeard import db
 from sickbeard import encodingKludge as ek
 from sickbeard import notifiers
 
+from lib.linktastic import linktastic
 from lib.tvdb_api import tvdb_api, tvdb_exceptions
 
 import xml.etree.cElementTree as etree
@@ -427,6 +428,25 @@ def moveFile(srcFile, destFile):
         ek.ek(os.rename, srcFile, destFile)
         fixSetGroupID(destFile)
     except OSError:
+        copyFile(srcFile, destFile)
+        ek.ek(os.unlink, srcFile)
+
+def hardlinkFile(srcFile, destFile):
+    try:
+        ek.ek(linktastic.link, srcFile, destFile)
+        fixSetGroupID(destFile)
+    except OSError:
+        logger.log(u"Failed to create hardlink of " + srcFile + " at " + destFile + ". Copying instead", logger.ERROR)
+        copyFile(srcFile, destFile)
+        ek.ek(os.unlink, srcFile)
+
+def moveAndSymlinkFile(srcFile, destFile):
+    try:
+        ek.ek(os.rename, srcFile, destFile)
+        fixSetGroupID(destFile)
+        ek.ek(linktastic.symlink, destFile, srcFile)
+    except OSError:
+        logger.log(u"Failed to create symlink of " + srcFile + " at " + destFile + ". Copying instead", logger.ERROR)
         copyFile(srcFile, destFile)
         ek.ek(os.unlink, srcFile)
 

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -290,6 +290,44 @@ class PostProcessor(object):
 
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_copy)
 
+    def _hardlink(self, file_path, new_path, new_base_name, associated_files=False):
+        """
+        file_path: The full path of the media file to move
+        new_path: Destination path where we want to create a hard linked file
+        new_base_name: The base filename (no extension) to use during the link. Use None to keep the same name.
+        associated_files: Boolean, whether we should move similarly-named files too
+        """
+
+        def _int_hard_link(cur_file_path, new_file_path):
+
+            self._log(u"Hard linking file from " + cur_file_path + " to " + new_file_path, logger.DEBUG)
+            try:
+                helpers.hardlinkFile(cur_file_path, new_file_path)
+                helpers.chmodAsParent(new_file_path)
+            except (IOError, OSError), e:
+                self._log("Unable to link file " + cur_file_path + " to " + new_file_path + ": "+ex(e), logger.ERROR)
+                raise e
+        self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_hard_link)
+
+    def _moveAndSymlink(self, file_path, new_path, new_base_name, associated_files=False):
+        """
+        file_path: The full path of the media file to move
+        new_path: Destination path where we want to move the file to create a symbolic link to
+        new_base_name: The base filename (no extension) to use during the link. Use None to keep the same name.
+        associated_files: Boolean, whether we should move similarly-named files too
+        """
+
+        def _int_move_and_sym_link(cur_file_path, new_file_path):
+
+            self._log(u"Moving then symbolic linking file from " + cur_file_path + " to " + new_file_path, logger.DEBUG)
+            try:
+                helpers.moveAndSymlinkFile(cur_file_path, new_file_path)
+                helpers.chmodAsParent(new_file_path)
+            except (IOError, OSError), e:
+                self._log("Unable to link file " + cur_file_path + " to " + new_file_path + ": " + ex(e), logger.ERROR)
+                raise e
+        self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_move_and_sym_link)
+
     def _history_lookup(self):
         """
         Look up the NZB name in the history and see if it contains a record for self.nzb_name
@@ -831,10 +869,18 @@ class PostProcessor(object):
 
         try:
             # move the episode and associated files to the show dir
-            if sickbeard.KEEP_PROCESSED_DIR:
+            if sickbeard.PROCESS_METHOD == "copy":
                 self._copy(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
-            else:
+            elif sickbeard.PROCESS_METHOD == "move":
                 self._move(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+            elif sickbeard.PROCESS_METHOD == "hardlink":
+              self._hardlink(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+            elif sickbeard.PROCESS_METHOD == "symlink":
+              self._moveAndSymlink(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES)
+            else:
+              logger.log(u"Unknown process method: " + sickbeard.PROCESS_METHOD, logger.ERROR)
+              raise exceptions.PostProcessingFailed("Unable to move the files to their new home")
+              
         except (OSError, IOError):
             raise exceptions.PostProcessingFailed("Unable to move the files to their new home")
 

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -116,7 +116,7 @@ def processDir (dirName, nzbName=None, recurse=False):
         # as long as the postprocessing was successful delete the old folder unless the config wants us not to
         if process_result:
 
-            if len(videoFiles) == 1 and not sickbeard.KEEP_PROCESSED_DIR and \
+            if len(videoFiles) == 1 and sickbeard.PROCESS_METHOD == "move" and \
                 ek.ek(os.path.normpath, dirName) != ek.ek(os.path.normpath, sickbeard.TV_DOWNLOAD_DIR) and \
                 len(remainingFolders) == 0:
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -848,7 +848,7 @@ class ConfigPostProcessing:
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                     xbmc_data=None, mediabrowser_data=None, synology_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None,
-                    use_banner=None, keep_processed_dir=None, process_automatically=None, rename_episodes=None,
+                    use_banner=None, keep_processed_dir=None, process_method=None, process_automatically=None, rename_episodes=None,
                     move_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
         results = []
@@ -888,6 +888,7 @@ class ConfigPostProcessing:
 
         sickbeard.PROCESS_AUTOMATICALLY = process_automatically
         sickbeard.KEEP_PROCESSED_DIR = keep_processed_dir
+        sickbeard.PROCESS_METHOD = process_method
         sickbeard.RENAME_EPISODES = rename_episodes
         sickbeard.MOVE_ASSOCIATED_FILES = move_associated_files
         sickbeard.NAMING_CUSTOM_ABD = naming_custom_abd


### PR DESCRIPTION
Instead of simply leaving an option to keep files when renaming, there are now four options.
Move - Do not keep just move.
Copy - Same as keep before, copy file.
Physical Link - Creates a physical link in the destination folder.
Symbolic Link - Moves the file and creates a link in its original location.

Combining post processing scripts with this will allow using to continue seeding torrents while still having the media files renamed/moved into their TV directories.

I've added linktastic to libs which is used by CouchPotato and nzbToMedia to create symbolic/hard links on both *Nix and Windows systems.

Also I realize that by using nzbToMedia we can create physical links and then just allow sickbeard to move the files. However, not all systems support physical links (unRaid to name one), so even if I can get nzbToMedia to include symbolic links, Sickbeard also will need to support symbolic links. Additionally, it seems better to me to just include this support in sickbeard itself rather than in the scripts.
