### PR TITLE
Limit air-by-date searches to in-season eps.

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -313,7 +313,7 @@ class GenericProvider:
                     continue
 
                 myDB = db.DBConnection()
-                sql_results = myDB.select("SELECT season, episode FROM tv_episodes WHERE showid = ? AND airdate = ?", [show.tvdbid, parse_result.air_date.toordinal()])
+                sql_results = myDB.select("SELECT season, episode FROM tv_episodes WHERE season != 0 AND showid = ? AND airdate = ?", [show.tvdbid, parse_result.air_date.toordinal()])
 
                 if len(sql_results) != 1:
                     logger.log(u"Tried to look up the date for the episode " + title + " but the database didn't give proper results, skipping it", logger.WARNING)


### PR DESCRIPTION
If searching for air-by-date episodes, limit the DB search to Seasons only (not Specials). Occasionally air-by-date's have a special same day as an ep. This breaks the search.

eg. [Last Week Tonight with John Oliver](http://thetvdb.com/?tab=series&id=278518) Episode 1, Date 2014-04-27 conflicts with a Special on the same day. 
