### PR TITLE
Speed up scrolling

### DIFF
--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -24,7 +24,7 @@
 
 <style type="text/css">
 <!--
-#contentWrapper { background: url("$sbRoot/images/bg.png") repeat fixed 0 0 transparent; }
+#contentWrapper { background: url("$sbRoot/images/bg.png") repeat 0 0 transparent; }
 
 [class^="icon-"], [class*=" icon-"] { background-image: url("$sbRoot/images/glyphicons-halflings.png"); }
 .icon-white { background-image: url("$sbRoot/images/glyphicons-halflings-white.png"); }


### PR DESCRIPTION
I removed the fixed background, as it was causing a full page reflow under Chrome. In particular, this speeds up the scrolling on show pages with lots of episodes. I'm getting repaints of 0.3-0.5 ms instead of 200-300ms, so it's smooth as butter now :+1: 

Was there a reason the background was fixed? It's a very subtle pattern, so I didn't see any reason it should be.
