### PR TITLE
Adding option to order by DVD ordering

### DIFF
--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -72,6 +72,10 @@ Air by date:
 <input type="checkbox" name="air_by_date" #if $show.air_by_date == 1 then "checked=\"checked\"" else ""# /><br />
 (check this if the show is released as Show.03.02.2010 rather than Show.S02E03) 
 <br /><br />
+DVD Order:
+<input type="checkbox" name="dvdorder" #if $show.dvdorder == 1 then "checked=\"checked\"" else ""# /><br/>
+(check this if you wish to use the DVD order instead of the Airing order)
+<br/><br/>
 <input class="btn" type="submit" value="Submit" />
 </form>
 

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -827,6 +827,23 @@ class Tvdb:
                 seas_no = int(cur_ep.find('SeasonNumber').text)
                 ep_no = int(cur_ep.find('EpisodeNumber').text)
 
+            useDVD = False
+
+            if (self.config['dvdorder']):
+                log().debug('DVD Order?  Yes')
+                useDVD = (cur_ep.find('DVD_season').text != None and cur_ep.find('DVD_episodenumber').text != None)
+            else:
+                log().debug('DVD Order? No')
+
+            if (useDVD):
+                log().debug('Use DVD Order? Yes')
+                seas_no = int(cur_ep.find('DVD_season').text)
+                ep_no   = int(float(cur_ep.find('DVD_episodenumber').text))
+            else:
+                log().debug('Use DVD Order? No')
+                seas_no = int(cur_ep.find('SeasonNumber').text)
+                ep_no = int(cur_ep.find('EpisodeNumber').text)
+
             for cur_item in cur_ep.getchildren():
                 tag = cur_item.tag.lower()
                 value = cur_item.text

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -26,7 +26,7 @@ from sickbeard import encodingKludge as ek
 from sickbeard.name_parser.parser import NameParser, InvalidNameException
 
 MIN_DB_VERSION = 9  # oldest db version we support migrating from
-MAX_DB_VERSION = 14
+MAX_DB_VERSION = 15
 
 
 class MainSanityCheck(db.DBSanityCheck):
@@ -421,4 +421,13 @@ class AddLastUpdateTVDB(AddShowidTvdbidIndex):
         if not self.hasColumn("tv_shows", "last_update_tvdb"):
             self.addColumn("tv_shows", "last_update_tvdb", default=1)
 
+        self.incDBVersion()
+
+
+class AddDvdOrderOption(UpgradeHistoryForGenericProviders):
+    def test(self):
+        return self.checkDBVersion() >= 13
+
+    def execute(self):
+        self.connection.action("ALTER TABLE tv_shows ADD dvdorder NUMERIC")
         self.incDBVersion()

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -346,6 +346,9 @@ class GenericMetadata():
             if tvdb_lang and not tvdb_lang == 'en':
                 ltvdb_api_parms['language'] = tvdb_lang
 
+            if ep_obj.show.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
+
             t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
             tvdb_show_obj = t[ep_obj.show.tvdbid]
         except tvdb_exceptions.tvdb_shownotfound, e:
@@ -721,6 +724,9 @@ class GenericMetadata():
             if tvdb_lang and not tvdb_lang == 'en':
                 ltvdb_api_parms['language'] = tvdb_lang
 
+            if show_obj.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
+
             t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
             tvdb_show_obj = t[show_obj.tvdbid]
         except (tvdb_exceptions.tvdb_error, IOError), e:
@@ -757,6 +763,9 @@ class GenericMetadata():
 
             if tvdb_lang and not tvdb_lang == 'en':
                 ltvdb_api_parms['language'] = tvdb_lang
+
+            if ep_obj.show.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
 
             t = tvdb_api.Tvdb(banners=True, **ltvdb_api_parms)
             tvdb_show_obj = t[show_obj.tvdbid]

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -234,6 +234,9 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         if tvdb_lang and not tvdb_lang == 'en':
             ltvdb_api_parms['language'] = tvdb_lang
 
+        if ep_obj.show.dvdorder != 0:
+            ltvdb_api_parms['dvdorder'] = True
+
         t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
 
         tv_node = etree.Element("Series")
@@ -400,6 +403,9 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
             if tvdb_lang and not tvdb_lang == 'en':
                 ltvdb_api_parms['language'] = tvdb_lang
+
+            if ep_obj.show.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
 
             t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
             myShow = t[ep_obj.show.tvdbid]

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -175,6 +175,9 @@ class TIVOMetadata(generic.GenericMetadata):
             if tvdb_lang and not tvdb_lang == 'en':
                 ltvdb_api_parms['language'] = tvdb_lang
 
+            if ep_obj.show.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
+
             t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
             myShow = t[ep_obj.show.tvdbid]
         except tvdb_exceptions.tvdb_shownotfound, e:

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -186,6 +186,9 @@ class WDTVMetadata(generic.GenericMetadata):
             if tvdb_lang and not tvdb_lang == 'en':
                 ltvdb_api_parms['language'] = tvdb_lang
 
