### PR TITLE
update notifiers

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -17,7 +17,7 @@
 
 
             <br />
-            <h2>Home Theater</h2>
+            <h2>Home Theater / NAS</h2>
             <br />
 
 
@@ -366,17 +366,18 @@
 
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
-                        <img class="notifier-icon" src="$sbRoot/images/notifiers/synoindex.png" alt="" title="Synology Indexer" />
-                        <h3><a href="http://synology.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Synology Indexer</a></h3>
+                        <img class="notifier-icon" src="$sbRoot/images/notifiers/synoindex.png" alt="" title="Synology" />
+                        <h3><a href="http://synology.com/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Synology</a></h3>
+                        <p>The Synology DiskStation NAS.</p>
                         <p>Synology Indexer is the daemon running on the Synology NAS to build its media database.</p>
+                        <p>Synology Notifier is the notification system of Synology DSM.</p>
                     </div>
-
                     <fieldset class="component-group-list">
                         <div class="field-pair">
                             <input type="checkbox" class="enabler" name="use_synoindex" id="use_synoindex" #if $sickbeard.USE_SYNOINDEX then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="use_synoindex">
                                 <span class="component-title">Enable</span>
-                                <span class="component-desc">Should Sick Beard send notifications to the synoindex daemon?<br /><br />
+                                <span class="component-desc">Should Sick Beard send Synology commands?<br /><br />
                                 </span>
                             </label>
                             <label class="nocheck clearfix" for="use_synoindex">
@@ -386,8 +387,31 @@
                         </div>
 
                         <div id="content_use_synoindex">
+                            <div class="field-pair">
+                                <input type="checkbox" name="synoindex_notify_onsnatch" id="synoindex_notify_onsnatch" #if $sickbeard.SYNOINDEX_NOTIFY_ONSNATCH then "checked=\"checked\"" else ""# />
+                                <label class="clearfix" for="synoindex_notify_onsnatch">
+                                    <span class="component-title">Notify on Snatch</span>
+                                    <span class="component-desc">Send notification when we start a download?</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <input type="checkbox" name="synoindex_notify_ondownload" id="synoindex_notify_ondownload" #if $sickbeard.SYNOINDEX_NOTIFY_ONDOWNLOAD then "checked=\"checked\"" else ""# />
+                                <label class="clearfix" for="synoindex_notify_ondownload">
+                                    <span class="component-title">Notify on Download</span>
+                                    <span class="component-desc">Send notification when we finish a download?</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
+                                <input type="checkbox" name="synoindex_update_library" id="synoindex_update_library" #if $sickbeard.SYNOINDEX_UPDATE_LIBRARY then "checked=\"checked\"" else ""# />
+                                <label class="clearfix" for="synoindex_update_library">
+                                    <span class="component-title">Update Library</span>
+                                    <span class="component-desc">Update Synology library when we finish a download?</span>
+                                </label>
+                            </div>
+                            <div class="testNotification" id="testSynoNotify-result">Click below to test.</div>
+                            <input type="button" class="btn" value="Test Notice (SynoDSMnotify)" id="testSynoNotify" />
                             <input type="submit" class="btn config_submitter" value="Save Changes" />
-                        </div><!-- /content_use_pytivo //-->
+                        </div><!-- /content_use_synoindex //-->
 
                     </fieldset>
                 </div><!-- /synoindex component-group //-->
@@ -397,14 +421,14 @@
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/pytivo.png" alt="" title="pyTivo" />
                         <h3><a href="http://pytivo.sourceforge.net/wiki/index.php/PyTivo" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">pyTivo</a></h3>
-                        <p>pyTivo is both an HMO and GoBack server.  This notifier will load the completed downloads to your Tivo.</p>
+                        <p>pyTivo is both an HMO and GoBack server. This notifier will load the completed downloads to your Tivo.</p>
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
                             <input type="checkbox" class="enabler" name="use_pytivo" id="use_pytivo" #if $sickbeard.USE_PYTIVO then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="use_pytivo">
                                 <span class="component-title">Enable</span>
-                                <span class="component-desc">Should Sick Beard send notifications to pyTivo?<br /><br /></span>
+                                <span class="component-desc">Should Sick Beard update commands to pyTivo?<br /><br /></span>
                             </label>
                             <label class="nocheck clearfix" for="use_pytivo">
                                 <span class="component-title">&nbsp;</span>
@@ -637,7 +661,7 @@
                             <input type="checkbox" class="enabler" name="use_pushover" id="use_pushover" #if $sickbeard.USE_PUSHOVER then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="use_pushover">
                                 <span class="component-title">Enable</span>
-                                <span class="component-desc">Should Sick Beard send notifications through Pushover?</span>
+                                <span class="component-desc">Should Sick Beard send Pushover notifications?</span>
                             </label>
                         </div>
 
@@ -678,14 +702,14 @@
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/boxcar.png" alt="" title="Boxcar" />
                         <h3><a href="http://boxcar.io/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Boxcar</a></h3>
-                        <p>Read your messages where and when you want them! A subscription will be sent if needed.</p>
+                        <p>Universal push notification for iOS. Read your messages where and when you want them! A subscription will be sent if needed.</p>
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
                             <input type="checkbox" class="enabler" name="use_boxcar" id="use_boxcar" #if $sickbeard.USE_BOXCAR then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="use_boxcar">
                                 <span class="component-title">Enable</span>
-                                <span class="component-desc">Should Sick Beard send notifications through Boxcar?</span>
+                                <span class="component-desc">Should Sick Beard send Boxcar notifications?</span>
                             </label>
                         </div>
 
@@ -792,7 +816,7 @@
                 </div><br />
 
                 <br />
-                <h2>Online</h2>
+                <h2>Social</h2>
                 <br />
 
 

--- a/data/js/configNotifications.js
+++ b/data/js/configNotifications.js
@@ -257,4 +257,15 @@ $(document).ready(function () {
                 $("#testNMA").attr("disabled", false);
             });
     });
+
+    $("#testSynoNotify").click(function () {
+        $(this).attr("disabled", true);
+        $("#testSynoNotify-result").html(loading);
+        $.get(sbRoot + "/home/testSynoNotify")
+            .done(function (data) {
+                $("#testSynoNotify-result").html(data);
+                $("#testSynoNotify").attr("disabled", false);
+            });
+    });
+
 });

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -58,7 +58,7 @@ CFG = None
 CONFIG_FILE = None
 
 # this is the version of the config we EXPECT to find
-CONFIG_VERSION = 5
+CONFIG_VERSION = 6
 
 PROG_DIR = '.'
 MY_FULLNAME = None
@@ -267,6 +267,9 @@ NMJ_DATABASE = None
 NMJ_MOUNT = None
 
 USE_SYNOINDEX = False
+SYNOINDEX_NOTIFY_ONSNATCH = False
+SYNOINDEX_NOTIFY_ONDOWNLOAD = False
+SYNOINDEX_UPDATE_LIBRARY = False
 
 USE_NMJv2 = False
 NMJv2_HOST = None
