### PR TITLE
Set parameter "TV_DOWNLOAD_DIR" as default input value

### DIFF
--- a/data/interfaces/default/home_postprocess.tmpl
+++ b/data/interfaces/default/home_postprocess.tmpl
@@ -8,7 +8,7 @@
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
 <form name="processForm" method="post" action="processEpisode">
-Enter the folder containing the episode: <input type="text" name="dir" id="episodeDir" size="50" /> <input type="submit" class="btn" value="Process" />
+Enter the folder containing the episode: <input type="text" name="dir" id="episodeDir" size="50" value="$sickbeard.TV_DOWNLOAD_DIR"/> <input type="submit" class="btn" value="Process" />
 </form>
 <br />
 


### PR DESCRIPTION
This little change sets the default input value of the "Manual Post-Processing" interface to the TV Download Dir from Post-Processing Settings. This helps doing a quick rescan of the default directory, e.g. after repairing a failed download.
