### PR TITLE
CMD_Shows should return both TVDBID and SHOW_NAME regardless of sort order

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -2360,19 +2360,19 @@ class CMD_Shows(ApiCall):
                         "quality": _get_quality_string(curShow.quality),
                         "language": curShow.lang,
                         "air_by_date": curShow.air_by_date,
+                        "tvdbid": curShow.tvdbid,
                         "tvrage_id": curShow.tvrid,
                         "tvrage_name": curShow.tvrname,
                         "network": curShow.network,
+                        "show_name": curShow.name,
                         "status": curShow.status,
                         "next_ep_airdate": nextAirdate}
             showDict["cache"] = CMD_ShowCache((), {"tvdbid": curShow.tvdbid}).run()["data"]
             if not showDict["network"]:
                 showDict["network"] = ""
             if self.sort == "name":
-                showDict["tvdbid"] = curShow.tvdbid
                 shows[curShow.name] = showDict
             else:
-                showDict["show_name"] = curShow.name
                 shows[curShow.tvdbid] = showDict
         return _responds(RESULT_SUCCESS, shows)
 


### PR DESCRIPTION
If making a search using id i.e. '/api/1234/?cmd=shows&sort=id', the return object yields: 

```
{"data":{ "71489": { "air_by_date": 0... 
```

which makes parsing the data much more difficult than just including the variables in the return object. With the changes provided, it would allow the return object usable without having to parse through and pull out the 'id' or 'show_name' from a loop.

When making an API call, CMD_Shows returns an object of objects thus making grabbing required information difficult to obtain. These modifications would make of the information available.
