### PR TITLE
Correct checking for TV Download Dir deletion

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -117,7 +117,7 @@ def processDir (dirName, nzbName=None, recurse=False):
         if process_result:
 
             if len(videoFiles) == 1 and not sickbeard.KEEP_PROCESSED_DIR and \
-                ek.ek(os.path.normpath, dirName) != ek.ek(os.path.normpath, sickbeard.TV_DOWNLOAD_DIR) and \
+                ek.ek(os.path.realpath, dirName) != ek.ek(os.path.realpath, sickbeard.TV_DOWNLOAD_DIR) and \
                 len(remainingFolders) == 0:
 
                 returnStr += logHelper(u"Deleting folder " + dirName, logger.DEBUG)

--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -22,12 +22,25 @@ import unittest
 
 import test_lib as test
 
-import sys, os.path
+import sys, os.path, os, shutil
 
 from sickbeard.postProcessor import PostProcessor
+
 import sickbeard
 from sickbeard.tv import TVEpisode, TVShow
+from sickbeard.processTV import processDir
 
+def init_shows():
+    show = TVShow(3)
+    show.name = test.SHOWNAME
+    show.location = test.SHOWDIR
+    show.saveToDB()
+
+    sickbeard.showList = [show]
+    ep = TVEpisode(show, test.SEASON, test.EPISODE)
+    ep.name = "some ep name"
+    ep.saveToDB()
+    return (show, ep)
 
 class PPInitTests(unittest.TestCase):
 
@@ -78,19 +91,34 @@ class PPPrivateTests(test.SickbeardTestDBCase):
         ecpectedPath = os.path.join(test.FILEDIR, "Season 0" + str(test.SEASON))
         self.assertEqual(calculatedPath, ecpectedPath)
 
+    def test_do_not_delete_tv_download_dir(self):
+        TEST_DOWNLOAD_DIR = u"tv_download_dir"
+        TEST_DOWNLOAD_DIR_LINK = u"tv_download_dir_link"
+        TEST_NEW_EP_FILE = u"show name - s01e010.mkv"
+
+        (show, ep) = init_shows()
+
+        old_download_dir = sickbeard.TV_DOWNLOAD_DIR
+        sickbeard.TV_DOWNLOAD_DIR = TEST_DOWNLOAD_DIR_LINK
+        if(os.path.exists(TEST_DOWNLOAD_DIR_LINK)):
+            os.remove(TEST_DOWNLOAD_DIR_LINK)
+        if(os.path.exists(TEST_DOWNLOAD_DIR)):
+            shutil.rmtree(TEST_DOWNLOAD_DIR)
+        os.mkdir(TEST_DOWNLOAD_DIR)
+        os.symlink(TEST_DOWNLOAD_DIR, TEST_DOWNLOAD_DIR_LINK)
+        open(os.path.join(TEST_DOWNLOAD_DIR_LINK, TEST_NEW_EP_FILE), "a").close()
+        processDir(TEST_DOWNLOAD_DIR_LINK)
+
+        sickbeard.TV_DOWNLOAD_DIR = old_download_dir
+        self.assertTrue(os.path.exists(TEST_DOWNLOAD_DIR))
+
+        shutil.rmtree(TEST_DOWNLOAD_DIR)
+        os.remove(TEST_DOWNLOAD_DIR_LINK)
 
 class PPBasicTests(test.SickbeardTestDBCase):
 
     def test_process(self):
-        show = TVShow(3)
-        show.name = test.SHOWNAME
-        show.location = test.SHOWDIR
-        show.saveToDB()
-
-        sickbeard.showList = [show]
-        ep = TVEpisode(show, test.SEASON, test.EPISODE)
-        ep.name = "some ep name"
-        ep.saveToDB()
+        (show, ep) = init_shows()
 
         pp = PostProcessor(test.FILEPATH)
         self.assertTrue(pp.process())


### PR DESCRIPTION
I've noticed that when TV download dir set up in Post-Processing settings is a symbolic link and a single downloaded episode file is processed, my download directory gets deleted. Fix is rather straightforward and makes sure that real paths are compared, not only the canonical forms of directory paths.

P.S.
Sorry for submitting this to master first. I've totally missed the code submission guidelines.
