### PR TITLE
Womble's Index has moved

### DIFF
--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -28,7 +28,7 @@ class WombleProvider(generic.NZBProvider):
     def __init__(self):
         generic.NZBProvider.__init__(self, "Womble's Index")
         self.cache = WombleCache(self)
-        self.url = 'http://nzb.isasecret.com/'
+        self.url = 'http://www.newshost.co.za/'
 
     def isEnabled(self):
         return sickbeard.WOMBLE


### PR DESCRIPTION
The old url of nzb.isasecret.com was a temporary testing address. 
The permanent address is now www.newshost.co.za

This is the word of The Womble.
