### PR TITLE
iOS standalone mobile app links fix

### DIFF
--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -6,6 +6,32 @@
         <title>Sick Beard - alpha $sickbeard.version.SICKBEARD_VERSION - $title</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <meta name="robots" content="noindex">
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <script type="text/javascript">
+            // Mobile Safari in standalone mode
+            if(("standalone" in window.navigator) && window.navigator.standalone){
+         
+                // If you want to prevent remote links in standalone web apps opening Mobile Safari, change 'remotes' to true
+                var noddy, remotes = false;
+            
+                document.addEventListener('click', function(event) {
+                
+                    noddy = event.target;
+                
+                    // Bubble up until we hit link or top HTML element. Warning: BODY element is not compulsory so better to stop on HTML
+                    while(noddy.nodeName !== "A" && noddy.nodeName !== "HTML") {
+                        noddy = noddy.parentNode;
+                    }
+                
+                    if('href' in noddy && noddy.href.indexOf('http') !== -1 && (noddy.href.indexOf(document.location.host) !== -1 || remotes))
+                    {
+                        event.preventDefault();
+                        document.location.href = noddy.href;
+                    }
+            
+                },false);
+            }
+        </script>
         <!--[if lt IE 9]>
             <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
         <![endif]-->


### PR DESCRIPTION
When viewing Sickbeard from iOS as a standalone mobile app, clicking on links in the Sickbeard menu will leave the mobile app and open the link in Safari.

This fix makes it so that all links clicked will stay in the standalone mobile app, making it actually usable.

This code is taken from https://gist.github.com/kylebarrow/1042026/
