### PR TITLE
Add require/ignore words per show

### DIFF
--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -72,6 +72,17 @@ Air by date:
 <input type="checkbox" name="air_by_date" #if $show.air_by_date == 1 then "checked=\"checked\"" else ""# /><br />
 (check this if the show is released as Show.03.02.2010 rather than Show.S02E03) 
 <br /><br />
+
+Separate words with a comma, e.g. "word1,word2,word3"<br/><br/>
+
+Ignored Words: <input type="text" name="rls_ignore_words" id="rls_ignore_words" value="$show.rls_ignore_words" size="50" /><br />
+Results with any of these words in the title will be filtered out
+<br /><br />
+
+Required Words: <input type="text" name="rls_require_words" id="rls_require_words" value="$show.rls_require_words" size="50" /><br />
+Results without these words in the title will be filtered out 
+<br /><br />
+
 <input class="btn" type="submit" value="Submit" />
 </form>
 

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -150,7 +150,7 @@ class ProperFinder():
                 continue
 
             if not show_name_helpers.filterBadReleases(curProper.name):
-                logger.log(u"Proper " + curProper.name + " isn't a valid scene release that we want, igoring it", logger.DEBUG)
+                logger.log(u"Proper " + curProper.name + " isn't a valid scene release that we want, ignoring it", logger.DEBUG)
                 continue
 
             # if we have an air-by-date show then get the real season/episode numbers

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -256,6 +256,8 @@ class QueueItemAdd(ShowQueueItem):
             # be smartish about this
             if self.show.genre and "talk show" in self.show.genre.lower():
                 self.show.air_by_date = 1
+            if self.show.genre and "documentary" in self.show.genre.lower():
+                self.show.air_by_date = 0
 
         except tvdb_exceptions.tvdb_exception, e:
             logger.log(u"Unable to add show due to an error with TVDB: " + ex(e), logger.ERROR)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -70,6 +70,9 @@ class TVShow(object):
         self.lang = lang
         self.last_update_tvdb = 1
 
+        self.rls_ignore_words = ""
+        self.rls_require_words = ""
+
         self.lock = threading.Lock()
         self._isDirGood = False
 
@@ -655,6 +658,9 @@ class TVShow(object):
 
             self.last_update_tvdb = sqlResults[0]["last_update_tvdb"]
 
+            self.rls_ignore_words = sqlResults[0]["rls_ignore_words"]
+            self.rls_require_words = sqlResults[0]["rls_require_words"]
+
     def loadFromTVDB(self, cache=True, tvapi=None, cachedSeason=None):
 
         logger.log(str(self.tvdbid) + u": Loading show info from theTVDB")
@@ -815,7 +821,9 @@ class TVShow(object):
                         "startyear": self.startyear,
                         "tvr_name": self.tvrname,
                         "lang": self.lang,
-                        "last_update_tvdb": self.last_update_tvdb
+                        "last_update_tvdb": self.last_update_tvdb,
+                        "rls_ignore_words": self.rls_ignore_words,
+                        "rls_require_words": self.rls_require_words
                         }
 
         myDB.upsert("tv_shows", newValueDict, controlValueDict)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2158,7 +2158,7 @@ class Home:
         return result['description'] if result else 'Episode not found.'
 
     @cherrypy.expose
-    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, directCall=False, air_by_date=None, tvdbLang=None):
+    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, directCall=False, air_by_date=None, tvdbLang=None, rls_ignore_words=None, rls_require_words=None):
 
         if show == None:
             errString = "Invalid show ID: " + str(show)
@@ -2224,6 +2224,9 @@ class Home:
             showObj.paused = paused
             showObj.air_by_date = air_by_date
             showObj.lang = tvdb_lang
+
+            showObj.rls_ignore_words = rls_ignore_words
+            showObj.rls_require_words = rls_require_words
 
             # if we change location clear the db of episodes, change it, write to db, and rescan
             if os.path.normpath(showObj._location) != os.path.normpath(location):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2220,11 +2220,13 @@ class Home:
                     errors.append("Unable to refresh this show: " + ex(e))
 
             showObj.paused = paused
-            showObj.air_by_date = air_by_date
-            showObj.lang = tvdb_lang
 
-            showObj.rls_ignore_words = rls_ignore_words
-            showObj.rls_require_words = rls_require_words
+            # if this routine was called via the mass edit, do not change the options that are not passed
+            if not directCall:
+                showObj.air_by_date = air_by_date
+                showObj.lang = tvdb_lang
+                showObj.rls_ignore_words = rls_ignore_words.strip()
+                showObj.rls_require_words = rls_require_words.strip()
 
             # if we change location clear the db of episodes, change it, write to db, and rescan
             if os.path.normpath(showObj._location) != os.path.normpath(location):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2186,8 +2186,6 @@ class Home:
             return _munge(t)
 
         flatten_folders = config.checkbox_to_value(flatten_folders)
-        logger.log(u"flatten folders: " + str(flatten_folders))
-
         paused = config.checkbox_to_value(paused)
         air_by_date = config.checkbox_to_value(air_by_date)
 


### PR DESCRIPTION
Some example cases, note these are PER show:
- Now you could block `webrip` while still getting `web-dl`.
- Now you could seek a specific's groups release like `QRUS` or block `mSD`.
- Now you could set it to grab HD but only if it has `DD5` audio.
- Now you could grab those Top Gear `VFR` (variable frame rate) releases specifically.
- Now you could grab the `Uncut` or `XL` versions of a show (since TVDB does not allow 'duplicate' shows).

Do note that the ignore word logic comes before required words. So be careful on what you ignore. The words are not case sensitive, and if you use multiple words then a release will be rejected if ANY match.

Also the require word logic comes before the proper/repack, this is so that you don't have a proper/repack for (the non uncut / non xl / non vfr) wrong releases that your specifically seeking. If you use multiple require words, ALL of them must be found otherwise it gets rejected.
