### PR TITLE
location path removal off by one (cuts off first character of filename)

### DIFF
--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -160,7 +160,7 @@ Change selected episodes to
     <td align="center" class="nowrap">#if int($epResult["airdate"]) == 1 then "never" else $datetime.date.fromordinal(int($epResult["airdate"]))#</td>
     <td>
 #if $epLoc and $show._location and $epLoc.lower().startswith($show._location.lower()):
-$epLoc[len($show._location)+1:]
+$epLoc[len($show._location):]
 #elif $epLoc and (not $epLoc.lower().startswith($show._location.lower()) or not $show._location):
 $epLoc
 #end if


### PR DESCRIPTION
```
$show._location                  /media/disk1/Someshow/
$epLoc                           /media/disk1/Someshow/Someshow - 1x01 - Test.mp4
$epLoc[len($show._location)+1:]  omeshow - 1x01 - Test.mp4
$epLoc[len($show._location):]    Someshow - 1x01 - Test.mp4
```

This happens on Linux and presumably on other *nix systems, too. No idea if this applies to Windows as well, but I don’t see why it should be different there.
