### PR TITLE
Add 'promo' to default set of IGNORE_WORDS

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -299,7 +299,7 @@ EXTRA_SCRIPTS = []
 
 GIT_PATH = None
 
-IGNORE_WORDS = "german,french,core2hd,dutch,swedish,480p"
+IGNORE_WORDS = "german,french,core2hd,dutch,swedish,480p,promo"
 
 __INITIALIZED__ = False
 


### PR DESCRIPTION
Recently various NZB indexers have been adding promo/preview ads for shows earlier in the week (eg: Saturday Night Live). SickBeard tends to grab these promotions rather than the actual episode even when searching. Add 'promo' as a default IGNORE_WORDS string to avoid this problem.
