### PR TITLE
fix compatibility issues when migrating towards jquery 1.9.x. & browser update

### DIFF
--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -130,7 +130,7 @@ Change selected episodes to
 #for $epResult in $sqlResults:
 
     #if int($epResult["season"]) != $curSeason:
-  <tr><td colspan="9"><a name="season-$epResult["season"]"></a></td></tr>
+  <tr class="seasonheader"><td colspan="9"><a name="season-$epResult["season"]"></a></td></tr>
   <tr class="seasonheader" id="season-$epResult["season"]">
     <td colspan="9">
         <h2>#if int($epResult["season"]) == 0 then "Specials" else "Season "+str($epResult["season"])#</h2>
@@ -138,7 +138,7 @@ Change selected episodes to
   </tr>
   <tr id="season-$epResult["season"]-cols"><th width="1%"><input type="checkbox" class="seasonCheck" id="$epResult["season"]" /></th><th>NFO</th><th>TBN</th><th>Episode</th><th>Name</th><th class="nowrap">Airdate</th><th>Filename</th><th>Status</th><th>Search</th></tr>
         #set $curSeason = int($epResult["season"])
-    #end if    
+    #end if
 
   #set $epStr = str($epResult["season"]) + "x" + str($epResult["episode"])
   #set $epLoc = $epResult["location"]

