### PR TITLE
Prepare init.freebsd for FreeBSD port

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -17,6 +17,8 @@
 #			Default: /usr/local/sickbeard
 # sickbeard_chdir:  Change to this directory before running Sick Beard.
 #     Default is same as sickbeard_dir.
+# sickbeard_datadir:  Data directory for Sick Beard (DB, Logs, config)
+#     Default is same as sickbeard_chdir
 # sickbeard_pid:  The name of the pidfile to create.
 #     Default is sickbeard.pid in sickbeard_dir.
 # sickbeard_host: The hostname or IP Sick Beard is listening on
@@ -27,6 +29,8 @@
 #     Default is an empty string (no username)
 # sickbeard_web_password: Password to authenticate to the Sick Beard web interface
 #     Default is an empty string (no password)
+# sickbeard_webroot: Set to value of web_root in config (for proxies etc)
+#     Default is an empty string (if set must start with a "/")
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin"
 
 . /etc/rc.subr
@@ -40,13 +44,13 @@ load_rc_config ${name}
 : ${sickbeard_user:="_sabnzbd"}
 : ${sickbeard_dir:="/usr/local/sickbeard"}
 : ${sickbeard_chdir:="${sickbeard_dir}"}
+: ${sickbeard_datadir}:="${sickbeard_chdir}"}
 : ${sickbeard_pid:="${sickbeard_dir}/sickbeard.pid"}
 : ${sickbeard_host:="127.0.0.1"}
 : ${sickbeard_port:="8081"}
 : ${sickbeard_web_user:=""}
 : ${sickbeard_web_password:=""}
-
-WGET="/usr/local/bin/wget" # You need wget for this script to safely shutdown Sick Beard.
+: ${sickbeard_webroot:=""}
 
 status_cmd="${name}_status"
 stop_cmd="${name}_stop"
@@ -54,11 +58,9 @@ stop_cmd="${name}_stop"
 command="/usr/sbin/daemon"
 command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py --quiet --nolaunch"
 
-# Check for wget and refuse to start without it.
-if [ ! -x "${WGET}" ]; then
-  warn "Sickbeard not started: You need wget to safely shut down Sick Beard."
-  exit 1
-fi
+# Add datadir to the command if set
+[ ! -z "${sickbeard_datadir}" ] && \
+  command_args="${command_args} --datadir ${sickbeard_datadir}"
 
 # Ensure user is root when running this script.
 if [ `id -u` != "0" ]; then
@@ -77,7 +79,12 @@ verify_sickbeard_pid() {
 sickbeard_stop() {
     echo "Stopping $name"
     verify_sickbeard_pid
-    ${WGET} -O - -q --user=${sickbeard_web_user} --password=${sickbeard_web_password} "http://${sickbeard_host}:${sickbeard_port}/home/shutdown/" >/dev/null
+    sickbeard_url="${sickbeard_host}:${sickbeard_port}"
+    [ ! -z "${sickbeard_web_user}" ] && \
+       sickbeard_url="${sickbeard_web_user}:${sickbeard_web_password}@${sickbeard_url}"
+    [ ! -z "${sickbeard_webroot}" ] && \
+       sickbeard_url="${sickbeard_url}${sickbeard_webroot}"
+    fetch -o - -q "http://${sickbeard_url}/home/shutdown/?pid=${pid}" >/dev/null
     if [ -n "${pid}" ]; then
       wait_for_pids ${pid}
       echo "Stopped"
@@ -89,4 +96,3 @@ sickbeard_status() {
 }
 
 run_rc_command "$1"
-


### PR DESCRIPTION
- Add datadir option (separate app from data)
- Add webroot option (for proxied setups)
- Remove wget dependency
  - fetch supports RFC1738 Common Internet Scheme Syntax http://user:pass@host:port/path?querystring
  - appending pid=PID works reliably, also with user:pass
