### PR TITLE
Update postProcessor.py

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -202,6 +202,7 @@ class PostProcessor(object):
                 ek.ek(os.remove, cur_file)
                 # do the library update for synoindex
                 notifiers.synoindex_notifier.deleteFile(cur_file)
+    	self.del_file = cur_file
 
     def _combined_file_operation (self, file_path, new_path, new_base_name, associated_files=False, action=None):
         """
@@ -649,10 +650,16 @@ class PostProcessor(object):
         
         ep_obj: The object to use when calling the extra script
         """
+        try:
+            self.del_file
+        except AttributeError:
+            self.del_file = "None"
+            self._log(u"No file being replaced")
         for curScriptName in sickbeard.EXTRA_SCRIPTS:
             
             # generate a safe command line string to execute the script and provide all the parameters
-            script_cmd = shlex.split(curScriptName) + [ep_obj.location, self.file_path, str(ep_obj.show.tvdbid), str(ep_obj.season), str(ep_obj.episode), str(ep_obj.airdate)]
+            script_cmd = shlex.split(curScriptName) + [ep_obj.location, self.file_path, str(ep_obj.show.tvdbid), str(ep_obj.season), str(ep_obj.episode), str(ep_obj.airdate), self.del_file]
+            self.del_file = "None"
             
             # use subprocess to run the command and capture output
             self._log(u"Executing command "+str(script_cmd))


### PR DESCRIPTION
The postProcessor.py file has been modified to now include the name of any episode that has been replaced with a better quality one as an extra parameter passed to the "extra scripts". This will allow the user more flexibility in their extra scripts ran after post processing by knowing what files have been replaced. Normally the following 6 parameters are passed:

final full path to the episode file
original name of the episode file
show tvdb id
season number
episode number
episode air date
The 7th is now the deleted file. If no file was replaced, the argument will be "None"

This is my first experience with git and a pull request so if I did something wrong, please be gentle. :)
