### PR TITLE
404 fix when a custom web_root is used

### DIFF
--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -70,7 +70,7 @@ def initWebServer(options = {}):
         <br/>
     </body>
 </html>
-''' % '/'
+''' % options['web_root']
 
         # cherrypy setup
         enable_https = options['enable_https']


### PR DESCRIPTION
When SB reached an 404 page, and a custom web_root is used, it will always redirect to /, this commit will fix that and use the root from the options.
