### PR TITLE
Better click-handling of main show listing's table

### DIFF
--- a/data/js/tableClick.js
+++ b/data/js/tableClick.js
@@ -1,10 +1,23 @@
 $(document).ready(function () {
 
     $("table td.tvShow").live('click', function (e) {
-        if ((!$.browser.msie && e.button == 0) || ($.browser.msie && e.button == 1)) {
-            if (!e.shiftKey) {
-                var href = $(this).find("a").attr("href");
-                if (href) { window.location = href; }
+        // Check the primary click button is pressed, different in IE
+        var is_correct_button = (!$.browser.msie && e.button == 0) || ($.browser.msie && e.button == 1);
+
+        // Handle ctrl/cmd/shift click as open in new-window (or tab)
+        var is_modified_pressed = (e.ctrlKey || e.metaKey || e.shiftKey);
+
+        // If clicked on <a>, let the browser handle things
+        var is_link = (e.srcElement instanceof HTMLAnchorElement);
+
+        if (is_correct_button && !is_link) {
+            var href = $(this).find("a").attr("href");
+            if (!href) { return; } // No link found
+            if (is_modified_pressed) {
+                // New window or tab
+                window.open(href, "_blank");
+            } else {
+                window.location = href;
             }
         }
     });


### PR DESCRIPTION
> Mainly it handles cmd+click on Chrome/OS X properly - before, the link
> would be opened twice, once in a new tab (default link handling) and
> once in the current tab (because of the window.href change)
> 
> This should better emulate the clicking behaviour in "most" browsers,
> but I've only tested in Chrome 26.0 and Safari 6.0, on OS X. What
> could possibly go wrong?