@@ -341,7 +344,8 @@ def initialize(consoleLogging=True):
                 EXTRA_SCRIPTS, USE_TWITTER, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
                 USE_BOXCAR, BOXCAR_USERNAME, BOXCAR_PASSWORD, BOXCAR_NOTIFY_ONDOWNLOAD, BOXCAR_NOTIFY_ONSNATCH, \
                 USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, \
-                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, USE_SYNOINDEX, \
+                USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, \
+                USE_SYNOINDEX, SYNOINDEX_NOTIFY_ONSNATCH, SYNOINDEX_NOTIFY_ONDOWNLOAD, SYNOINDEX_UPDATE_LIBRARY, \
                 USE_LISTVIEW, METADATA_XBMC, METADATA_XBMC_12PLUS, METADATA_MEDIABROWSER, METADATA_MEDE8ER, METADATA_PS3, metadata_provider_dict, \
                 GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
@@ -602,6 +606,9 @@ def initialize(consoleLogging=True):
 
         CheckSection(CFG, 'Synology')
         USE_SYNOINDEX = bool(check_setting_int(CFG, 'Synology', 'use_synoindex', 0))
+        SYNOINDEX_NOTIFY_ONSNATCH = bool(check_setting_int(CFG, 'Synology', 'synoindex_notify_onsnatch', 0))
+        SYNOINDEX_NOTIFY_ONDOWNLOAD = bool(check_setting_int(CFG, 'Synology', 'synoindex_notify_ondownload', 0))
+        SYNOINDEX_UPDATE_LIBRARY = bool(check_setting_int(CFG, 'Synology', 'synoindex_update_library', 0))
 
         CheckSection(CFG, 'Trakt')
         USE_TRAKT = bool(check_setting_int(CFG, 'Trakt', 'use_trakt', 0))
@@ -1114,6 +1121,9 @@ def save_config():
 
     new_config['Synology'] = {}
     new_config['Synology']['use_synoindex'] = int(USE_SYNOINDEX)
+    new_config['Synology']['synoindex_notify_onsnatch'] = int(SYNOINDEX_NOTIFY_ONSNATCH)
+    new_config['Synology']['synoindex_notify_ondownload'] = int(SYNOINDEX_NOTIFY_ONDOWNLOAD)
+    new_config['Synology']['synoindex_update_library'] = int(SYNOINDEX_UPDATE_LIBRARY)
 
     new_config['NMJv2'] = {}
     new_config['NMJv2']['use_nmjv2'] = int(USE_NMJv2)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -645,3 +645,10 @@ class ConfigMigrator():
         sickbeard.METADATA_WDTV = _migrate_metadata(metadata_wdtv, 'WDTV', use_banner)
         sickbeard.METADATA_TIVO = _migrate_metadata(metadata_tivo, 'TIVO', use_banner)
         sickbeard.METADATA_MEDE8ER = _migrate_metadata(metadata_mede8er, 'Mede8er', use_banner)
+
+    # Migration v6: Synology notifier update
+    def _migrate_v6(self):
+        """ Updates Synology notifier to reflect that their now is an update library option instead misusing the enable option """
+
+        # clone use_synoindex to update_library since this now has notification options
+        sickbeard.SYNOINDEX_UPDATE_LIBRARY = bool(check_setting_int(self.config_obj, 'Synology', 'use_synoindex', 0))

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -39,12 +39,12 @@ from sickbeard.common import *
 from sickbeard import logger
 from sickbeard.exceptions import ex
 
-# home theater
+# home theater/nas
 xbmc_notifier = xbmc.XBMCNotifier()
 plex_notifier = plex.PLEXNotifier()
 nmj_notifier = nmj.NMJNotifier()
-synoindex_notifier = synoindex.synoIndexNotifier()
 nmjv2_notifier = nmjv2.NMJv2Notifier()
+synoindex_notifier = synoindex.synoIndexNotifier()
 pytivo_notifier = pytivo.pyTivoNotifier()
 # devices
 growl_notifier = growl.GrowlNotifier()
@@ -53,7 +53,7 @@ libnotify_notifier = libnotify.LibnotifyNotifier()
 pushover_notifier = pushover.PushoverNotifier()
 boxcar_notifier = boxcar.BoxcarNotifier()
 nma_notifier = nma.NMA_Notifier()
-# online
+# social
 twitter_notifier = tweet.TwitterNotifier()
 trakt_notifier = trakt.TraktNotifier()
 

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -36,6 +36,8 @@ import tweet
 import trakt
 
 from sickbeard.common import *
+from sickbeard import logger
+from sickbeard.exceptions import ex
 
 # home theater
 xbmc_notifier = xbmc.XBMCNotifier()
