### PR TITLE
tvdb_api update

### DIFF
--- a/lib/tvdb_api/readme.md
+++ b/lib/tvdb_api/readme.md
@@ -63,7 +63,7 @@ For example, to find out what network Scrubs is aired:
 The data is stored in an attribute named `data`, within the Show instance:
 
     >>> t['scrubs'].data.keys()
-    ['networkid', 'rating', 'airs_dayofweek', 'contentrating', 'seriesname', 'id', 'airs_time', 'network', 'fanart', 'lastupdated', 'actors', 'ratingcount', 'status', 'added', 'poster', 'imdb_id', 'genre', 'banner', 'seriesid', 'language', 'zap2it_id', 'addedby', 'firstaired', 'runtime', 'overview']
+    ['networkid', 'rating', 'airs_dayofweek', 'contentrating', 'seriesname', 'id', 'airs_time', 'network', 'fanart', 'lastupdated', 'actors', 'ratingcount', 'status', 'added', 'poster', 'imdb_id', 'genre', 'banner', 'seriesid', 'language', 'zap2it_id', 'addedby', 'tms_wanted', 'firstaired', 'runtime', 'overview']
 
 Although each element is also accessible via `t['scrubs']` for ease-of-use:
 

--- a/lib/tvdb_api/tests/test_tvdb_api.py
+++ b/lib/tvdb_api/tests/test_tvdb_api.py
@@ -99,6 +99,10 @@ class test_tvdb_basic(unittest.TestCase):
             show
         )
 
+    def test_no_season(self):
+        show = self.t['Katekyo Hitman Reborn']
+        print tvdb_api
+        print show[1][1]
 
 class test_tvdb_errors(unittest.TestCase):
     # Used to store the cached instance of Tvdb()


### PR DESCRIPTION
- Skip episodes which are missing SeasonNumber or Episode Number (or DVD_season or DVD_episodenumber)
- Avoid excessive calls to the ShowContainer garbage collection
- fix ShowContainer cache resizing
