### PR TITLE
Update sabToSickBeard.py

### DIFF
--- a/autoProcessTV/sabToSickBeard.py
+++ b/autoProcessTV/sabToSickBeard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/


### PR DESCRIPTION
SAB fails to run this script in environments where python 3 is the default. setting python2.7 in the shebang fixes this issue.
