### PR TITLE
Sets a processtitle for Sickbeard, if module is available.

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -204,6 +204,15 @@ def main():
     # Need console logging for SickBeard.py and SickBeard-console.exe
     consoleLogging = (not hasattr(sys, "frozen")) or (sickbeard.MY_NAME.lower().find('-console') > 0)
 
+    try:
+        from setproctitle import setproctitle
+    except ImportError:
+        if consoleLogging:
+            sys.stderr.write(u"setproctitle module is not available.\n")
+        setproctitle = lambda t: None
+
+    setproctitle(sickbeard.MY_NAME)
+
     # Rename the main thread
     threading.currentThread().name = "MAIN"
 


### PR DESCRIPTION
This is useful to distinguish Sickbeard from other processes running python, where several such are available.

Implemented to only give a warning if the appropriate module is not available.