--- a/data/js/addExistingShow.js
+++ b/data/js/addExistingShow.js
@@ -1,15 +1,15 @@
 $(document).ready(function() { 
 
-    $('#checkAll').live('click', function(){
+    $('#tableDiv').on('click', '#checkAll', function() {
 
         var seasCheck = this;
 
-        $('.dirCheck').each(function(){
+        $('.dirCheck').each(function() {
             this.checked = seasCheck.checked;
         });
     });
 
-    $('#submitShowDirs').click(function(){
+    $('#submitShowDirs').click(function() {
 
         var dirArr = new Array();
 
@@ -35,7 +35,7 @@ $(document).ready(function() {
 
     function loadContent() {
         var url = '';
-        $('.dir_check').each(function(i,w){
+        $('.dir_check').each(function(i,w) {
             if ($(w).is(':checked')) {
                 if (url.length) {
                     url += '&';
@@ -72,10 +72,12 @@ $(document).ready(function() {
         loadContent();
     });
 
-    $('.dir_check').live('click', loadContent);
+    $('#rootDirStaticList').on('click', '.dir_check', loadContent);
 
-    $('.showManage').live('click', function() {
-        $("#tabs").tabs( 'select', 0);
+    $('#tableDiv').on('click', '.showManage', function(event) {
+        event.preventDefault();
+        $("#tabs").tabs('option', 'active', 0);
+        $('html,body').animate({scrollTop:0}, 1000);
     });
 
 });

--- a/data/js/browser.js
+++ b/data/js/browser.js
@@ -34,6 +34,8 @@
                 return i++ != 0;
             });
             $('<h2>').text(first_val.current_path).appendTo(fileBrowserDialog);
+            // set current path to what we path we actually did load (in case the previous dir is no longer there)
+            currentBrowserPath = first_val.current_path;
             list = $('<ul>').appendTo(fileBrowserDialog);
             $.each(data, function (i, entry) {
                 link = $("<a href='javascript:void(0)' />").click(function () { browse(entry.path, endpoint); }).text(entry.name);
@@ -92,6 +94,10 @@
         var initialDir = '';
         if (options.initialDir) {
             initialDir = options.initialDir;
+        }
+        // HACK to allow users to specify \\server\path to override use of stored values
+        if (options.field && options.field.val().indexOf('\\') == 0) {
+            initialDir = options.field.val()
         }
         browse(initialDir, options.url);
         fileBrowserDialog.dialog('open');

--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -198,7 +198,7 @@ $(document).ready(function () {
             if (data == null) {
                 $("#nmjv2_database").removeAttr("readonly");
             }
-            var JSONData = $.parseJSON(data);
+            var JSONData = $.parseJSON(data || "null");
             $("#testNMJv2-result").html(JSONData.message);
             $("#nmjv2_database").val(JSONData.database);
 

--- a/data/js/configProviders.js
+++ b/data/js/configProviders.js
@@ -92,18 +92,18 @@ $(document).ready(function(){
         $('#newznab_key').val(data[2]);
 
         if (selectedProvider == 'addNewznab') {
-            $('#newznab_name').removeAttr("disabled");
-            $('#newznab_url').removeAttr("disabled");
+            $('#newznab_name').prop("disabled", false);
+            $('#newznab_url').prop("disabled", false);
         } else {
 
-            $('#newznab_name').attr("disabled", "disabled");
+            $('#newznab_name').prop("disabled", true);
 
             if (isDefault) {
-                $('#newznab_url').attr("disabled", "disabled");
-                $('#newznab_delete').attr("disabled", "disabled");
+                $('#newznab_url').prop("disabled", true);
+                $('#newznab_delete').prop("disabled", true);
             } else {
-                $('#newznab_url').removeAttr("disabled");
-                $('#newznab_delete').removeAttr("disabled");
+                $('#newznab_url').prop("disabled", false);
+                $('#newznab_delete').prop("disabled", false);
             }
         }
 
@@ -161,15 +161,15 @@ $(document).ready(function(){
 
     });
 
-    $('#editAProvider').change(function(){
+    $('#editAProvider').change(function() {
         $(this).showHideProviders();
     });
 
-    $('#editANewznabProvider').change(function(){
+    $('#editANewznabProvider').change(function() {
         $(this).populateNewznabSection();
     });
 
-    $('.provider_enabler').live('click', function(){
+    $('#providerOrderList').on('click', '.provider_enabler', function() {
         $(this).refreshProviderList();
     });
 

--- a/data/js/displayShow.js
+++ b/data/js/displayShow.js
@@ -14,9 +14,9 @@ $(document).ready(function(){
     $("#prevShow").click(function() {
         var show = $('#pickShow option:selected');
         if (show.prev('option').length < 1){
-            show.parent().children('option:last').attr('selected', 'selected');
+            show.parent().children('option:last').prop('selected', true);
         } else{
-            show.prev('option').attr('selected', 'selected');
+            show.prev('option').prop('selected', true);
         }
         $("#pickShow").change();
     });
@@ -24,9 +24,9 @@ $(document).ready(function(){
     $("#nextShow").click(function() {
         var show = $('#pickShow option:selected');
         if (show.next('option').length < 1) {
-            show.parent().children('option:first').attr('selected', 'selected');
+            show.parent().children('option:first').prop('selected', true);
         } else{
-            show.next('option').attr('selected', 'selected');
+            show.next('option').prop('selected', true);
         }
         $("#pickShow").change();
     });
@@ -113,7 +113,7 @@ $(document).ready(function(){
     // handle the show selection dropbox
     $('#pickShow').change(function() {
         var sbRoot = $('#sbRoot').val();
-        var val = $(this).attr('value');
+        var val = $(this).val();
         if (val == 0) {
             return;
         }

--- a/data/js/newShow.js
+++ b/data/js/newShow.js
@@ -187,14 +187,14 @@ $(document).ready(function () {
         // also toggle the add show button
         if (($("#rootDirs option:selected").length || ($('#fullShowPath').length && $('#fullShowPath').val().length)) &&
             ($('input:radio[name=whichSeries]:checked').length) || ($('input:hidden[name=whichSeries]').length && $('input:hidden[name=whichSeries]').val().length)) {
-            $('#addShowButton').attr('disabled', false);
+            $('#addShowButton').prop('disabled', false);
         } else {
-            $('#addShowButton').attr('disabled', true);
+            $('#addShowButton').prop('disabled', true);
         }
     }
 
     $('#rootDirText').change(updateSampleText);
-    $('#whichSeries').live('change', updateSampleText);
+    $('#searchResults').on('change', '#whichSeries', updateSampleText);
 
     $('#nameToSearch').keyup(function (event) {
         if (event.keyCode == 13) {

--- a/data/js/qualityChooser.js
+++ b/data/js/qualityChooser.js
@@ -10,18 +10,18 @@ $(document).ready(function() {
         $('#anyQualities option').each(function(i) {
             var result = preset & $(this).val();
             if (result > 0) {
-                $(this).attr('selected', 'selected');
+                $(this).prop('selected', true);
             } else {
-                $(this).attr('selected', false);
+                $(this).prop('selected', false);
             }
         });
 
         $('#bestQualities option').each(function(i) {
             var result = preset & ($(this).val() << 16);
             if (result > 0) {
-                $(this).attr('selected', 'selected');
+                $(this).prop('selected', true);
             } else {
-                $(this).attr('selected', false);
+                $(this).prop('selected', false);
             }
         });
 

--- a/data/js/rootDirs.js
+++ b/data/js/rootDirs.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
             is_default = true;
         }
 
-        $('#rootDirs').append('<option value="'+path+'">'+path+'</option>');
+        $('#rootDirs').append('<option value="' + path + '">' + path + '</option>');
 
         syncOptionIDs();
 


### PR DESCRIPTION
fix compatibility issues when migrating towards jquery 1.9.x.
- update parseJSON to fallback to null if none passed.
- convert deprecated `.live()` to `.on()`
- convert using `.attr()` to `.prop()` for boolean properties
- fix addShows manage directories link
- fix displayShow to include spacer when all episodes in season are hidden

Tweak browser.js
- set current path to what we path we actually did load, in case the previous dir is no longer there (ex: load parent folder instead)
- add hack that allows users to specify `\\server\path` for location and have it override the internal initalDir browse path
