### PR TITLE
Added support for direct messages and mentions in twitter notifications

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -861,7 +861,7 @@
                             </label>
                             <label class="nocheck clearfix" for="use_twitter">
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">You may want to use a second account.</span>
+                                <span class="component-desc">You may want to use a second account or use direct messages.</span>
                             </label>
                         </div>
 
@@ -878,6 +878,23 @@
                                 <label class="clearfix" for="twitter_notify_ondownload">
                                     <span class="component-title">Notify on Download</span>
                                     <span class="component-desc">Send notification when we finish a download?</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <input type="checkbox" name="twitter_use_direct_message" id="twitter_use_direct_message" #if $sickbeard.TWITTER_USE_DIRECT_MESSAGE then "checked=\"checked\"" else ""# />
+                                <label class="clearfix" for="twitter_use_direct_message">
+                                    <span class="component-title">Use direct message</span>
+                                    <span class="component-desc">Send notifications as direct message instead of normal tweets? Direct messages don't show up on the twitter timeline</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Mention Twitter users</span>
+                                    <input type="text" name="twitter_mention" id="twitter_mention" value="$sickbeard.TWITTER_MENTION" size="35" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Mention other users in the tweet. Required if direct message is used; the mentioned users will each receive a direct message. (e.g. '@someUser1, @someUser2' without quotes) </span>
                                 </label>
                             </div>
                             <div class="field-pair">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -243,6 +243,8 @@ PROWL_PRIORITY = 0
 USE_TWITTER = False
 TWITTER_NOTIFY_ONSNATCH = False
 TWITTER_NOTIFY_ONDOWNLOAD = False
+TWITTER_USE_DIRECT_MESSAGE = False
+TWITTER_MENTION = None
 TWITTER_USERNAME = None
 TWITTER_PASSWORD = None
 TWITTER_PREFIX = None
@@ -347,7 +349,7 @@ def initialize(consoleLogging=True):
                 NAMING_PATTERN, NAMING_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, \
                 RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
                 NZBSRUS, NZBSRUS_UID, NZBSRUS_HASH, WOMBLE, NZBX, NZBX_COMPLETION, OMGWTFNZBS, OMGWTFNZBS_UID, OMGWTFNZBS_KEY, providerList, newznabProviderList, \
-                EXTRA_SCRIPTS, USE_TWITTER, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
+                EXTRA_SCRIPTS, USE_TWITTER, TWITTER_USE_DIRECT_MESSAGE, TWITTER_MENTION, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
                 USE_NOTIFO, NOTIFO_USERNAME, NOTIFO_APISECRET, NOTIFO_NOTIFY_ONDOWNLOAD, NOTIFO_NOTIFY_ONSNATCH, \
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
@@ -638,6 +640,8 @@ def initialize(consoleLogging=True):
         USE_TWITTER = bool(check_setting_int(CFG, 'Twitter', 'use_twitter', 0))
         TWITTER_NOTIFY_ONSNATCH = bool(check_setting_int(CFG, 'Twitter', 'twitter_notify_onsnatch', 0))
         TWITTER_NOTIFY_ONDOWNLOAD = bool(check_setting_int(CFG, 'Twitter', 'twitter_notify_ondownload', 0))
+        TWITTER_USE_DIRECT_MESSAGE = bool(check_setting_int(CFG, 'Twitter', 'twitter_use_direct_message', 0))
+        TWITTER_MENTION = check_setting_str(CFG, 'Twitter', 'twitter_mention', '')
         TWITTER_USERNAME = check_setting_str(CFG, 'Twitter', 'twitter_username', '')
         TWITTER_PASSWORD = check_setting_str(CFG, 'Twitter', 'twitter_password', '')
         TWITTER_PREFIX = check_setting_str(CFG, 'Twitter', 'twitter_prefix', 'Sick Beard')
@@ -1131,6 +1135,8 @@ def save_config():
     new_config['Twitter']['use_twitter'] = int(USE_TWITTER)
     new_config['Twitter']['twitter_notify_onsnatch'] = int(TWITTER_NOTIFY_ONSNATCH)
     new_config['Twitter']['twitter_notify_ondownload'] = int(TWITTER_NOTIFY_ONDOWNLOAD)
+    new_config['Twitter']['twitter_use_direct_message'] = int(TWITTER_USE_DIRECT_MESSAGE)
+    new_config['Twitter']['twitter_mention'] = TWITTER_MENTION
     new_config['Twitter']['twitter_username'] = TWITTER_USERNAME
     new_config['Twitter']['twitter_password'] = TWITTER_PASSWORD
     new_config['Twitter']['twitter_prefix'] = TWITTER_PREFIX

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1155,7 +1155,7 @@ class ConfigNotifications:
                           plex_server_host=None, plex_host=None, plex_username=None, plex_password=None,
                           use_growl=None, growl_notify_onsnatch=None, growl_notify_ondownload=None, growl_host=None, growl_password=None,
                           use_prowl=None, prowl_notify_onsnatch=None, prowl_notify_ondownload=None, prowl_api=None, prowl_priority=0,
-                          use_twitter=None, twitter_notify_onsnatch=None, twitter_notify_ondownload=None,
+                          use_twitter=None, twitter_notify_onsnatch=None, twitter_notify_ondownload=None, twitter_use_direct_message=None, twitter_mention=None,
                           use_notifo=None, notifo_notify_onsnatch=None, notifo_notify_ondownload=None, notifo_username=None, notifo_apisecret=None,
                           use_boxcar=None, boxcar_notify_onsnatch=None, boxcar_notify_ondownload=None, boxcar_username=None,
                           use_pushover=None, pushover_notify_onsnatch=None, pushover_notify_ondownload=None, pushover_userkey=None,
@@ -1257,6 +1257,12 @@ class ConfigNotifications:
             twitter_notify_ondownload = 1
         else:
             twitter_notify_ondownload = 0
+
+        if twitter_use_direct_message == "on":
+            twitter_use_direct_message = 1
+        else:
+            twitter_use_direct_message = 0
+
         if use_twitter == "on":
             use_twitter = 1
         else:
@@ -1393,6 +1399,8 @@ class ConfigNotifications:
         sickbeard.USE_TWITTER = use_twitter
         sickbeard.TWITTER_NOTIFY_ONSNATCH = twitter_notify_onsnatch
         sickbeard.TWITTER_NOTIFY_ONDOWNLOAD = twitter_notify_ondownload
+        sickbeard.TWITTER_USE_DIRECT_MESSAGE = twitter_use_direct_message
+        sickbeard.TWITTER_MENTION = twitter_mention
 
         sickbeard.USE_NOTIFO = use_notifo
         sickbeard.NOTIFO_NOTIFY_ONSNATCH = notifo_notify_onsnatch


### PR DESCRIPTION
Oops, wrong target branch...did base my changes off the correct branch though :) 

_Take 2_

The changes in the pull request allow other users to be mentioned in the notification tweets, as well as open up the possibility to use twitter direct messages instead of publicly visibile tweets on the timeline.