@@ -56,7 +58,7 @@ twitter_notifier = tweet.TwitterNotifier()
 trakt_notifier = trakt.TraktNotifier()
 
 notifiers = [
-    libnotify_notifier, # Libnotify notifier goes first because it doesn't involve blocking on network activity.
+    libnotify_notifier,  # Libnotify notifier goes first because it doesn't involve blocking on network activity.
     xbmc_notifier,
     plex_notifier,
     nmj_notifier,
@@ -75,14 +77,23 @@ notifiers = [
 
 def notify_download(ep_name):
     for n in notifiers:
-        n.notify_download(ep_name)
+        try:
+            n.notify_download(ep_name)
+        except Exception, e:
+            logger.log(n.__class__.__name__ + ": " + ex(e), logger.ERROR)
 
 
 def notify_snatch(ep_name):
     for n in notifiers:
-        n.notify_snatch(ep_name)
+        try:
+            n.notify_snatch(ep_name)
+        except Exception, e:
+            logger.log(n.__class__.__name__ + ": " + ex(e), logger.ERROR)
 
 
 def update_library(ep_obj):
     for n in notifiers:
-        n.update_library(ep_obj)
+        try:
+            n.update_library(ep_obj)
+        except Exception, e:
+            logger.log(n.__class__.__name__ + ": " + ex(e), logger.ERROR)

--- a/sickbeard/notifiers/boxcar.py
+++ b/sickbeard/notifiers/boxcar.py
@@ -64,7 +64,6 @@ class BoxcarNotifier:
 
         # send the request to boxcar
         try:
-            # TODO: Use our getURL from helper?
             req = urllib2.Request(curUrl)
             handle = urllib2.urlopen(req, data)
             handle.close()
@@ -72,10 +71,10 @@ class BoxcarNotifier:
         except urllib2.URLError, e:
             # if we get an error back that doesn't have an error code then who knows what's really happening
             if not hasattr(e, 'code'):
-                logger.log(u"BOXCAR: Boxcar notification failed." + ex(e), logger.ERROR)
+                logger.log(u"BOXCAR: Notification failed." + ex(e), logger.ERROR)
                 return False
             else:
-                logger.log(u"BOXCAR: Boxcar notification failed. Error code: " + str(e.code), logger.WARNING)
+                logger.log(u"BOXCAR: Notification failed. Error code: " + str(e.code), logger.ERROR)
 
             # HTTP status 404 if the provided email address isn't a Boxcar user.
             if e.code == 404:
@@ -103,10 +102,10 @@ class BoxcarNotifier:
 
             # If you receive an HTTP status code of 400, it is because you failed to send the proper parameters
             elif e.code == 400:
-                logger.log(u"BOXCAR: Wrong data send to boxcar.", logger.ERROR)
+                logger.log(u"BOXCAR: Wrong data sent to boxcar.", logger.ERROR)
                 return False
 
-        logger.log(u"BOXCAR: Boxcar notification successful.", logger.DEBUG)
+        logger.log(u"BOXCAR: Notification successful.", logger.MESSAGE)
         return True
 
     def _notify(self, title, message, username=None, force=False):
@@ -129,8 +128,7 @@ class BoxcarNotifier:
 
         logger.log(u"BOXCAR: Sending notification for " + message, logger.DEBUG)
 
-        self._sendBoxcar(message, title, username)
-        return True
+        return self._sendBoxcar(message, title, username)
 
 ##############################################################################
 # Public functions
@@ -144,10 +142,10 @@ class BoxcarNotifier:
         if sickbeard.BOXCAR_NOTIFY_ONDOWNLOAD:
             self._notify(notifyStrings[NOTIFY_DOWNLOAD], ep_name)
 
-    def test_notify(self, email, title="Test"):
-        return self._sendBoxcar("This is a test notification from SickBeard", title, email)
+    def test_notify(self, boxcar_username):
+        return self._notify("This is a test notification from Sick Beard", "Test", boxcar_username, force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         pass
 
 notifier = BoxcarNotifier

--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -115,11 +115,11 @@ class GrowlNotifier:
             print pc
             opts['host'] = pc[0]
             opts['port'] = pc[1]
-            logger.log(u"GROWL: Sending message '" + message + "' to " + opts['host'] + ":" + str(opts['port']))
+            logger.log(u"GROWL: Sending message '" + message + "' to " + opts['host'] + ":" + str(opts['port']), logger.DEBUG)
             try:
                 return self._send_growl(opts, message)
             except Exception, e:
-                logger.log(u"GROWL: Unable to send growl to " + opts['host'] + ":" + str(opts['port']) + " - " + ex(e))
+                logger.log(u"GROWL: Unable to send growl to " + opts['host'] + ":" + str(opts['port']) + " - " + ex(e), logger.WARNING)
                 return False
 
     def _sendRegistration(self, host=None, password=None, name="Sick Beard Notification"):
@@ -161,7 +161,7 @@ class GrowlNotifier:
         try:
             return self._send(opts['host'], opts['port'], register.encode(), opts['debug'])
         except Exception, e:
-            logger.log(u"GROWL: Unable to send growl to " + opts['host'] + ":" + str(opts['port']) + " - " + ex(e))
+            logger.log(u"GROWL: Unable to send growl to " + opts['host'] + ":" + str(opts['port']) + " - " + ex(e), logger.WARNING)
             return False
 
 ##############################################################################
@@ -183,7 +183,7 @@ class GrowlNotifier:
         else:
             return result
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         pass
 
 notifier = GrowlNotifier

--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -67,15 +67,15 @@ class LibnotifyNotifier:
         try:
             import pynotify
         except ImportError:
-            logger.log(u"LIBNOTIFY: Unable to import pynotify. libnotify notifications won't work.")
+            logger.log(u"LIBNOTIFY: Unable to import pynotify. libnotify notifications won't work.", logger.ERROR)
             return False
         try:
             import gobject
         except ImportError:
-            logger.log(u"LIBNOTIFY: Unable to import gobject. We can't catch a GError in display.")
+            logger.log(u"LIBNOTIFY: Unable to import gobject. We can't catch a GError in display.", logger.ERROR)
             return False
         if not pynotify.init('Sick Beard'):
-            logger.log(u"LIBNOTIFY: Initialization of pynotify failed. libnotify notifications won't work.")
+            logger.log(u"LIBNOTIFY: Initialization of pynotify failed. libnotify notifications won't work.", logger.ERROR)
             return False
         self.pynotify = pynotify
         self.gobject = gobject
@@ -119,7 +119,7 @@ class LibnotifyNotifier:
     def test_notify(self):
         return self._notify("Test notification", "This is a test notification from Sick Beard", force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         pass
 
 notifier = LibnotifyNotifier

--- a/sickbeard/notifiers/nma.py
+++ b/sickbeard/notifiers/nma.py
@@ -8,7 +8,7 @@ class NMA_Notifier:
 
     def _sendNMA(self, nma_api=None, nma_priority=None, event=None, message=None, force=False):
 
-        title = "Sick-Beard"
+        title = "Sick Beard"
 
         # suppress notifications if the notifier is disabled but the notify options are checked
         if not sickbeard.USE_NMA and not force:
@@ -20,10 +20,6 @@ class NMA_Notifier:
         if nma_priority == None:
             nma_priority = sickbeard.NMA_PRIORITY
 
-        logger.log(u"NMA: title: " + title, logger.DEBUG)
-        logger.log(u"NMA: event: " + event, logger.DEBUG)
-        logger.log(u"NMA: message: " + message, logger.DEBUG)
-
         batch = False
 
         p = pynma.PyNMA()
@@ -33,12 +29,14 @@ class NMA_Notifier:
         if len(keys) > 1:
             batch = True
 
+        logger.log("NMA: Sending notice with details: event=\"%s\", message=\"%s\", priority=%s, batch=%s" % (event, message, nma_priority, batch), logger.DEBUG)
         response = p.push(title, event, message, priority=nma_priority, batch_mode=batch)
 
         if not response[nma_api][u'code'] == u'200':
             logger.log(u"NMA: Could not send notification to NotifyMyAndroid", logger.ERROR)
             return False
         else:
+            logger.log(u"NMA: Notification sent to NotifyMyAndroid", logger.MESSAGE)
             return True
 
 ##############################################################################
@@ -56,7 +54,7 @@ class NMA_Notifier:
     def test_notify(self, nma_api, nma_priority):
         return self._sendNMA(nma_api, nma_priority, event="Test", message="Testing NMA settings from Sick Beard", force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         pass
 
 notifier = NMA_Notifier

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -44,7 +44,6 @@ class NMJv2Notifier:
         """
         try:
             url_loc = "http://" + host + ":8008/file_operation?arg0=list_user_storage_file&arg1=&arg2=" + instance + "&arg3=20&arg4=true&arg5=true&arg6=true&arg7=all&arg8=name_asc&arg9=false&arg10=false"
-            # TODO: Use our getURL from helper?
             req = urllib2.Request(url_loc)
             handle1 = urllib2.urlopen(req)
             response1 = handle1.read()
@@ -71,7 +70,7 @@ class NMJv2Notifier:
                         sickbeard.NMJv2_DATABASE = DB_path
                         return True
         except IOError, e:
-            logger.log(u"NMJv2: Warning: Couldn't contact Popcorn Hour on host %s: %s" % (host, e))
+            logger.log(u"NMJv2: Could not contact Popcorn Hour on host %s: %s" % (host, e), logger.WARNING)
             return False
 
         return False
@@ -90,9 +89,9 @@ class NMJv2Notifier:
         #if a host is provided then attempt to open a handle to that URL
         try:
             url_scandir = "http://" + host + ":8008/metadata_database?arg0=update_scandir&arg1=" + sickbeard.NMJv2_DATABASE + "&arg2=&arg3=update_all"
-            logger.log(u"NMJv2 scan update command send to host: %s" % (host))
+            logger.log(u"NMJv2: Scan update command send to host: %s" % (host), logger.DEBUG)
             url_updatedb = "http://" + host + ":8008/metadata_database?arg0=scanner_start&arg1=" + sickbeard.NMJv2_DATABASE + "&arg2=background&arg3="
-            logger.log(u"Try to mount network drive via url: %s" % (host), logger.DEBUG)
+            logger.log(u"NMJv2: Try to mount network drive via url: %s" % (host), logger.DEBUG)
             prereq = urllib2.Request(url_scandir)
             req = urllib2.Request(url_updatedb)
             handle1 = urllib2.urlopen(prereq)
@@ -101,7 +100,7 @@ class NMJv2Notifier:
             handle2 = urllib2.urlopen(req)
             response2 = handle2.read()
         except IOError, e:
-            logger.log(u"NMJv2: Warning: Couldn't contact Popcorn Hour on host %s: %s" % (host, e))
+            logger.log(u"NMJv2: Could not contact Popcorn Hour on host %s: %s" % (host, e), logger.WARNING)
             return False
 
         try:
@@ -130,15 +129,15 @@ class NMJv2Notifier:
 
         if int(result1) > 0:
             index = error_codes.index(result1)
-            logger.log(u"NMJv2: Popcorn Hour returned an error: %s" % (error_messages[index]))
+            logger.log(u"NMJv2: Popcorn Hour returned an error: %s" % (error_messages[index]), logger.ERROR)
             return False
         else:
             if int(result2) > 0:
                 index = error_codes.index(result2)
-                logger.log(u"NMJv2: Popcorn Hour returned an error: %s" % (error_messages[index]))
+                logger.log(u"NMJv2: Popcorn Hour returned an error: %s" % (error_messages[index]), logger.ERROR)
                 return False
             else:
-                logger.log(u"NMJv2: Started background scan.")
+                logger.log(u"NMJv2: Started background scan.", logger.MESSAGE)
                 return True
 
     def _notifyNMJ(self, host=None, force=False):
@@ -170,14 +169,12 @@ class NMJv2Notifier:
         pass
 
     def notify_download(self, ep_name):
-        # TODO: Drop this and use update_library
-        if sickbeard.USE_NMJv2:
-            self._notifyNMJ()
+        pass
 
     def test_notify(self, host):
-        return self._sendNMJ(host)
+        return self._notifyNMJ(host, force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         if sickbeard.USE_NMJv2:
             self._notifyNMJ()
 

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -56,7 +56,7 @@ class PLEXNotifier:
             password = sickbeard.PLEX_PASSWORD
 
         if not host:
-            logger.log(u"PLEX: No Plex host specified, check your settings", logger.DEBUG)
+            logger.log(u"PLEX: No host specified, check your settings", logger.ERROR)
             return False
 
         for key in command:
@@ -64,7 +64,7 @@ class PLEXNotifier:
                 command[key] = command[key].encode('utf-8')
 
         enc_command = urllib.urlencode(command)
-        logger.log(u"PLEX: Plex encoded API command: " + enc_command, logger.DEBUG)
+        logger.log(u"PLEX: Encoded API command: " + enc_command, logger.DEBUG)
 
         url = 'http://%s/xbmcCmds/xbmcHttp/?%s' % (host, enc_command)
         try:
@@ -74,17 +74,16 @@ class PLEXNotifier:
                 base64string = base64.encodestring('%s:%s' % (username, password))[:-1]
                 authheader = "Basic %s" % base64string
                 req.add_header("Authorization", authheader)
-                logger.log(u"PLEX: Contacting Plex (with auth header) via url: " + url, logger.DEBUG)
+                logger.log(u"PLEX: Contacting (with auth header) via url: " + url, logger.DEBUG)
             else:
-                logger.log(u"PLEX: Contacting Plex via url: " + url, logger.DEBUG)
+                logger.log(u"PLEX: Contacting via url: " + url, logger.DEBUG)
 
-            # TODO: Use our getURL from helper?
             response = urllib2.urlopen(req)
 
             result = response.read().decode(sickbeard.SYS_ENCODING)
             response.close()
 
-            logger.log(u"PLEX: Plex HTTP response: " + result.replace('\n', ''), logger.DEBUG)
+            logger.log(u"PLEX: HTTP response: " + result.replace('\n', ''), logger.DEBUG)
             # could return result response = re.compile('<html><li>(.+\w)</html>').findall(result)
             return 'OK'
 
@@ -101,7 +100,7 @@ class PLEXNotifier:
             host: Plex Media Client(s) host:port
             username: Plex username
             password: Plex password
-            force: Used for the Test method to override config saftey checks
+            force: Used for the Test method to override config safety checks
 
         Returns:
             Returns a list results in the format of host:ip:result
@@ -123,7 +122,7 @@ class PLEXNotifier:
 
         result = ''
         for curHost in [x.strip() for x in host.split(",")]:
-            logger.log(u"PLEX: Sending Plex notification to '" + curHost + "' - " + message, logger.MESSAGE)
+            logger.log(u"PLEX: Sending notification to '" + curHost + "' - " + message, logger.MESSAGE)
 
             command = {'command': 'ExecBuiltIn', 'parameter': 'Notification(' + title.encode("utf-8") + ',' + message.encode("utf-8") + ')'}
             notifyResult = self._send_to_plex(command, curHost, username, password)
@@ -147,7 +146,7 @@ class PLEXNotifier:
     def test_notify(self, host, username, password):
         return self._notify("Testing Plex notifications from Sick Beard", "Test Notification", host, username, password, force=True)
 
-    def update_library(self):
+    def update_library(self, ep_obj=None):
         """Handles updating the Plex Media Server host via HTTP API
 
         Plex Media Server currently only supports updating the whole video library and not a specific path.
@@ -159,14 +158,13 @@ class PLEXNotifier:
 
         if sickbeard.USE_PLEX and sickbeard.PLEX_UPDATE_LIBRARY:
             if not sickbeard.PLEX_SERVER_HOST:
-                logger.log(u"PLEX: No Plex Server host specified, check your settings", logger.DEBUG)
+                logger.log(u"PLEX: No Plex Media Server host specified, check your settings", logger.DEBUG)
                 return False
 
             logger.log(u"PLEX: Updating library for the Plex Media Server host: " + sickbeard.PLEX_SERVER_HOST, logger.MESSAGE)
 
             url = "http://%s/library/sections" % sickbeard.PLEX_SERVER_HOST
             try:
-                # TODO: Use our getURL from helper?
                 xml_tree = etree.parse(urllib.urlopen(url))
                 media_container = xml_tree.getroot()
             except IOError, e:

--- a/sickbeard/notifiers/prowl.py
+++ b/sickbeard/notifiers/prowl.py
@@ -42,12 +42,7 @@ class ProwlNotifier:
 
         title = "Sick Beard"
 
-        # TODO: Consolidate this to one logging dict?
-        logger.log(u"PROWL: title: " + title, logger.DEBUG)
-        logger.log(u"PROWL: event: " + event, logger.DEBUG)
-        logger.log(u"PROWL: message: " + message, logger.DEBUG)
-        logger.log(u"PROWL: api: " + prowl_api, logger.DEBUG)
-        logger.log(u"PROWL: priority: " + prowl_priority, logger.DEBUG)
+        logger.log("PROWL: Sending notice with details: event=\"%s\", message=\"%s\", priority=%s, api=%s" % (event, message, prowl_priority, prowl_api), logger.DEBUG)
 
         try:
 
@@ -74,7 +69,7 @@ class ProwlNotifier:
             return False
 
         if request_status == 200:
-            logger.log(u"PROWL: Notifications sent.", logger.DEBUG)
+            logger.log(u"PROWL: Notifications sent.", logger.MESSAGE)
             return True
         elif request_status == 401:
             logger.log(u"PROWL: Auth failed: %s" % response.reason, logger.ERROR)
@@ -98,7 +93,7 @@ class ProwlNotifier:
     def test_notify(self, prowl_api, prowl_priority):
         return self._notify(prowl_api, prowl_priority, event="Test", message="Testing Prowl settings from Sick Beard", force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         pass
 
 notifier = ProwlNotifier

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -62,7 +62,6 @@ class PushoverNotifier:
 
         # send the request to pushover
         try:
-            # TODO: Use our getURL from helper?
             req = urllib2.Request(curUrl)
             handle = urllib2.urlopen(req, data)
             handle.close()
@@ -73,7 +72,7 @@ class PushoverNotifier:
                 logger.log(u"PUSHOVER: Notification failed." + ex(e), logger.ERROR)
                 return False
             else:
-                logger.log(u"PUSHOVER: Notification failed. Error code: " + str(e.code), logger.WARNING)
+                logger.log(u"PUSHOVER: Notification failed. Error code: " + str(e.code), logger.ERROR)
 
             # HTTP status 404 if the provided email address isn't a Pushover user.
             if e.code == 404:
@@ -97,10 +96,10 @@ class PushoverNotifier:
                 logger.log(u"PUSHOVER: Wrong data sent to Pushover", logger.ERROR)
                 return False
 
-        logger.log(u"PUSHOVER: Notification successful.", logger.DEBUG)
+        logger.log(u"PUSHOVER: Notification successful.", logger.MESSAGE)
         return True
 
-    def _notify(self, title, message, userKey=None ):
+    def _notify(self, title, message, userKey=None, force=False):
         """
         Sends a pushover notification based on the provided info or SB config
 
@@ -110,7 +109,7 @@ class PushoverNotifier:
         """
 
         # suppress notifications if the notifier is disabled but the notify options are checked
-        if not sickbeard.USE_PUSHOVER:
+        if not sickbeard.USE_PUSHOVER and not force:
             return False
 
         # fill in omitted parameters
@@ -119,8 +118,7 @@ class PushoverNotifier:
 
         logger.log(u"PUSHOVER: Sending notification for " + message, logger.DEBUG)
 
-        self._sendPushover(message, title)
-        return True
+        return self._sendPushover(message, title)
 
 ##############################################################################
 # Public functions
@@ -135,9 +133,9 @@ class PushoverNotifier:
             self._notify(notifyStrings[NOTIFY_DOWNLOAD], ep_name)
 
     def test_notify(self, userKey=None):
-        return self._sendPushover("This is a test notification from SickBeard", 'Test', userKey)
+        return self._notify("This is a test notification from Sick Beard", "Test", userKey, force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None):
         pass
 
 notifier = PushoverNotifier

--- a/sickbeard/notifiers/synoindex.py
+++ b/sickbeard/notifiers/synoindex.py
@@ -22,6 +22,7 @@ import subprocess
 import sickbeard
 
 from sickbeard import logger
+from sickbeard.common import notifyStrings, NOTIFY_SNATCH, NOTIFY_DOWNLOAD
 from sickbeard import encodingKludge as ek
 from sickbeard.exceptions import ex
 
@@ -37,14 +38,14 @@ class synoIndexNotifier:
     def moveObject(self, old_path, new_path):
         if sickbeard.USE_SYNOINDEX:
             synoindex_cmd = ['/usr/syno/bin/synoindex', '-N', ek.ek(os.path.abspath, new_path), ek.ek(os.path.abspath, old_path)]
-            logger.log(u"SYNOINDEX: Executing command " + str(synoindex_cmd))
+            logger.log(u"SYNOINDEX: Executing command " + str(synoindex_cmd), logger.DEBUG)
             logger.log(u"SYNOINDEX: Absolute path to command: " + ek.ek(os.path.abspath, synoindex_cmd[0]), logger.DEBUG)
             try:
                 p = subprocess.Popen(synoindex_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=sickbeard.PROG_DIR)
                 out, err = p.communicate()  # @UnusedVariable
                 logger.log(u"SYNOINDEX: Script result: " + str(out), logger.DEBUG)
             except OSError, e:
-                logger.log(u"SYNOINDEX: Unable to run synoindex: " + ex(e))
+                logger.log(u"SYNOINDEX: Unable to run synoindex: " + ex(e), logger.WARNING)
 
     def deleteFolder(self, cur_path):
         self.makeObject('-D', cur_path)
@@ -61,23 +62,50 @@ class synoIndexNotifier:
     def makeObject(self, cmd_arg, cur_path):
         if sickbeard.USE_SYNOINDEX:
             synoindex_cmd = ['/usr/syno/bin/synoindex', cmd_arg, ek.ek(os.path.abspath, cur_path)]
-            logger.log(u"SYNOINDEX: Executing command " + str(synoindex_cmd))
+            logger.log(u"SYNOINDEX: Executing command " + str(synoindex_cmd), logger.DEBUG)
             logger.log(u"SYNOINDEX: Absolute path to command: " + ek.ek(os.path.abspath, synoindex_cmd[0]), logger.DEBUG)
             try:
                 p = subprocess.Popen(synoindex_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=sickbeard.PROG_DIR)
                 out, err = p.communicate()  # @UnusedVariable
                 logger.log(u"SYNOINDEX: Script result: " + str(out), logger.DEBUG)
             except OSError, e:
-                logger.log(u"SYNOINDEX: Unable to run synoindex: " + ex(e))
+                logger.log(u"SYNOINDEX: Unable to run synoindex: " + ex(e), logger.WARNING)
+
+    def _notify(self, message, title, force=False):
+        # suppress notifications if the notifier is disabled but the notify options are checked
+        if not sickbeard.USE_SYNOINDEX and not force:
+            return False
+
+        synodsmnotify_cmd = ['/usr/syno/bin/synodsmnotify', '@administrators', title, message]
+        logger.log(u"SYNOINDEX: Executing command " + str(synodsmnotify_cmd), logger.DEBUG)
+        logger.log(u"SYNOINDEX: Absolute path to command: " + ek.ek(os.path.abspath, synodsmnotify_cmd[0]), logger.DEBUG)
+        try:
+            p = subprocess.Popen(synodsmnotify_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                 cwd=sickbeard.PROG_DIR)
+            out, err = p.communicate()  # @UnusedVariable
+            logger.log(u"SYNOINDEX: Script result: " + str(out), logger.DEBUG)
+            return True
+        except OSError, e:
+            logger.log(u"SYNOINDEX: Unable to run synodsmnotify: " + ex(e), logger.WARNING)
+            return False
 
 ##############################################################################
 # Public functions
 ##############################################################################
 
     def notify_snatch(self, ep_name):
-        pass
+        if sickbeard.SYNOINDEX_NOTIFY_ONSNATCH:
+            self._notify(notifyStrings[NOTIFY_SNATCH], ep_name)
 
     def notify_download(self, ep_name):
-        pass
+        if sickbeard.SYNOINDEX_NOTIFY_ONDOWNLOAD:
+            self._notify(notifyStrings[NOTIFY_DOWNLOAD], ep_name)
+
+    def test_notify(self):
+        return self._notify("This is a test notification from Sick Beard", "Test", force=True)
+
+    def update_library(self, ep_obj=None):
+        if sickbeard.USE_SYNOINDEX:
+            self.addFile(ep_obj.location)
 
 notifier = synoIndexNotifier

--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -32,7 +32,7 @@ from sickbeard import logger
 
 class TraktNotifier:
 
-    def _notifyTrakt(self, method, api, username, password, data={}):
+    def _notifyTrakt(self, method, api, username, password, data={}, force=False):
         """
         A generic method for communicating with trakt. Uses the method and data provided along
         with the auth info to send the command.
@@ -44,6 +44,10 @@ class TraktNotifier:
 
         Returns: A boolean representing success
         """
+        # suppress notifications if the notifier is disabled but the notify options are checked
+        if not sickbeard.USE_TRAKT and not force:
+            return False
+
         logger.log(u"TRAKT: Calling method " + method, logger.DEBUG)
 
         # if the API isn't given then use the config API
@@ -71,7 +75,6 @@ class TraktNotifier:
         # request the URL from trakt and parse the result as json
         try:
             logger.log(u"TRAKT: Calling method http://api.trakt.tv/" + method + ", with data" + encoded_data, logger.DEBUG)
-            # TODO: Use our getURL from helper?
             stream = urllib2.urlopen("http://api.trakt.tv/" + method, encoded_data)
             resp = stream.read()
 
@@ -85,7 +88,7 @@ class TraktNotifier:
             return False
 
         if (resp["status"] == "success"):
-            logger.log(u"TRAKT: Succeeded calling method. Result: " + resp["message"], logger.DEBUG)
+            logger.log(u"TRAKT: Succeeded calling method. Result: " + resp["message"], logger.MESSAGE)
             return True
 
         logger.log(u"TRAKT: Failed calling method", logger.ERROR)
@@ -114,9 +117,9 @@ class TraktNotifier:
         """
 
         method = "account/test/"
-        return self._notifyTrakt(method, api, username, password, {})
+        return self._notifyTrakt(method, api, username, password, {}, force=True)
 
-    def update_library(self, ep_obj):
+    def update_library(self, ep_obj=None):
         """
         Sends a request to trakt indicating that the given episode is part of our library.
 

--- a/sickbeard/notifiers/tweet.py
+++ b/sickbeard/notifiers/tweet.py
@@ -47,12 +47,12 @@ class TwitterNotifier:
         oauth_consumer = oauth.Consumer(key=self.consumer_key, secret=self.consumer_secret)
         oauth_client = oauth.Client(oauth_consumer)
 
-        logger.log(u'TWITTER: Requesting temp token from Twitter')
+        logger.log(u'TWITTER: Requesting temp token from Twitter', logger.DEBUG)
 
         resp, content = oauth_client.request(self.REQUEST_TOKEN_URL, 'GET')
 
         if resp['status'] != '200':
-            logger.log(u"TWITTER: Invalid respond from Twitter requesting temp token: %s" % resp['status'])
+            logger.log(u"TWITTER: Invalid respond from Twitter requesting temp token: %s" % resp['status'], logger.ERROR)
         else:
             request_token = dict(parse_qsl(content))
 
@@ -71,26 +71,26 @@ class TwitterNotifier:
         token = oauth.Token(request_token['oauth_token'], request_token['oauth_token_secret'])
         token.set_verifier(key)
 
-        logger.log(u"TWITTER: Generating and signing request for an access token using key " + key)
+        logger.log(u"TWITTER: Generating and signing request for an access token using key " + key, logger.DEBUG)
 
         signature_method_hmac_sha1 = oauth.SignatureMethod_HMAC_SHA1()  # @UnusedVariable
         oauth_consumer = oauth.Consumer(key=self.consumer_key, secret=self.consumer_secret)
-        logger.log(u"TWITTER: oauth_consumer: " + str(oauth_consumer))
+        logger.log(u"TWITTER: oauth_consumer: " + str(oauth_consumer), logger.DEBUG)
         oauth_client = oauth.Client(oauth_consumer, token)
-        logger.log(u"TWITTER: oauth_client: " + str(oauth_client))
+        logger.log(u"TWITTER: oauth_client: " + str(oauth_client), logger.DEBUG)
         resp, content = oauth_client.request(self.ACCESS_TOKEN_URL, method='POST', body='oauth_verifier=%s' % key)
-        logger.log(u"TWITTER: resp, content: " + str(resp) + "," + str(content))
+        logger.log(u"TWITTER: resp, content: " + str(resp) + "," + str(content), logger.DEBUG)
 
         access_token = dict(parse_qsl(content))
-        logger.log(u"TWITTER: access_token: " + str(access_token))
+        logger.log(u"TWITTER: access_token: " + str(access_token), logger.DEBUG)
 
-        logger.log(u"TWITTER: resp[status] = " + str(resp['status']))
+        logger.log(u"TWITTER: resp[status] = " + str(resp['status']), logger.DEBUG)
         if resp['status'] != '200':
             logger.log(u"TWITTER: The request for a token with did not succeed: " + str(resp['status']), logger.ERROR)
             return False
         else:
-            logger.log(u"TWITTER: Your Twitter Access Token key: %s" % access_token['oauth_token'])
-            logger.log(u"TWITTER: Access Token secret: %s" % access_token['oauth_token_secret'])
+            logger.log(u"TWITTER: Your Twitter Access Token key: %s" % access_token['oauth_token'], logger.DEBUG)
+            logger.log(u"TWITTER: Access Token secret: %s" % access_token['oauth_token_secret'], logger.DEBUG)
             sickbeard.TWITTER_USERNAME = access_token['oauth_token']
             sickbeard.TWITTER_PASSWORD = access_token['oauth_token_secret']
             return True
@@ -102,7 +102,7 @@ class TwitterNotifier:
         access_token_key = sickbeard.TWITTER_USERNAME
         access_token_secret = sickbeard.TWITTER_PASSWORD
 
-        logger.log(u"TWITTER: Sending tweet: " + message)
+        logger.log(u"TWITTER: Sending tweet: " + message, logger.DEBUG)
 
         api = twitter.Api(username, password, access_token_key, access_token_secret)
 
@@ -136,7 +136,7 @@ class TwitterNotifier:
     def test_notify(self):
         return self._notify("This is a test notification from Sick Beard", force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj):
         pass
 
 notifier = TwitterNotifier

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -67,7 +67,7 @@ class XBMCNotifier:
                  3  | (pre Eden)
                  4  | v11 (Eden)
                  5  | (pre Frodo)
-                 6  | v12 (Frodo)
+                 6  | v12 (Frodo) / v13 (Gotham)
 
         """
 
@@ -174,7 +174,7 @@ class XBMCNotifier:
             password = sickbeard.XBMC_PASSWORD
 
         if not host:
-            logger.log(u"XBMC: No XBMC host passed, aborting update", logger.DEBUG)
+            logger.log(u"XBMC: No host specified, check your settings", logger.DEBUG)
             return False
 
         for key in command:
@@ -182,7 +182,7 @@ class XBMCNotifier:
                 command[key] = command[key].encode('utf-8')
 
         enc_command = urllib.urlencode(command)
-        logger.log(u"XBMC: XBMC encoded API command: " + enc_command, logger.DEBUG)
+        logger.log(u"XBMC: Encoded API command: " + enc_command, logger.DEBUG)
 
         url = 'http://%s/xbmcCmds/xbmcHttp/?%s' % (host, enc_command)
         try:
@@ -197,11 +197,11 @@ class XBMCNotifier:
             result = response.read().decode(sickbeard.SYS_ENCODING)
             response.close()
 
-            logger.log(u"XBMC: XBMC HTTP response: " + result.replace('\n', ''), logger.DEBUG)
+            logger.log(u"XBMC: HTTP response: " + result.replace('\n', ''), logger.DEBUG)
             return result
 
         except (urllib2.URLError, IOError), e:
-            logger.log(u"XBMC: Warning: Couldn't contact XBMC HTTP at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
+            logger.log(u"XBMC: Could not contact XBMC HTTP at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
             return False
 
     def _update_library(self, host=None, showName=None):
@@ -220,14 +220,12 @@ class XBMCNotifier:
         """
 
         if not host:
-            logger.log(u"XBMC: No XBMC host passed, aborting update", logger.DEBUG)
+            logger.log(u"XBMC: No host specified, check your settings", logger.DEBUG)
             return False
-
-        logger.log(u"XBMC: Updating XBMC library via HTTP method for host: " + host, logger.DEBUG)
 
         # if we're doing per-show
         if showName:
-            logger.log(u"XBMC: Updating library in XBMC via HTTP method for show " + showName, logger.DEBUG)
+            logger.log(u"XBMC: Updating library via HTTP method for show " + showName, logger.MESSAGE)
 
             pathSql = 'select path.strPath from path, tvshow, tvshowlinkpath where ' \
                 'tvshow.c00 = "%s" and tvshowlinkpath.idShow = tvshow.idShow ' \
@@ -268,23 +266,23 @@ class XBMCNotifier:
             for path in paths:
                 # we do not need it double-encoded, gawd this is dumb
                 unEncPath = urllib.unquote(path.text).decode(sickbeard.SYS_ENCODING)
-                logger.log(u"XBMC: XBMC Updating " + showName + " on " + host + " at " + unEncPath, logger.MESSAGE)
+                logger.log(u"XBMC: Updating " + showName + " on " + host + " at " + unEncPath, logger.MESSAGE)
                 updateCommand = {'command': 'ExecBuiltIn', 'parameter': 'XBMC.updatelibrary(video, %s)' % (unEncPath)}
                 request = self._send_to_xbmc(updateCommand, host)
                 if not request:
-                    logger.log(u"XBMC: Update of show directory failed on " + showName + " on " + host + " at " + unEncPath, logger.ERROR)
+                    logger.log(u"XBMC: Update of show directory failed on " + showName + " on " + host + " at " + unEncPath, logger.WARNING)
                     return False
                 # sleep for a few seconds just to be sure xbmc has a chance to finish each directory
                 if len(paths) > 1:
                     time.sleep(5)
         # do a full update if requested
         else:
-            logger.log(u"XBMC: Doing Full Library XBMC update on host: " + host, logger.DEBUG)
+            logger.log(u"XBMC: Doing Full Library update via HTTP method for host: " + host, logger.MESSAGE)
             updateCommand = {'command': 'ExecBuiltIn', 'parameter': 'XBMC.updatelibrary(video)'}
             request = self._send_to_xbmc(updateCommand, host)
 
             if not request:
-                logger.log(u"XBMC: XBMC Full Library update failed on: " + host, logger.ERROR)
+                logger.log(u"XBMC: Full Library update failed on: " + host, logger.ERROR)
                 return False
 
         return True
@@ -314,11 +312,11 @@ class XBMCNotifier:
             password = sickbeard.XBMC_PASSWORD
 
         if not host:
-            logger.log(u"XBMC: No XBMC host passed, aborting update", logger.DEBUG)
+            logger.log(u"XBMC: No host specified, check your settings", logger.DEBUG)
             return False
 
         command = command.encode('utf-8')
-        logger.log(u"XBMC: XBMC JSON command: " + command, logger.DEBUG)
+        logger.log(u"XBMC: JSON command: " + command, logger.DEBUG)
 
         url = 'http://%s/jsonrpc' % (host)
         try:
@@ -340,14 +338,14 @@ class XBMCNotifier:
             try:
                 result = json.load(response)
                 response.close()
-                logger.log(u"XBMC: XBMC JSON response: " + str(result), logger.DEBUG)
+                logger.log(u"XBMC: JSON response: " + str(result), logger.DEBUG)
                 return result  # need to return response for parsing
             except ValueError, e:
                 logger.log(u"XBMC: Unable to decode JSON: " + response, logger.WARNING)
                 return False
 
         except IOError, e:
-            logger.log(u"XBMC: Warning: Couldn't contact XBMC JSON API at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
+            logger.log(u"XBMC: Could not contact XBMC JSON API at " + fixStupidEncodings(url) + " " + ex(e), logger.WARNING)
             return False
 
     def _update_library_json(self, host=None, showName=None):
@@ -366,15 +364,13 @@ class XBMCNotifier:
         """
 
         if not host:
-            logger.log(u"XBMC: No XBMC host passed, aborting update", logger.DEBUG)
+            logger.log(u"XBMC: No host specified, check your settings", logger.DEBUG)
             return False
-
-        logger.log(u"XBMC: Updating XBMC library via JSON method for host: " + host, logger.MESSAGE)
 
         # if we're doing per-show
         if showName:
             tvshowid = -1
-            logger.log(u"XBMC: Updating library in XBMC via JSON method for show " + showName, logger.DEBUG)
+            logger.log(u"XBMC: Updating library via JSON method for show " + showName, logger.MESSAGE)
 
             # get tvshowid by showName
             showsCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows","id":1}'
@@ -410,11 +406,11 @@ class XBMCNotifier:
                 logger.log(u"XBMC: No valid path found for " + showName + " with ID: " + str(tvshowid) + " on " + host, logger.WARNING)
                 return False
 
-            logger.log(u"XBMC: XBMC Updating " + showName + " on " + host + " at " + path, logger.MESSAGE)
+            logger.log(u"XBMC: Updating " + showName + " on " + host + " at " + path, logger.MESSAGE)
             updateCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.Scan","params":{"directory":%s},"id":1}' % (json.dumps(path))
             request = self._send_to_xbmc_json(updateCommand, host)
             if not request:
-                logger.log(u"XBMC: Update of show directory failed on " + showName + " on " + host + " at " + path, logger.ERROR)
+                logger.log(u"XBMC: Update of show directory failed on " + showName + " on " + host + " at " + path, logger.WARNING)
                 return False
 
             # catch if there was an error in the returned request
@@ -425,12 +421,12 @@ class XBMCNotifier:
 
         # do a full update if requested
         else:
-            logger.log(u"XBMC: Doing Full Library XBMC update on host: " + host, logger.MESSAGE)
+            logger.log(u"XBMC: Doing Full Library update via JSON method for host: " + host, logger.MESSAGE)
             updateCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.Scan","id":1}'
             request = self._send_to_xbmc_json(updateCommand, host, sickbeard.XBMC_USERNAME, sickbeard.XBMC_PASSWORD)
 
             if not request:
-                logger.log(u"XBMC: XBMC Full Library update failed on: " + host, logger.ERROR)
+                logger.log(u"XBMC: Full Library update failed on: " + host, logger.ERROR)
                 return False
 
         return True
@@ -450,7 +446,7 @@ class XBMCNotifier:
     def test_notify(self, host, username, password):
         return self._notify("Testing XBMC notifications from Sick Beard", "Test Notification", host, username, password, force=True)
 
-    def update_library(self, showName=None):
+    def update_library(self, ep_obj=None, show_obj=None):
         """Public wrapper for the update library functions to branch the logic for JSON-RPC or legacy HTTP API
 
         Checks the XBMC API version to branch the logic to call either the legacy HTTP API or the newer JSON-RPC over HTTP methods.
@@ -466,9 +462,18 @@ class XBMCNotifier:
 
         """
 
+        if ep_obj:
+            showName = ep_obj.show.name
+        else:
+            showName = None
+
+        # for updateXBMC
+        if show_obj:
+            showName = show_obj.name
+
         if sickbeard.USE_XBMC and sickbeard.XBMC_UPDATE_LIBRARY:
             if not sickbeard.XBMC_HOST:
-                logger.log(u"XBMC: No XBMC hosts specified, check your settings", logger.DEBUG)
+                logger.log(u"XBMC: No host specified, check your settings", logger.DEBUG)
                 return False
 
             if sickbeard.XBMC_UPDATE_ONLYFIRST:
@@ -479,26 +484,20 @@ class XBMCNotifier:
 
             result = 0
             for curHost in [x.strip() for x in host.split(",")]:
-                logger.log(u"XBMC: Sending request to update library for XBMC host: '" + curHost + "'", logger.MESSAGE)
+                logger.log(u"XBMC: Sending request to update library for host: '" + curHost + "'", logger.MESSAGE)
 
                 xbmcapi = self._get_xbmc_version(curHost, sickbeard.XBMC_USERNAME, sickbeard.XBMC_PASSWORD)
                 if xbmcapi:
                     if (xbmcapi <= 4):
                         # try to update for just the show, if it fails, do full update if enabled
                         if not self._update_library(curHost, showName):
-                            if showName:
-                                logger.log(u"XBMC: XBMC single show update failed", logger.WARNING)
-                                if  sickbeard.XBMC_UPDATE_FULL:
-                                    logger.log(u"XBMC: Falling back to XBMC full update")
-                                    self._update_library(curHost)
+                            if showName and sickbeard.XBMC_UPDATE_FULL:
+                                self._update_library(curHost)
                     else:
                         # try to update for just the show, if it fails, do full update if enabled
                         if not self._update_library_json(curHost, showName):
-                            if showName:
-                                logger.log(u"XBMC: XBMC single show update failed", logger.WARNING)
-                                if  sickbeard.XBMC_UPDATE_FULL:
-                                    logger.log(u"XBMC: Falling back to XBMC full update")
-                                    self._update_library_json(curHost)
+                            if showName and sickbeard.XBMC_UPDATE_FULL:
+                                self._update_library_json(curHost)
                 else:
                     if sickbeard.XBMC_ALWAYS_ON:
                         logger.log(u"XBMC: Failed to detect XBMC version for '" + curHost + "', check configuration and try again.", logger.ERROR)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -883,30 +883,15 @@ class PostProcessor(object):
         # log it to history
         history.logDownload(ep_obj, self.file_path, new_ep_quality, self.release_group)
 
-        # send notifications
+        # send notifiers download notification
         notifiers.notify_download(ep_obj.prettyName())
 
         # generate nfo/tbn
         ep_obj.createMetaFiles()
         ep_obj.saveToDB()
 
-        # do the library update for XBMC
-        notifiers.xbmc_notifier.update_library(ep_obj.show.name)
-
-        # do the library update for Plex
-        notifiers.plex_notifier.update_library()
-
-        # do the library update for NMJ
-        # nmj_notifier kicks off its library update when the notify_download is issued (inside notifiers)
-
-        # do the library update for Synology Indexer
-        notifiers.synoindex_notifier.addFile(ep_obj.location)
-
-        # do the library update for pyTivo
-        notifiers.pytivo_notifier.update_library(ep_obj)
-
-        # do the library update for Trakt
-        notifiers.trakt_notifier.update_library(ep_obj)
+        # send notifiers library update
+        notifiers.update_library(ep_obj)
 
         self._run_extra_scripts(ep_obj)
 


### PR DESCRIPTION
- Safeguard notifiers from affecting the post-processing routine, catch and log exceptions.
- Instead of calling each notifier update_library routine individually, we now just call all of them similar to the notifications
- Cleaned up notifier ui page wording so they follow similar pattern.
- Converted updateXBMC to use show id rather than show name (works the same way as refreshShow/updateShow/etc)
- Better exception handling for pyTivo and NMJ
- Cleaned up logging entries, trying to standardize on what level we report and verbiage (not using contractions, prune out duplicate/excessive entries)
- Added notification support for Synology (notifies Synology DSM) with migration of old setting
- Dropped getURL helper reference since importing helper is more trouble than its worth, will just rewrite each notifier using Requests when we move to python 2.6+
