### PR TITLE
Fix for log file handle remaining open on restarts

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -910,6 +910,7 @@ def saveAndShutdown(restart=False):
             if '--nolaunch' not in popen_list:
                 popen_list += ['--nolaunch']
             logger.log(u"Restarting Sick Beard with " + str(popen_list))
+            logger.close()
             subprocess.Popen(popen_list, cwd=os.getcwd())
 
     os._exit(0)

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -59,6 +59,13 @@ class SBRotatingLogHandler(object):
 
         self.log_lock = threading.Lock()
 
+    def close(self):
+        if self.cur_handler:
+            self.cur_handler.flush()
+            self.cur_handler.close()
+            sb_logger = logging.getLogger('sickbeard')
+            sb_logger.removeHandler(self.cur_handler)
+
     def initLogging(self, consoleLogging=True):
 
         old_handler = None
@@ -189,3 +196,6 @@ sb_log_instance = SBRotatingLogHandler('sickbeard.log', NUM_LOGS, LOG_SIZE)
 
 def log(toLog, logLevel=MESSAGE):
     sb_log_instance.log(toLog, logLevel)
+
+def close():
+    sb_log_instance.close()


### PR DESCRIPTION
Close the log file prior to starting a new subprocess so the log file doesn't remain locked by previous instance.

I've had this issue for a long time in both source and exe builds with windows.  I'm not sure if other OS's have the same problem or not.

To reproduce, just start SB, and restart it from within the UI.  Using process explorer goto the python process for sickbeard and press Ctrl+L, you should see the log file listed twice, if its like this, the log file is locked still by the previous instance.
