### PR TITLE
Remove PID_FILE after successful start-stop-daemon --stop in Debian init script

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -99,11 +99,13 @@ case "$1" in
     stop)
         echo "Stopping $DESC"
         start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+	test x$? = x0 && rm $PID_FILE
         ;;
 
     restart|force-reload)
         echo "Restarting $DESC"
         start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+	test x$? = x0 && rm $PID_FILE
         start-stop-daemon -d $APP_PATH -c $RUN_AS $EXTRA_SSD_OPTS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;
     *)


### PR DESCRIPTION
SickBeard is happy to create its own PID file, but doesn't remove it
when killed by start-stop-daemon(8). Upon being restarted, it find the
previous PID file, assumes it hasn't been stopped properly, and refuses
to restart.

This ini.d script change fixes that, by letting the stratup script
remove the PID file after start-stop-daemon(8) has terminated properly.

At the moment, this fix probably does not handle incorrect terminations
such as power cuts well, as the PID file would still be there at the
next boot, but the SickBeard process obviously not.  This problem would
probably be better fixed by letting SickBeard check whether the PID
recorded in the PID file is still a running SickBeard instance.

Signed-off-by: shtrom-sickbeard@ssji.net <Olivier Mehani>
