### PR TITLE
Fix ordering for shows with 500+ episodes. Now it works for up to 500k.

### DIFF
--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -60,7 +60,7 @@
         if (parseInt(nums[0]) === 0)
             return parseInt(nums[1]);
 
-        var finalNum = parseInt((nums[0]/nums[1])*1000)*100;
+        var finalNum = parseInt((nums[0]/nums[1])*1000000)*100;
         if (finalNum > 0)
             finalNum += parseInt(nums[0]);
 


### PR DESCRIPTION
The "Downloads" ordering works by taking the percentage of episodes downloaded vs non downloaded, but it needs to transform this into a integer, previously it was being multiplied by 1000, but that's not enough to sort shows with 500+ episodes, like Simpsons, SNL, etc.

So I changed it to multiply by a million, that way it will work for up to 500k episodes. That should be enough until we evolve into beings that can watch multiple shows at a time while absorbing all of it.
