### PR TITLE
Minor updates to the configProviders.js

### DIFF
--- a/data/js/configProviders.js
+++ b/data/js/configProviders.js
@@ -11,24 +11,30 @@ $(document).ready(function(){
                 $(this).hide();
 
         });
-    } 
+    }
 
     $.fn.addProvider = function (id, name, url, key, isDefault) {
 
+        url = $.trim(url);
+        if (!url)
+            return;
+
+        if (!/^https?:\/\//i.test(url))
+            url = "http://" + url;
+
         if (url.match('/$') == null)
-            url = url + '/'
+            url = url + '/';
 
         var newData = [isDefault, [name, url, key]];
         newznabProviders[id] = newData;
 
-        if (!isDefault)
-        {
+        if (!isDefault) {
             $('#editANewznabProvider').addOption(id, name);
             $(this).populateNewznabSection();
         }
 
         if ($('#providerOrderList > #'+id).length == 0) {
-            var toAdd = '<li class="ui-state-default" id="'+id+'"> <input type="checkbox" id="enable_'+id+'" class="provider_enabler" CHECKED> <a href="'+url+'" class="imgLink" target="_new"><img src="'+sbRoot+'/images/providers/newznab.gif" alt="'+name+'" width="16" height="16"></a> '+name+'</li>'
+            var toAdd = '<li class="ui-state-default" id="'+id+'"> <input type="checkbox" id="enable_'+id+'" class="provider_enabler" CHECKED> <a href="'+url+'" class="imgLink" target="_new"><img src="'+sbRoot+'/images/providers/newznab.png" alt="'+name+'" width="16" height="16"></a> '+name+'</li>';
 
             $('#providerOrderList').append(toAdd);
             $('#providerOrderList').sortable("refresh");
@@ -46,11 +52,11 @@ $(document).ready(function(){
         $(this).populateNewznabSection();
 
         $(this).makeNewznabProviderString();
-    
+
     }
 
     $.fn.deleteProvider = function (id) {
-    
+
         $('#editANewznabProvider').removeOption(id);
         delete newznabProviders[id];
         $(this).populateNewznabSection();
@@ -80,7 +86,7 @@ $(document).ready(function(){
         $('#newznab_name').val(data[0]);
         $('#newznab_url').val(data[1]);
         $('#newznab_key').val(data[2]);
-        
+
         if (selectedProvider == 'addNewznab') {
             $('#newznab_name').removeAttr("disabled");
             $('#newznab_url').removeAttr("disabled");
@@ -98,19 +104,19 @@ $(document).ready(function(){
         }
 
     }
-    
+
     $.fn.makeNewznabProviderString = function() {
 
         var provStrings = new Array();
-        
+
         for (var id in newznabProviders) {
             provStrings.push(newznabProviders[id][1].join('|'));
         }
 
-        $('#newznab_string').val(provStrings.join('!!!'))
+        $('#newznab_string').val(provStrings.join('!!!'));
 
     }
-    
+
     $.fn.refreshProviderList = function() {
             var idArr = $("#providerOrderList").sortable('toArray');
             var finalArr = new Array();
@@ -135,21 +141,21 @@ $(document).ready(function(){
         $(this).updateProvider(provider_id, url, key);
 
     });
-    
+
     $('#newznab_key,#newznab_url').change(function(){
-        
+
         var selectedProvider = $('#editANewznabProvider :selected').val();
 
-		if (selectedProvider == "addNewznab")
-			return;
+        if (selectedProvider == "addNewznab")
+            return;
 
         var url = $('#newznab_url').val();
         var key = $('#newznab_key').val();
-        
+
         $(this).updateProvider(selectedProvider, url, key);
-        
+
     });
-    
+
     $('#editAProvider').change(function(){
         $(this).showHideProviders();
     });
@@ -157,22 +163,22 @@ $(document).ready(function(){
     $('#editANewznabProvider').change(function(){
         $(this).populateNewznabSection();
     });
-    
+
     $('.provider_enabler').live('click', function(){
         $(this).refreshProviderList();
-    }); 
-    
+    });
+
 
     $('#newznab_add').click(function(){
-        
+
         var selectedProvider = $('#editANewznabProvider :selected').val();
-        
+
         var name = $('#newznab_name').val();
         var url = $('#newznab_url').val();
         var key = $('#newznab_key').val();
-        
-        var params = { name: name }
-        
+
+        var params = { name: name };
+
         // send to the form with ajax, get a return value
         $.getJSON(sbRoot + '/config/providers/canAddNewznabProvider', params,
             function(data){
@@ -188,7 +194,7 @@ $(document).ready(function(){
     });
 
     $('.newznab_delete').click(function(){
-    
+
         var selectedProvider = $('#editANewznabProvider :selected').val();
 
         $(this).deleteProvider(selectedProvider);


### PR DESCRIPTION
- Check if url for newznab provider being added starts with http|https, if not just add http://.
- Abort adding provider if url is empty.
- Trim leading and trailing spaces from the url for provider before any logic is ran on it.
- Correct extension of default newznab provider image from .gif to .png.
- Added some missing semicolons and cleaned up some trailing spaces in the js file.
