### PR TITLE
Bugfix :: loadFromTVDB : Prevents corrupted data from TheTVDB

### DIFF
--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -404,6 +404,9 @@ class QueueItemUpdate(ShowQueueItem):
         except tvdb_exceptions.tvdb_error, e:
             logger.log(u"Unable to contact TVDB, aborting: " + ex(e), logger.WARNING)
             return
+        except tvdb_exceptions.tvdb_attributenotfound, e:
+            logger.log(u"Data retrieved from TVDB was incomplete, aborting: " + ex(e), logger.ERROR)
+            return
 
         # get episode list from DB
         logger.log(u"Loading all episodes from the database", logger.DEBUG)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -637,7 +637,10 @@ class TVShow(object):
 
         myEp = t[self.tvdbid]
 
-        self.name = myEp["seriesname"]
+        try:
+            self.name = myEp["seriesname"].strip()
+        except AttributeError:
+            raise tvdb_exceptions.tvdb_attributenotfound("Found %s, but attribute 'seriesname' was empty." % (self.tvdbid))
 
         self.genre = myEp['genre']
         self.network = myEp['network']


### PR DESCRIPTION
tv_shows.show_name in sickbeard.db can never be a NoneType. Patch prevents this from happening if someone has removed the seriesname attribute in the TVDB show entry.

http://www.sickbeard.com/forums/viewtopic.php?f=4&t=7249
