### PR TITLE
Fix trailing os dir separator

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2424,7 +2424,7 @@ class Home:
                     # change it
                     try:
                         if location.endswith(os.sep):
-                            location = location[:len(location) - 1]
+                            location = location[:-1]
                         showObj.location = location
                         try:
                             sickbeard.showQueueScheduler.action.refreshShow(showObj) #@UndefinedVariable

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2423,6 +2423,8 @@ class Home:
                 elif not do_update:
                     # change it
                     try:
+                        if location.endswith(os.sep):
+                            location = location[:len(location) - 1]
                         showObj.location = location
                         try:
                             sickbeard.showQueueScheduler.action.refreshShow(showObj) #@UndefinedVariable


### PR DESCRIPTION
users are able to include a trailing slash/backslash. This causes `displayShow.tmpl` to eat the first character of the filename of a show. This patch ensures the os dir separator is removed if present.

STR the issue:
1. add an existing show. Note trailing os sep **isn't** present. Say path is `/some/show/test`.
2. Edit show
3. manually edit the location text field to read `/some/show/` (note trailing os sep **is** present)
4. Save

Path now contains a trailing os sep. 
