### PR TITLE
SB-API - Update

### DIFF
--- a/data/interfaces/default/apiBuilder.tmpl
+++ b/data/interfaces/default/apiBuilder.tmpl
@@ -32,7 +32,6 @@ addListGroup("api", "Command");
 
 addOption("Command", "SickBeard", "?cmd=sb", 1); //make default
 addList("Command", "SickBeard.AddRootDir", "?cmd=sb.addrootdir", "sb.addrootdir", "", "", "action");
-addList("Command", "SickBeard.AnalyzeName", "?cmd=sb.analyzename", "sb.analyzename", "", "", "action");
 addOption("Command", "SickBeard.CheckScheduler", "?cmd=sb.checkscheduler", "", "", "action");
 addList("Command", "SickBeard.DeleteRootDir", "?cmd=sb.deleterootdir", "sb.deleterootdir", "", "", "action");
 addOption("Command", "SickBeard.ForceSearch", "?cmd=sb.forcesearch", "", "", "action");
@@ -339,12 +338,6 @@ addList("sb.addrootdir", "S:\\Invalid_Location", "&location=S:\\Invalid_Location
 addOption("sb.addrootdir-opt", "Optional Param", "", 1);
 addOption("sb.addrootdir-opt", "Default", "&default=1");
 addOption("sb.addrootdir-opt", "Not Default", "&default=0");
-
-addOption("sb.analyzename", "Burn.Notice.S07E12.1080p.WEB-DL.DD5.1.H.264-NTb", "&name=Burn.Notice.S07E12.1080p.WEB-DL.DD5.1.H.264-NTb", 1);
-addOption("sb.analyzename", "Burn.Notice.S07E12.720p.HDTV.x264-EVOLVE", "&name=Burn.Notice.S07E12.720p.HDTV.x264-EVOLVE");
-addOption("sb.analyzename", "Battlestar.Galactica.S01E01.E02.E03.DVDRip.XviD-SFM", "&name=Battlestar.Galactica.S01E01.E02.E03.DVDRip.XviD-SFM");
-addOption("sb.analyzename", "Neighbours.S28E101-E105.WS.PDTV.XviD-FQM", "&name=Neighbours.S28E101-E105.WS.PDTV.XviD-FQM");
-addOption("sb.analyzename", "Jimmy.Fallon.2012.06.07.Chris.Rock.REPACK.720p.HDTV.x264-2HD", "&name=Jimmy.Fallon.2012.06.07.Chris.Rock.REPACK.720p.HDTV.x264-2HD");
 
 addOption("sb.deleterootdir", "C:\\Temp", "&location=C:\\Temp", "", 1);
 addOption("sb.deleterootdir", "/usr/bin", "&location=/usr/bin/");

--- a/data/interfaces/default/apiBuilder.tmpl
+++ b/data/interfaces/default/apiBuilder.tmpl
@@ -32,6 +32,7 @@ addListGroup("api", "Command");
 
 addOption("Command", "SickBeard", "?cmd=sb", 1); //make default
 addList("Command", "SickBeard.AddRootDir", "?cmd=sb.addrootdir", "sb.addrootdir", "", "", "action");
+addList("Command", "SickBeard.AnalyzeName", "?cmd=sb.analyzename", "sb.analyzename", "", "", "action");
 addOption("Command", "SickBeard.CheckScheduler", "?cmd=sb.checkscheduler", "", "", "action");
 addList("Command", "SickBeard.DeleteRootDir", "?cmd=sb.deleterootdir", "sb.deleterootdir", "", "", "action");
 addOption("Command", "SickBeard.ForceSearch", "?cmd=sb.forcesearch", "", "", "action");
@@ -339,6 +340,12 @@ addOption("sb.addrootdir-opt", "Optional Param", "", 1);
 addOption("sb.addrootdir-opt", "Default", "&default=1");
 addOption("sb.addrootdir-opt", "Not Default", "&default=0");
 
+addOption("sb.analyzename", "Burn.Notice.S07E12.1080p.WEB-DL.DD5.1.H.264-NTb", "&name=Burn.Notice.S07E12.1080p.WEB-DL.DD5.1.H.264-NTb", 1);
+addOption("sb.analyzename", "Burn.Notice.S07E12.720p.HDTV.x264-EVOLVE", "&name=Burn.Notice.S07E12.720p.HDTV.x264-EVOLVE");
+addOption("sb.analyzename", "Battlestar.Galactica.S01E01.E02.E03.DVDRip.XviD-SFM", "&name=Battlestar.Galactica.S01E01.E02.E03.DVDRip.XviD-SFM");
+addOption("sb.analyzename", "Neighbours.S28E101-E105.WS.PDTV.XviD-FQM", "&name=Neighbours.S28E101-E105.WS.PDTV.XviD-FQM");
+addOption("sb.analyzename", "Jimmy.Fallon.2012.06.07.Chris.Rock.REPACK.720p.HDTV.x264-2HD", "&name=Jimmy.Fallon.2012.06.07.Chris.Rock.REPACK.720p.HDTV.x264-2HD");
+
 addOption("sb.deleterootdir", "C:\\Temp", "&location=C:\\Temp", "", 1);
 addOption("sb.deleterootdir", "/usr/bin", "&location=/usr/bin/");
 addOption("sb.deleterootdir", "S:\\Invalid_Location", "&location=S:\\Invalid_Location");
@@ -362,6 +369,7 @@ addOption("show.pause-opt", "Pause", "&pause=1");
             <input type="text" size="40" id="apikey" name="apikey" value="$apikey">
             <input type="checkbox" id="debug" class="global"><label for="debug"> Debug?</label>
             <input type="checkbox" id="profile" class="global"><label for="profile"> Profile?</label>
+            <input type="checkbox" id="jsonp" class="global"><label for="jsonp"> JSONP?</label>
             <input type="checkbox" id="help" class="global"><label for="help"> Help?</label>
         </td>
     </tr>

--- a/data/js/apibuilder.js
+++ b/data/js/apibuilder.js
@@ -15,7 +15,13 @@ function goListGroup(apikey, L7, L6, L5, L4, L3, L2, L1){
     $('.global').each(function(){
         var checked = $(this).prop('checked');
         if(checked) {
-            GlobalOptions = GlobalOptions + "&" + $(this).attr('id') + "=1";
+            var globalID = $(this).attr('id');
+            // handle jsonp/callback global option differently
+            if(globalID == "jsonp") {
+                GlobalOptions = GlobalOptions + "&" + globalID + "=foo";
+            } else {
+                GlobalOptions = GlobalOptions + "&" + globalID + "=1";
+            }
         }
     });
 

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -395,7 +395,7 @@ class PostProcessor(object):
                 else:
                     logger.log(u"Nothing was good, found " + repr(test_name) + " and wanted either " + repr(self.nzb_name) + ", " + repr(self.folder_name) + ", or " + repr(self.file_name))
             else:
-                logger.log(u"Parse result not suficent(all folowing have to be set). will not save release name", logger.DEBUG)
+                logger.log(u"Parse result not sufficient(all following have to be set). Will not save release name", logger.DEBUG)
                 logger.log(u"Parse result(series_name): " + str(parse_result.series_name), logger.DEBUG)
                 logger.log(u"Parse result(season_number): " + str(parse_result.season_number), logger.DEBUG)
                 logger.log(u"Parse result(episode_numbers): " + str(parse_result.episode_numbers), logger.DEBUG)

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1622,15 +1622,19 @@ class CMD_SickBeardAnalyzeName(ApiCall):
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):
-        processor = postProcessor.PostProcessor('', self.name)
+
         try:
-            analyzed_name = processor._analyze_name(self.name, file=False)
+            processor = postProcessor.PostProcessor('', self.name)
+            (tvdb, season, episode) = processor._find_info()
+
         except InvalidNameException, e:
             logger.log(u"API :: SickBeardAnalyzeName :: NameParser failed with InvalidNameException: " + repr(e), logger.DEBUG)
             return _responds(RESULT_FAILURE, msg=ex(e))
-        return _responds(RESULT_SUCCESS, data={'tvdbid': analyzed_name[0],
-                                                'season': analyzed_name[1],
-                                                'episodes': analyzed_name[2]})
+
+        return _responds(RESULT_SUCCESS, data={'tvdbid': tvdb,
+                                                'season': season,
+                                                'episodes': episode
+                                                })
 
 
 class CMD_Show(ApiCall):

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -26,7 +26,6 @@ import datetime
 import threading
 import re
 import traceback
-
 import cherrypy
 import sickbeard
 import webserve
@@ -38,8 +37,7 @@ from sickbeard.common import SNATCHED, SNATCHED_PROPER, DOWNLOADED, SKIPPED, UNA
 from common import Quality, qualityPresetStrings, statusStrings
 from sickbeard import image_cache
 from lib.tvdb_api import tvdb_api, tvdb_exceptions
-from sickbeard import postProcessor
-from sickbeard.name_parser.parser import InvalidNameException
+
 try:
     import json
 except ImportError:
@@ -69,7 +67,7 @@ result_type_map = {RESULT_SUCCESS: "success",
 
 class Api:
     """ api class that returns json results """
-    version = 5 # use an int since float-point is unpredictible
+    version = 4 # use an int since float-point is unpredictible
     intent = 4
 
     @cherrypy.expose
@@ -1609,34 +1607,6 @@ class CMD_SickBeardShutdown(ApiCall):
         return _responds(RESULT_SUCCESS, msg="SickBeard is shutting down...")
 
 
-class CMD_SickBeardAnalyzeName(ApiCall):
-    _help = {"desc": "takes a name and tries to figure out a show, season and episode from it.",
-            "requiredParameters": {"name": {"desc": "the name to lookup"}}
-            }
-
-    def __init__(self, args, kwargs):
-        # required
-        self.name, args = self.check_params(args, kwargs, "name", None, True, "string", [])
-        # optional
-        # super, missing, help
-        ApiCall.__init__(self, args, kwargs)
-
-    def run(self):
-
-        try:
-            processor = postProcessor.PostProcessor('', self.name)
-            (tvdb, season, episode) = processor._find_info()
-
-        except InvalidNameException, e:
-            logger.log(u"API :: SickBeardAnalyzeName :: NameParser failed with InvalidNameException: " + repr(e), logger.DEBUG)
-            return _responds(RESULT_FAILURE, msg=ex(e))
-
-        return _responds(RESULT_SUCCESS, data={'tvdbid': tvdb,
-                                                'season': season,
-                                                'episodes': episode
-                                                })
-
-
 class CMD_Show(ApiCall):
     _help = {"desc": "display information for a given show",
              "requiredParameters": {"tvdbid": {"desc": "thetvdb.com unique id of a show"},
@@ -2447,7 +2417,6 @@ _functionMaper = {"help": CMD_Help,
                   "logs": CMD_Logs,
                   "sb": CMD_SickBeard,
                   "sb.addrootdir": CMD_SickBeardAddRootDir,
-                  "sb.analyzename": CMD_SickBeardAnalyzeName,
                   "sb.checkscheduler": CMD_SickBeardCheckScheduler,
                   "sb.deleterootdir": CMD_SickBeardDeleteRootDir,
                   "sb.forcesearch": CMD_SickBeardForceSearch,

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -69,7 +69,7 @@ result_type_map = {RESULT_SUCCESS: "success",
 
 class Api:
     """ api class that returns json results """
-    version = 4 # use an int since float-point is unpredictible
+    version = 5 # use an int since float-point is unpredictible
     intent = 4
 
     @cherrypy.expose
@@ -207,7 +207,6 @@ def call_dispatcher(args, kwargs):
     """
     logger.log(u"API :: all args: '" + str(args) + "'", logger.DEBUG)
     logger.log(u"API :: all kwargs: '" + str(kwargs) + "'", logger.DEBUG)
-    #logger.log(u"API :: dateFormat: '" + str(dateFormat) + "'", logger.DEBUG)
 
     cmds = None
     if args:
@@ -1627,10 +1626,10 @@ class CMD_SickBeardAnalyzeName(ApiCall):
         try:
             analyzed_name = processor._analyze_name(self.name, file=False)
         except InvalidNameException, e:
-            logger.log(u"API :: SickBeardAnalyzeName :: NameParser failed with InvalidNameException: "+ repr(e), logger.DEBUG)
+            logger.log(u"API :: SickBeardAnalyzeName :: NameParser failed with InvalidNameException: " + repr(e), logger.DEBUG)
             return _responds(RESULT_FAILURE, msg=ex(e))
         return _responds(RESULT_SUCCESS, data={'tvdbid': analyzed_name[0],
-                                                'season':  analyzed_name[1],
+                                                'season': analyzed_name[1],
                                                 'episodes': analyzed_name[2]})
 
 
@@ -2444,6 +2443,7 @@ _functionMaper = {"help": CMD_Help,
                   "logs": CMD_Logs,
                   "sb": CMD_SickBeard,
                   "sb.addrootdir": CMD_SickBeardAddRootDir,
+                  "sb.analyzename": CMD_SickBeardAnalyzeName,
                   "sb.checkscheduler": CMD_SickBeardCheckScheduler,
                   "sb.deleterootdir": CMD_SickBeardDeleteRootDir,
                   "sb.forcesearch": CMD_SickBeardForceSearch,
@@ -2456,7 +2456,6 @@ _functionMaper = {"help": CMD_Help,
                   "sb.searchtvdb": CMD_SickBeardSearchTVDB,
                   "sb.setdefaults": CMD_SickBeardSetDefaults,
                   "sb.shutdown": CMD_SickBeardShutdown,
-                  "sb.analyzename": CMD_SickBeardAnalyzeName,
                   "show": CMD_Show,
                   "show.addexisting": CMD_ShowAddExisting,
                   "show.addnew": CMD_ShowAddNew,


### PR DESCRIPTION
Added JSONP callback to the api-builder.
Fix minor spelling mistake in the pp logger.
Remove sb.analyzename for now as it wasn't properly added, and after 'fixing' it (thanks itofzo) there appears to be some possible issues (messes with history) that could come up from misusing the pp for this purpose. Ideally this would need to be properly segmented and handled for the 'test' case scenario.. also it should add the quality for the release? 
