### PR TITLE
Option to suppress XBMC 'Failed to detect XBMC version' warning messages in log

### DIFF
--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -144,7 +144,7 @@ class XBMCNotifier:
                     if notifyResult:
                         result += curHost + ':' + notifyResult["result"].decode(sickbeard.SYS_ENCODING)
             else:
-                logger.log(u"Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.ERROR)
+                logger.log(u"Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.MESSAGE)
                 result += curHost + ':False'
 
         return result
@@ -506,7 +506,7 @@ class XBMCNotifier:
                                     logger.log(u"Falling back to XBMC full update")
                                     self._update_library_json(curHost)
                 else:
-                    logger.log(u"Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.ERROR)
+                    logger.log(u"Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.MESSAGE)
                     result = result + 1
 
             # needed for the 'update xbmc' submenu command


### PR DESCRIPTION
Many XBMC users configure their devices to sleep/shutdown when not in use. This causes sickbeard to throw warning messages whenever an XBMC update/notification takes place and the XBMC is not reachable. This can quickly fill up the web interfaces log warning page, potentially concealing more important messages and causing the user to repeatedly have to clear their error log.