+            if ep_obj.show.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
+
             t = tvdb_api.Tvdb(actors=True, **ltvdb_api_parms)
             myShow = t[ep_obj.show.tvdbid]
         except tvdb_exceptions.tvdb_shownotfound, e:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -67,6 +67,7 @@ class TVShow(object):
         self.startyear = 0
         self.paused = 0
         self.air_by_date = 0
+        self.dvdorder = 0
         self.lang = lang
         self.last_update_tvdb = 1
 
@@ -323,6 +324,9 @@ class TVShow(object):
         if self.lang:
             ltvdb_api_parms['language'] = self.lang
 
+        if self.dvdorder != 0:
+            ltvdb_api_parms['dvdorder'] = True
+
         t = tvdb_api.Tvdb(**ltvdb_api_parms)
 
         cachedShow = t[self.tvdbid]
@@ -373,6 +377,9 @@ class TVShow(object):
 
         if self.lang:
             ltvdb_api_parms['language'] = self.lang
+
+        if self.dvdorder != 0:
+            ltvdb_api_parms['dvdorder'] = True
 
         try:
             t = tvdb_api.Tvdb(**ltvdb_api_parms)
@@ -504,6 +511,9 @@ class TVShow(object):
 
                 if self.lang:
                     ltvdb_api_parms['language'] = self.lang
+
+                if self.dvdorder != 0:
+                    ltvdb_api_parms['dvdorder'] = True
 
                 t = tvdb_api.Tvdb(**ltvdb_api_parms)
 
@@ -639,6 +649,10 @@ class TVShow(object):
             if self.air_by_date == None:
                 self.air_by_date = 0
 
+            self.dvdorder = sqlResults[0]["dvdorder"]
+            if self.dvdorder == None:
+                self.dvdorder = 0
+
             self.quality = int(sqlResults[0]["quality"])
             self.flatten_folders = int(sqlResults[0]["flatten_folders"])
             self.paused = int(sqlResults[0]["paused"])
@@ -667,6 +681,9 @@ class TVShow(object):
 
             if self.lang:
                 ltvdb_api_parms['language'] = self.lang
+
+            if self.dvdorder != 0:
+                ltvdb_api_parms['dvdorder'] = True
 
             t = tvdb_api.Tvdb(**ltvdb_api_parms)
 
@@ -810,6 +827,7 @@ class TVShow(object):
                         "flatten_folders": self.flatten_folders,
                         "paused": self.paused,
                         "air_by_date": self.air_by_date,
+                        "dvdorder": self.dvdorder,
                         "startyear": self.startyear,
                         "tvr_name": self.tvrname,
                         "lang": self.lang,
@@ -1104,7 +1122,10 @@ class TVEpisode(object):
                         ltvdb_api_parms['cache'] = False
 
                     if tvdb_lang:
-                            ltvdb_api_parms['language'] = tvdb_lang
+                        ltvdb_api_parms['language'] = tvdb_lang
+
+                    if self.dvdorder != 0:
+                        ltvdb_api_parms['dvdorder'] = True
 
                     t = tvdb_api.Tvdb(**ltvdb_api_parms)
                 else:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2167,7 +2167,7 @@ class Home:
         return result['description'] if result else 'Episode not found.'
 
     @cherrypy.expose
-    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, directCall=False, air_by_date=None, tvdbLang=None):
+    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, directCall=False, air_by_date=None, dvdorder=None, tvdbLang=None):
 
         if show == None:
             errString = "Invalid show ID: " + str(show)
@@ -2199,6 +2199,20 @@ class Home:
 
         paused = config.checkbox_to_value(paused)
         air_by_date = config.checkbox_to_value(air_by_date)
+        if paused == "on":
+            paused = 1
+        else:
+            paused = 0
+
+        if air_by_date == "on":
+            air_by_date = 1
+        else:
+            air_by_date = 0
+
+        if dvdorder == "on":
+            dvdorder = 1
+        else:
+            dvdorder = 0
 
         if tvdbLang and tvdbLang in tvdb_api.Tvdb().config['valid_languages']:
             tvdb_lang = tvdbLang
@@ -2233,6 +2247,7 @@ class Home:
             showObj.paused = paused
             showObj.air_by_date = air_by_date
             showObj.lang = tvdb_lang
+            showObj.dvdorder = dvdorder
 
             # if we change location clear the db of episodes, change it, write to db, and rescan
             if os.path.normpath(showObj._location) != os.path.normpath(location):


### PR DESCRIPTION
This is an important option for TV Shows to allow for returning the results in DVD order instead of Airdate Order. Why is this important? Because many people are ripping their TV shows and using SickBeard to manage them and automatically name and process them.

The change here allows you to add shows like "Batman: The Animated Series" and "Firefly" where the network screwed up the air ordering but fixed it in a subsequent DVD release.

This PR requires a library update: https://github.com/midgetspy/Sick-Beard/pull/743
