### PR TITLE
Fix scene exceptions URL

### DIFF
--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -72,7 +72,7 @@ def retrieve_exceptions():
     query_list = []
 
     # remote exceptions are stored on github pages
-    url = 'http://midgetspy.github.com/sb_tvdb_scene_exceptions/exceptions.txt'
+    url = 'http://midgetspy.github.io/sb_tvdb_scene_exceptions/exceptions.txt'
 
     logger.log(u"Check scene exceptions update")
 


### PR DESCRIPTION
URL was pointing to old github.com domain. Pointed towards .io
domain.
