### PR TITLE
Set TV processor to ignore the '_unpack' folder

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -142,6 +142,8 @@ def processDir(dirName, nzbName=None, method=None, recurse=False, pp_options={})
 
         if helpers.is_hidden_folder(cur_folder):
             returnStr += logHelper(u"Ignoring hidden folder: " + cur_folder, logger.DEBUG)
+        elif cur_folder.startswith('_unpack'):
+            returnStr += logHelper(u"Ignoring _unpack folder: " + cur_folder, logger.DEBUG)
         else:
             returnStr += logHelper(u"Recursively processing a folder: " + cur_folder, logger.DEBUG)
             returnStr += processDir(cur_folder, nzbName=parent_nzbName, recurse=True, method=method, pp_options=pp_options)


### PR DESCRIPTION
When downloading with NZBGet it utilises a _unpack folder when
extracting RAR files and therefore these files are not complete.

This diff simply sets the processor to ignore any folders that have
'_unpack' at the start of the folder name.

This was raised off the back of
https://code.google.com/p/sickbeard/issues/detail?id=2453
