### PR TITLE
Added missing pid parameter to shutdown url

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -77,7 +77,7 @@ verify_sickbeard_pid() {
 sickbeard_stop() {
     echo "Stopping $name"
     verify_sickbeard_pid
-    ${WGET} -O - -q --user=${sickbeard_web_user} --password=${sickbeard_web_password} "http://${sickbeard_host}:${sickbeard_port}/home/shutdown/" >/dev/null
+    ${WGET} -O - -q --user=${sickbeard_web_user} --password=${sickbeard_web_password} "http://${sickbeard_host}:${sickbeard_port}/home/shutdown/?pid=${pid}" >/dev/null
     if [ -n "${pid}" ]; then
       wait_for_pids ${pid}
       echo "Stopped"


### PR DESCRIPTION
init.freebsd:

The current shutdown url doesn't pass the process ID and doesn't work. This patch adds the pid parameter.
