### PR TITLE
Bugfix :: tvrage.py : Handle "No Show Found" on TVRage.

### DIFF
--- a/sickbeard/tvrage.py
+++ b/sickbeard/tvrage.py
@@ -259,6 +259,9 @@ class TVRage:
         info = {}
 
         for x in urlData:
+            if x.startswith("No Show Results Were Found"):
+                logger.log(x.encode('utf-8'), logger.WARNING)
+                return info
             key, value = x.split("@")
             key = key.replace('<pre>','')
             info[key] = value.strip()


### PR DESCRIPTION
tvrage.py, _getTVRageInfo() does not handle `No Show Results Were Found For '<show>'`.

This occurs when adding a show that exists on TheTVDB but not on TVRage.

Submitted for peer review, still testing locally, initial results are good. Will update PR when satisfied nothing breaks over time.
