### PR TITLE
Added new .ini only variable **anon_redirect** with the default set to `http://derefer.me/?`

### DIFF
--- a/data/interfaces/default/comingEpisodes.tmpl
+++ b/data/interfaces/default/comingEpisodes.tmpl
@@ -132,7 +132,7 @@
     <span class="quality Custom">Custom</span>
 #end if
         </td>
-        <td align="center"><a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open(this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[info]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a></td>
+        <td align="center"><a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[info]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a></td>
         <td align="center">
         <a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Manual Search" id="forceUpdate-${cur_result["showid"]}" class="forceUpdate epSearch"><img alt="[search]" height="16" width="16" src="$sbRoot/images/search16.png" id="forceUpdateImage-${cur_result["showid"]}" /></a>
         </td>
@@ -228,7 +228,7 @@
             #end if            
             </a></span>
             <span class="tvshowTitleIcons">
-                <a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open(this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[tvdb]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a>
+                <a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[tvdb]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a>
                 <span><a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Manual Search" id="forceUpdate-${cur_result["showid"]}" class="epSearch forceUpdate"><img alt="[search]" height="16" width="16" src="$sbRoot/images/search16.png" id="forceUpdateImage-${cur_result["showid"]}" /></a></span>
             </span>
           </th>

--- a/data/interfaces/default/comingEpisodes.tmpl
+++ b/data/interfaces/default/comingEpisodes.tmpl
@@ -132,7 +132,7 @@
     <span class="quality Custom">Custom</span>
 #end if
         </td>
-        <td align="center"><a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[info]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a></td>
+        <td align="center"><a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[info]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a></td>
         <td align="center">
         <a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Manual Search" id="forceUpdate-${cur_result["showid"]}" class="forceUpdate epSearch"><img alt="[search]" height="16" width="16" src="$sbRoot/images/search16.png" id="forceUpdateImage-${cur_result["showid"]}" /></a>
         </td>
@@ -228,7 +228,7 @@
             #end if            
             </a></span>
             <span class="tvshowTitleIcons">
-                <a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[tvdb]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a>
+                <a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[tvdb]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a>
                 <span><a href="$sbRoot/home/searchEpisode?show=${cur_result["showid"]}&amp;season=$cur_result["season"]&amp;episode=$cur_result["episode"]" title="Manual Search" id="forceUpdate-${cur_result["showid"]}" class="epSearch forceUpdate"><img alt="[search]" height="16" width="16" src="$sbRoot/images/search16.png" id="forceUpdateImage-${cur_result["showid"]}" /></a></span>
             </span>
           </th>

--- a/data/interfaces/default/config.tmpl
+++ b/data/interfaces/default/config.tmpl
@@ -28,19 +28,19 @@
         <tr><td class="infoTableHeader">SB Arguments: </td><td>$sickbeard.MY_ARGS</td></tr>
         <tr><td class="infoTableHeader">SB Web Root: </td><td>$sickbeard.WEB_ROOT</td></tr>
         <tr><td class="infoTableHeader">Python Version: </td><td>$sys.version[:120]</td></tr>
-        <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Homepage </td><td><a href="http://www.sickbeard.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://www.sickbeard.com/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-web"></i> Forums </td><td><a href="http://sickbeard.com/forums/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://sickbeard.com/forums/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source </td><td><a href="https://github.com/midgetspy/Sick-Beard/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">https://github.com/midgetspy/Sick-Beard/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-win"></i> Bug Tracker &amp;<br/> Windows Builds </td><td><a href="http://code.google.com/p/sickbeard/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://code.google.com/p/sickbeard/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> Internet Relay Chat </td><td><a href="irc://irc.freenode.net/#sickbeard" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><i>#sickbeard</i> on <i>irc.freenode.net</i></a></td></tr>
+        <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Homepage </td><td><a href="http://www.sickbeard.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://www.sickbeard.com/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-web"></i> Forums </td><td><a href="http://sickbeard.com/forums/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://sickbeard.com/forums/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source </td><td><a href="https://github.com/midgetspy/Sick-Beard/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">https://github.com/midgetspy/Sick-Beard/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-win"></i> Bug Tracker &amp;<br/> Windows Builds </td><td><a href="http://code.google.com/p/sickbeard/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://code.google.com/p/sickbeard/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> Internet Relay Chat </td><td><a href="irc://irc.freenode.net/#sickbeard" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><i>#sickbeard</i> on <i>irc.freenode.net</i></a></td></tr>
     </table>
 </div>
 
 <div class="container padding" style="width: 600px;">
     <table class="infoTable">
         <tr>
-            <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><img src="$sbRoot/images/paypal/btn_donateCC_LG.gif" alt="[donate]" /></a></td>
-            <td>Sick Beard is free, but you can contribute by giving a <b><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">donation</a></b>.</td>
+            <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><img src="$sbRoot/images/paypal/btn_donateCC_LG.gif" alt="[donate]" /></a></td>
+            <td>Sick Beard is free, but you can contribute by giving a <b><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">donation</a></b>.</td>
         </tr>
     </table>
 </div>

--- a/data/interfaces/default/config.tmpl
+++ b/data/interfaces/default/config.tmpl
@@ -28,19 +28,19 @@
         <tr><td class="infoTableHeader">SB Arguments: </td><td>$sickbeard.MY_ARGS</td></tr>
         <tr><td class="infoTableHeader">SB Web Root: </td><td>$sickbeard.WEB_ROOT</td></tr>
         <tr><td class="infoTableHeader">Python Version: </td><td>$sys.version[:120]</td></tr>
-        <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Homepage </td><td><a href="http://www.sickbeard.com/">http://www.sickbeard.com/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-web"></i> Forums </td><td><a href="http://sickbeard.com/forums/">http://sickbeard.com/forums/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source </td><td><a href="https://github.com/midgetspy/Sick-Beard/">https://github.com/midgetspy/Sick-Beard/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-win"></i> Bug Tracker &amp;<br/> Windows Builds </td><td><a href="http://code.google.com/p/sickbeard/">http://code.google.com/p/sickbeard/</a></td></tr>
-        <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> Internet Relay Chat </td><td><a href="irc://irc.freenode.net/#sickbeard"><i>#sickbeard</i> on <i>irc.freenode.net</i></a></td></tr>
+        <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Homepage </td><td><a href="http://www.sickbeard.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://www.sickbeard.com/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-web"></i> Forums </td><td><a href="http://sickbeard.com/forums/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://sickbeard.com/forums/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source </td><td><a href="https://github.com/midgetspy/Sick-Beard/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">https://github.com/midgetspy/Sick-Beard/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-win"></i> Bug Tracker &amp;<br/> Windows Builds </td><td><a href="http://code.google.com/p/sickbeard/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://code.google.com/p/sickbeard/</a></td></tr>
+        <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> Internet Relay Chat </td><td><a href="irc://irc.freenode.net/#sickbeard" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><i>#sickbeard</i> on <i>irc.freenode.net</i></a></td></tr>
     </table>
 </div>
 
 <div class="container padding" style="width: 600px;">
     <table class="infoTable">
         <tr>
-            <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open(this.href); return false;"><img src="$sbRoot/images/paypal/btn_donateCC_LG.gif" alt="[donate]" /></a></td>
-            <td>Sick Beard is free, but you can contribute by giving a <b><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open(this.href); return false;">donation</a></b>.</td>
+            <td><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><img src="$sbRoot/images/paypal/btn_donateCC_LG.gif" alt="[donate]" /></a></td>
+            <td>Sick Beard is free, but you can contribute by giving a <b><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">donation</a></b>.</td>
         </tr>
     </table>
 </div>

--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -24,9 +24,9 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/xbmc.png" alt="" title="XBMC" />
-                        <h3><a href="http://xbmc.org/" onclick="window.open(this.href, '_blank'); return false;">XBMC</a></h3>
+                        <h3><a href="http://xbmc.org/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC</a></h3>
                         <p>A free and open source cross-platform media center and home entertainment system software with a 10-foot user interface designed for the living-room TV.</p>
-                        <p>For SickBeard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" onclick="window.open(this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
+                        <p>For SickBeard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
@@ -119,7 +119,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/plex.png" alt="" title="Plex Media Server" />
-                        <h3><a href="http://www.plexapp.com/" onclick="window.open(this.href, '_blank'); return false;">Plex Media Server</a></h3>
+                        <h3><a href="http://www.plexapp.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Plex Media Server</a></h3>
                         <p>Experience your media on a visually stunning, easy to use interface on your Mac connected to your TV. Your media library has never looked this good!</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -209,7 +209,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nmj.png" alt="" title="Networked Media Jukebox" />
-                        <h3><a href="http://www.popcornhour.com/" onclick="window.open(this.href, '_blank'); return false;">NMJ</a></h3>
+                        <h3><a href="http://www.popcornhour.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">NMJ</a></h3>
                         <p>The Networked Media Jukebox, or NMJ, is the official media jukebox interface made available for the Popcorn Hour 200-series.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -273,7 +273,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nmj.png" alt="" title="Networked Media Jukebox V2" />
-                        <h3><a href="http://www.popcornhour.com/" onclick="window.open(this.href, '_blank'); return false;">NMJv2</a></h3>
+                        <h3><a href="http://www.popcornhour.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">NMJv2</a></h3>
                         <p>The Networked Media Jukebox, or NMJv2, is the official media jukebox interface made available for the Popcorn Hour 300 &amp; 400-series.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -359,7 +359,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/synoindex.png" alt="" title="Synology Indexer" />
-                        <h3><a href="http://synology.com/" onclick="window.open(this.href, '_blank'); return false;">Synology Indexer</a></h3>
+                        <h3><a href="http://synology.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Synology Indexer</a></h3>
                         <p>Synology Indexer is the daemon running on the Synology NAS to build its media database.</p>
                     </div>
 
@@ -388,7 +388,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/pytivo.png" alt="" title="pyTivo" />
-                        <h3><a href="http://pytivo.sourceforge.net/wiki/index.php/PyTivo" onclick="window.open(this.href, '_blank'); return false;">pyTivo</a></h3>
+                        <h3><a href="http://pytivo.sourceforge.net/wiki/index.php/PyTivo" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">pyTivo</a></h3>
                         <p>pyTivo is both an HMO and GoBack server.  This notifier will load the completed downloads to your Tivo.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -453,7 +453,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/growl.png" alt="" title="Growl" />
-                        <h3><a href="http://growl.info/" onclick="window.open(this.href, '_blank'); return false;">Growl</a></h3>
+                        <h3><a href="http://growl.info/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Growl</a></h3>
                         <p>A cross-platform unobtrusive global notification system.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -516,7 +516,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/prowl.png" alt="Prowl" title="Prowl" />
-                        <h3><a href="http://www.prowlapp.com/" onclick="window.open(this.href, '_blank'); return false;">Prowl</a></h3>
+                        <h3><a href="http://www.prowlapp.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Prowl</a></h3>
                         <p>A Growl client for iOS.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -550,7 +550,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Get your key at: <a href="https://www.prowlapp.com/api_settings.php" onclick="window.open(this.href, '_blank'); return false;">https://prowlapp.com/api_settings.php</a></span>
+                                    <span class="component-desc">Get your key at: <a href="https://www.prowlapp.com/api_settings.php" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">https://prowlapp.com/api_settings.php</a></span>
                                 </label>
                             </div>
                             <div class="field-pair">
@@ -581,7 +581,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/notifo.png" alt="" title="Notifo" />
-                        <h3><a href="http://notifo.com/" onclick="window.open(this.href, '_blank'); return false;">Notifo</a></h3>
+                        <h3><a href="http://notifo.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notifo</a></h3>
                         <p>A platform for push-notifications to either mobile or desktop clients</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -625,7 +625,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Get your key at:  <a href="http://notifo.com/user/settings" onclick="window.open(this.href, '_blank'); return false;">http://notifo.com/user/settings</a></span>
+                                    <span class="component-desc">Get your key at:  <a href="http://notifo.com/user/settings" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://notifo.com/user/settings</a></span>
                                 </label>
                             </div>
                             <div class="testNotification" id="testNotifo-result">Click below to test.</div>
@@ -640,7 +640,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/libnotify.png" alt="" title="Libnotify" />
-                        <h3><a href="http://library.gnome.org/devel/libnotify/" onclick="window.open(this.href, '_blank'); return false;">Libnotify</a></h3>
+                        <h3><a href="http://library.gnome.org/devel/libnotify/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Libnotify</a></h3>
                         <p>The standard desktop notification API for Linux/*nix systems.  This notifier will only function if the pynotify module is installed (Ubuntu/Debian package <a href="apt:python-notify">python-notify</a>).</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -679,7 +679,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/pushover.png" alt="" title="Pushover" />
-                        <h3><a href="http://pushover.net/" onclick="window.open(this.href, '_blank'); return false;">Pushover</a></h3>
+                        <h3><a href="http://pushover.net/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Pushover</a></h3>
                         <p>Pushover makes it easy to send real-time notifications to your Android and iOS devices.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -727,7 +727,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/boxcar.png" alt="" title="Boxcar" />
-                        <h3><a href="http://boxcar.io/" onclick="window.open(this.href, '_blank'); return false;">Boxcar</a></h3>
+                        <h3><a href="http://boxcar.io/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Boxcar</a></h3>
                         <p>Read your messages where and when you want them! A subscription will be send if needed.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -776,7 +776,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nma.png" alt="" title="NMA" />
-                        <h3><a href="http://nma.usk.bz" onclick="window.open(this.href, '_blank'); return false;">Notify My Android</a></h3>
+                        <h3><a href="http://nma.usk.bz" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notify My Android</a></h3>
                         <p>Notify My Android is a Prowl-like Android App and API that offers an easy way to send notifications from your application directly to your Android device.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -849,7 +849,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/twitter.png" alt="" title="Twitter" />
-                        <h3><a href="http://www.twitter.com/" onclick="window.open(this.href, '_blank'); return false;">Twitter</a></h3>
+                        <h3><a href="http://www.twitter.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Twitter</a></h3>
                         <p>A social networking and microblogging service, enabling its users to send and read other users' messages called tweets.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -916,7 +916,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/trakt.png" alt="" title="Trakt" />
-                        <h3><a href="http://trakt.tv/" onclick="window.open(this.href, '_blank'); return false;">Trakt</a></h3>
+                        <h3><a href="http://trakt.tv/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Trakt</a></h3>
                         <p>trakt helps keep a record of what TV shows and movies you are watching. Based on your favorites, trakt recommends additional shows and movies you'll enjoy!</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -956,7 +956,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Get your key at: <a href="http://trakt.tv/settings/api" onclick="window.open(this.href, '_blank'); return false;">http://trakt.tv/settings/api</a></span>
+                                    <span class="component-desc">Get your key at: <a href="http://trakt.tv/settings/api" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://trakt.tv/settings/api</a></span>
                                 </label>
                             </div>
                             <div class="testNotification" id="testTrakt-result">Click below to test.</div>

--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -24,9 +24,9 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/xbmc.png" alt="" title="XBMC" />
-                        <h3><a href="http://xbmc.org/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC</a></h3>
+                        <h3><a href="http://xbmc.org/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC</a></h3>
                         <p>A free and open source cross-platform media center and home entertainment system software with a 10-foot user interface designed for the living-room TV.</p>
-                        <p>For SickBeard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
+                        <p>For SickBeard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
@@ -119,7 +119,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/plex.png" alt="" title="Plex Media Server" />
-                        <h3><a href="http://www.plexapp.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Plex Media Server</a></h3>
+                        <h3><a href="http://www.plexapp.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Plex Media Server</a></h3>
                         <p>Experience your media on a visually stunning, easy to use interface on your Mac connected to your TV. Your media library has never looked this good!</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -209,7 +209,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nmj.png" alt="" title="Networked Media Jukebox" />
-                        <h3><a href="http://www.popcornhour.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">NMJ</a></h3>
+                        <h3><a href="http://www.popcornhour.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">NMJ</a></h3>
                         <p>The Networked Media Jukebox, or NMJ, is the official media jukebox interface made available for the Popcorn Hour 200-series.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -273,7 +273,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nmj.png" alt="" title="Networked Media Jukebox V2" />
-                        <h3><a href="http://www.popcornhour.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">NMJv2</a></h3>
+                        <h3><a href="http://www.popcornhour.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">NMJv2</a></h3>
                         <p>The Networked Media Jukebox, or NMJv2, is the official media jukebox interface made available for the Popcorn Hour 300 &amp; 400-series.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -359,7 +359,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/synoindex.png" alt="" title="Synology Indexer" />
-                        <h3><a href="http://synology.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Synology Indexer</a></h3>
+                        <h3><a href="http://synology.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Synology Indexer</a></h3>
                         <p>Synology Indexer is the daemon running on the Synology NAS to build its media database.</p>
                     </div>
 
@@ -388,7 +388,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/pytivo.png" alt="" title="pyTivo" />
-                        <h3><a href="http://pytivo.sourceforge.net/wiki/index.php/PyTivo" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">pyTivo</a></h3>
+                        <h3><a href="http://pytivo.sourceforge.net/wiki/index.php/PyTivo" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">pyTivo</a></h3>
                         <p>pyTivo is both an HMO and GoBack server.  This notifier will load the completed downloads to your Tivo.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -453,7 +453,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/growl.png" alt="" title="Growl" />
-                        <h3><a href="http://growl.info/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Growl</a></h3>
+                        <h3><a href="http://growl.info/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Growl</a></h3>
                         <p>A cross-platform unobtrusive global notification system.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -516,7 +516,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/prowl.png" alt="Prowl" title="Prowl" />
-                        <h3><a href="http://www.prowlapp.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Prowl</a></h3>
+                        <h3><a href="http://www.prowlapp.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Prowl</a></h3>
                         <p>A Growl client for iOS.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -550,7 +550,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Get your key at: <a href="https://www.prowlapp.com/api_settings.php" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">https://prowlapp.com/api_settings.php</a></span>
+                                    <span class="component-desc">Get your key at: <a href="https://www.prowlapp.com/api_settings.php" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">https://prowlapp.com/api_settings.php</a></span>
                                 </label>
                             </div>
                             <div class="field-pair">
@@ -581,7 +581,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/notifo.png" alt="" title="Notifo" />
-                        <h3><a href="http://notifo.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notifo</a></h3>
+                        <h3><a href="http://notifo.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notifo</a></h3>
                         <p>A platform for push-notifications to either mobile or desktop clients</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -625,7 +625,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Get your key at:  <a href="http://notifo.com/user/settings" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://notifo.com/user/settings</a></span>
+                                    <span class="component-desc">Get your key at:  <a href="http://notifo.com/user/settings" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://notifo.com/user/settings</a></span>
                                 </label>
                             </div>
                             <div class="testNotification" id="testNotifo-result">Click below to test.</div>
@@ -640,7 +640,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/libnotify.png" alt="" title="Libnotify" />
-                        <h3><a href="http://library.gnome.org/devel/libnotify/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Libnotify</a></h3>
+                        <h3><a href="http://library.gnome.org/devel/libnotify/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Libnotify</a></h3>
                         <p>The standard desktop notification API for Linux/*nix systems.  This notifier will only function if the pynotify module is installed (Ubuntu/Debian package <a href="apt:python-notify">python-notify</a>).</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -679,7 +679,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/pushover.png" alt="" title="Pushover" />
-                        <h3><a href="http://pushover.net/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Pushover</a></h3>
+                        <h3><a href="http://pushover.net/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Pushover</a></h3>
                         <p>Pushover makes it easy to send real-time notifications to your Android and iOS devices.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -727,7 +727,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/boxcar.png" alt="" title="Boxcar" />
-                        <h3><a href="http://boxcar.io/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Boxcar</a></h3>
+                        <h3><a href="http://boxcar.io/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Boxcar</a></h3>
                         <p>Read your messages where and when you want them! A subscription will be send if needed.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -776,7 +776,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nma.png" alt="" title="NMA" />
-                        <h3><a href="http://nma.usk.bz" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notify My Android</a></h3>
+                        <h3><a href="http://nma.usk.bz" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notify My Android</a></h3>
                         <p>Notify My Android is a Prowl-like Android App and API that offers an easy way to send notifications from your application directly to your Android device.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -849,7 +849,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/twitter.png" alt="" title="Twitter" />
-                        <h3><a href="http://www.twitter.com/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Twitter</a></h3>
+                        <h3><a href="http://www.twitter.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Twitter</a></h3>
                         <p>A social networking and microblogging service, enabling its users to send and read other users' messages called tweets.</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -916,7 +916,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/trakt.png" alt="" title="Trakt" />
-                        <h3><a href="http://trakt.tv/" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Trakt</a></h3>
+                        <h3><a href="http://trakt.tv/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Trakt</a></h3>
                         <p>trakt helps keep a record of what TV shows and movies you are watching. Based on your favorites, trakt recommends additional shows and movies you'll enjoy!</p>
                     </div>
                     <fieldset class="component-group-list">
@@ -956,7 +956,7 @@
                                 </label>
                                 <label class="nocheck clearfix">
                                     <span class="component-title">&nbsp;</span>
-                                    <span class="component-desc">Get your key at: <a href="http://trakt.tv/settings/api" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://trakt.tv/settings/api</a></span>
+                                    <span class="component-desc">Get your key at: <a href="http://trakt.tv/settings/api" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">http://trakt.tv/settings/api</a></span>
                                 </label>
                             </div>
                             <div class="testNotification" id="testTrakt-result">Click below to test.</div>

--- a/data/interfaces/default/config_providers.tmpl
+++ b/data/interfaces/default/config_providers.tmpl
@@ -60,7 +60,7 @@
                             #set $curName = $curProvider.getID()
                           <li class="ui-state-default" id="$curName">
                             <input type="checkbox" id="enable_$curName" class="checkbox provider_enabler" #if $curProvider.isEnabled() then "checked=\"checked\"" else ""#/>
-                            <a href="$curProvider.url" class="imgLink" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><img src="$sbRoot/images/providers/$curProvider.imageName()" alt="" title="$curProvider.name" width="16" height="16" /></a>
+                            <a href="$curProvider.url" class="imgLink" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><img src="$sbRoot/images/providers/$curProvider.imageName()" alt="" title="$curProvider.name" width="16" height="16" /></a>
                             $curProvider.name
                             #if not $curProvider.supportsBacklog then "*" else ""#
                             #if $curProvider.name == "EZRSS" then "**" else ""#

--- a/data/interfaces/default/config_providers.tmpl
+++ b/data/interfaces/default/config_providers.tmpl
@@ -60,7 +60,7 @@
                             #set $curName = $curProvider.getID()
                           <li class="ui-state-default" id="$curName">
                             <input type="checkbox" id="enable_$curName" class="checkbox provider_enabler" #if $curProvider.isEnabled() then "checked=\"checked\"" else ""#/>
-                            <a href="$curProvider.url" class="imgLink" target="_new"><img src="$sbRoot/images/providers/$curProvider.imageName()" alt="" title="$curProvider.name" width="16" height="16" /></a>
+                            <a href="$curProvider.url" class="imgLink" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><img src="$sbRoot/images/providers/$curProvider.imageName()" alt="" title="$curProvider.name" width="16" height="16" /></a>
                             $curProvider.name
                             #if not $curProvider.supportsBacklog then "*" else ""#
                             #if $curProvider.name == "EZRSS" then "**" else ""#

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -225,7 +225,7 @@
                 </div><!-- /component-group2 //-->
 
                 <div class="alert alert-danger" id="no-torrents">
-                    <strong>Note:</strong> Sick Beard works better with Usenet than with Torrents, <a href="http://www.sickbeard.com/usenet.html" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><b>here's why</b></a>.
+                    <strong>Note:</strong> Sick Beard works better with Usenet than with Torrents, <a href="http://www.sickbeard.com/usenet.html" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><b>here's why</b></a>.
                 </div>
 
                 <div id="core-component-group3" class="component-group clearfix">

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -225,7 +225,7 @@
                 </div><!-- /component-group2 //-->
 
                 <div class="alert alert-danger" id="no-torrents">
-                    <strong>Note:</strong> Sick Beard works better with Usenet than with Torrents, <a href="http://www.sickbeard.com/usenet.html" target="_blank"><b>here's why</b></a>.
+                    <strong>Note:</strong> Sick Beard works better with Usenet than with Torrents, <a href="http://www.sickbeard.com/usenet.html" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;"><b>here's why</b></a>.
                 </div>
 
                 <div id="core-component-group3" class="component-group clearfix">

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -4,7 +4,9 @@
 #import os.path, os
 #import datetime
 #set global $title=$show.name
-#set global $header = '<a href="http://thetvdb.com/?tab=series&amp;id=%d" target="_new">%s</a>' % ($show.tvdbid, $show.name)
+#set global $tvdb_url = 'http://thetvdb.com/?tab=series&amp;id=%d' % ($show.tvdbid)
+
+#set global $header = '<a href="%s" title="%s" onclick="window.open(\'%s\', \'_blank\'); return false;">%s</a>' % ($tvdb_url, $tvdb_url, $sickbeard.ANON_REDIRECT + $tvdb_url, $show.name)
 
 #set global $topmenu="manageShows"#
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -6,7 +6,7 @@
 #set global $title=$show.name
 #set global $tvdb_url = 'http://thetvdb.com/?tab=series&amp;id=%d' % ($show.tvdbid)
 
-#set global $header = '<a href="%s" title="%s" onclick="window.open(\'%s\', \'_blank\'); return false;">%s</a>' % ($tvdb_url, $tvdb_url, $sickbeard.ANON_REDIRECT + $tvdb_url, $show.name)
+#set global $header = '<a href="%s" title="%s" rel="noreferrer" onclick="window.open(\'%s\', \'_blank\'); return false;">%s</a>' % ($tvdb_url, $tvdb_url, $sickbeard.ANON_REDIRECT + $tvdb_url, $show.name)
 
 #set global $topmenu="manageShows"#
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")

--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -116,7 +116,7 @@
 <div id="header">
     <a name="top"></a>
     <span id="logo"><a href="$sbRoot/home/" title="Sick Beard homepage"><img alt="Sick Beard" src="$sbRoot/images/sickbeard.png" width="150" height="72" /></a></span>
-    <span id="versiontext">alpha <a href="https://github.com/midgetspy/Sick-Beard/wiki/ChangeLog" onclick="window.open(this.href, '_blank'); return false;">$sickbeard.version.SICKBEARD_VERSION</a></span>
+    <span id="versiontext">alpha <a href="https://github.com/midgetspy/Sick-Beard/wiki/ChangeLog" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">$sickbeard.version.SICKBEARD_VERSION</a></span>
 </div>
 
     <div class="navbar">
@@ -207,7 +207,7 @@
                     </ul>
                     <ul class="nav pull-right">
                         <li>
-                            <a id="navDonate" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open(this.href); return false;"><img src="$sbRoot/images/paypal/btn_donate_LG.gif" alt="[donate]" height="26" width="92" /></a>
+                            <a id="navDonate" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href); return false;"><img src="$sbRoot/images/paypal/btn_donate_LG.gif" alt="[donate]" height="26" width="92" /></a>
                         </li>
                     </ul>
                 </div><!-- /nav-collapse -->

--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -116,7 +116,7 @@
 <div id="header">
     <a name="top"></a>
     <span id="logo"><a href="$sbRoot/home/" title="Sick Beard homepage"><img alt="Sick Beard" src="$sbRoot/images/sickbeard.png" width="150" height="72" /></a></span>
-    <span id="versiontext">alpha <a href="https://github.com/midgetspy/Sick-Beard/wiki/ChangeLog" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">$sickbeard.version.SICKBEARD_VERSION</a></span>
+    <span id="versiontext">alpha <a href="https://github.com/midgetspy/Sick-Beard/wiki/ChangeLog" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">$sickbeard.version.SICKBEARD_VERSION</a></span>
 </div>
 
     <div class="navbar">
@@ -207,7 +207,7 @@
                     </ul>
                     <ul class="nav pull-right">
                         <li>
-                            <a id="navDonate" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href); return false;"><img src="$sbRoot/images/paypal/btn_donate_LG.gif" alt="[donate]" height="26" width="92" /></a>
+                            <a id="navDonate" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=JA8M7VDY89SQ4" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href); return false;"><img src="$sbRoot/images/paypal/btn_donate_LG.gif" alt="[donate]" height="26" width="92" /></a>
                         </li>
                     </ul>
                 </div><!-- /nav-collapse -->

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -102,6 +102,8 @@ WEB_PASSWORD = None
 WEB_HOST = None
 WEB_IPV6 = None
 
+ANON_REDIRECT = None
+
 USE_API = False
 API_KEY = None
 
@@ -148,9 +150,7 @@ DOWNLOAD_PROPERS = None
 
 SEARCH_FREQUENCY = None
 BACKLOG_SEARCH_FREQUENCY = 21
-
 MIN_SEARCH_FREQUENCY = 10
-
 DEFAULT_SEARCH_FREQUENCY = 60
 
 EZRSS = False
@@ -165,7 +165,6 @@ BTN = False
 BTN_API_KEY = None
 
 TORRENT_DIR = None
-
 ADD_SHOWS_WO_DIR = None
 CREATE_MISSING_SHOW_DIRS = None
 RENAME_EPISODES = False
@@ -355,7 +354,7 @@ def initialize(consoleLogging=True):
                 USE_BANNER, USE_LISTVIEW, METADATA_XBMC, METADATA_MEDIABROWSER, METADATA_PS3, METADATA_SYNOLOGY, metadata_provider_dict, \
                 NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
-                ADD_SHOWS_WO_DIR
+                ADD_SHOWS_WO_DIR, ANON_REDIRECT
 
         if __INITIALIZED__:
             return False
@@ -382,6 +381,11 @@ def initialize(consoleLogging=True):
         WEB_USERNAME = check_setting_str(CFG, 'General', 'web_username', '')
         WEB_PASSWORD = check_setting_str(CFG, 'General', 'web_password', '')
         LAUNCH_BROWSER = bool(check_setting_int(CFG, 'General', 'launch_browser', 1))
+
+        ANON_REDIRECT = check_setting_str(CFG, 'General', 'anon_redirect', 'http://derefer.me/?')
+        # attempt to help prevent users from breaking links by using a bad url
+        if not ANON_REDIRECT.endswith('?'):
+            ANON_REDIRECT = ''
 
         USE_API = bool(check_setting_int(CFG, 'General', 'use_api', 0))
         API_KEY = check_setting_str(CFG, 'General', 'api_key', '')
@@ -983,11 +987,13 @@ def save_config():
     new_config['General']['web_root'] = WEB_ROOT
     new_config['General']['web_username'] = WEB_USERNAME
     new_config['General']['web_password'] = WEB_PASSWORD
+    new_config['General']['anon_redirect'] = ANON_REDIRECT
     new_config['General']['use_api'] = int(USE_API)
     new_config['General']['api_key'] = API_KEY
     new_config['General']['enable_https'] = int(ENABLE_HTTPS)
     new_config['General']['https_cert'] = HTTPS_CERT
     new_config['General']['https_key'] = HTTPS_KEY
+
     new_config['General']['use_nzbs'] = int(USE_NZBS)
     new_config['General']['use_torrents'] = int(USE_TORRENTS)
     new_config['General']['nzb_method'] = NZB_METHOD


### PR DESCRIPTION
Added new .ini only variable **anon_redirect** with the default set to `http://derefer.me/?`.

> If users want to disable this they can go set the value to "" with SB shutdown.

What this does is prevents your local SB install from appearing in the backlink statistics of another web-page.
There are a whole bunch of link protection / anonymizers out there, just make sure you use the proper URL, it should end with a `?`, if you change the default.
