### PR TITLE
Make Sickbeard work properly behind a proxy.

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -112,6 +112,7 @@ ANON_REDIRECT = None
 USE_API = False
 API_KEY = None
 
+BEHIND_PROXY = False
 ENABLE_HTTPS = False
 HTTPS_CERT = None
 HTTPS_KEY = None
@@ -313,7 +314,7 @@ def initialize(consoleLogging=True):
 
     with INIT_LOCK:
 
-        global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
+        global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, BEHIND_PROXY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
@@ -384,6 +385,7 @@ def initialize(consoleLogging=True):
         USE_API = bool(check_setting_int(CFG, 'General', 'use_api', 0))
         API_KEY = check_setting_str(CFG, 'General', 'api_key', '')
 
+        BEHIND_PROXY = bool(check_setting_int(CFG, 'General', 'behind_proxy', 0))
         ENABLE_HTTPS = bool(check_setting_int(CFG, 'General', 'enable_https', 0))
         HTTPS_CERT = check_setting_str(CFG, 'General', 'https_cert', 'server.crt')
         HTTPS_KEY = check_setting_str(CFG, 'General', 'https_key', 'server.key')
@@ -987,6 +989,7 @@ def save_config():
     new_config['General']['anon_redirect'] = ANON_REDIRECT
     new_config['General']['use_api'] = int(USE_API)
     new_config['General']['api_key'] = API_KEY
+    new_config['General']['behind_proxy'] = int(BEHIND_PROXY)
     new_config['General']['enable_https'] = int(ENABLE_HTTPS)
     new_config['General']['https_cert'] = HTTPS_CERT
     new_config['General']['https_key'] = HTTPS_KEY

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -112,6 +112,7 @@ def initWebServer(options={}):
         'tools.gzip.mime_types': mime_gzip,
         'error_page.401': http_error_401_hander,
         'error_page.404': http_error_404_hander,
+        'tools.proxy.on': sickbeard.BEHIND_PROXY,
     }
 
     if enable_https:


### PR DESCRIPTION
Adds a configuration option BEHIND_PROXY, without exposing it in the UI.

This is only a halfway implementation, it could be argued to leave this always on, or it could be argued to check for this option before headers in PageTemplate, please advise on how to proceed.
