### PR TITLE
Specify time to do full update - GoogleIssue 1859

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -158,6 +158,7 @@ def help_message():
     help_msg += "                                    to load configuration from \n"
     help_msg += "                                    Default: config.ini in " + sickbeard.PROG_DIR + " or --datadir location\n"
     help_msg += "                --noresize          Prevent resizing of the banner/posters even if PIL is installed\n"
+    help_msg += "    -u <time>   --updatetime=<time> Override default/configured time to do daily full updates\n"
 
     return help_msg
 
@@ -206,7 +207,7 @@ def main():
     threading.currentThread().name = "MAIN"
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hfqdp::", ['help', 'forceupdate', 'quiet', 'nolaunch', 'daemon', 'pidfile=', 'port=', 'datadir=', 'config=', 'noresize'])  # @UnusedVariable
+        opts, args = getopt.getopt(sys.argv[1:], "hfqdpu::", ['help', 'forceupdate', 'quiet', 'nolaunch', 'daemon', 'pidfile=', 'port=', 'datadir=', 'config=', 'noresize', 'updatetime='])  # @UnusedVariable
     except getopt.GetoptError:
         sys.exit(help_message())
 
@@ -215,7 +216,7 @@ def main():
     noLaunch = False
 
     for o, a in opts:
-
+        
         # Prints help message
         if o in ('-h', '--help'):
             sys.exit(help_message())
@@ -233,6 +234,13 @@ def main():
         # Prevent duplicate browser window when restarting in the app
         if o in ('--nolaunch',):
             noLaunch = True
+
+        # Do the daily full update at a different time.
+        if o in ('-u', '--updatetime='):
+            enteredTime = int(a)
+            if enteredTime > 23 or enteredTime < 0:
+                sys.exit("Invalid Time for updates.")
+            sickbeard.UPDATE_TIME = int(a)
 
         # Run as a double forked daemon
         if o in ('-d', '--daemon'):

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -117,6 +117,7 @@ HTTPS_CERT = None
 HTTPS_KEY = None
 
 LAUNCH_BROWSER = None
+UPDATE_TIME = 3
 CACHE_DIR = None
 ACTUAL_CACHE_DIR = None
 ROOT_DIRS = None
@@ -349,7 +350,7 @@ def initialize(consoleLogging=True):
                 USE_LISTVIEW, METADATA_XBMC, METADATA_XBMC_12PLUS, METADATA_MEDIABROWSER, METADATA_MEDE8ER, METADATA_PS3, metadata_provider_dict, \
                 GIT_PATH, MOVE_ASSOCIATED_FILES, \
                 COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, METADATA_WDTV, METADATA_TIVO, IGNORE_WORDS, CREATE_MISSING_SHOW_DIRS, \
-                ADD_SHOWS_WO_DIR, ANON_REDIRECT
+                ADD_SHOWS_WO_DIR, ANON_REDIRECT, UPDATETIME
 
         if __INITIALIZED__:
             return False
@@ -988,6 +989,7 @@ def save_config():
     new_config['General']['naming_abd_pattern'] = NAMING_ABD_PATTERN
     new_config['General']['naming_multi_ep'] = int(NAMING_MULTI_EP)
     new_config['General']['launch_browser'] = int(LAUNCH_BROWSER)
+    new_config['General']['update_time'] = int(UPDATE_TIME)
 
     new_config['General']['use_listview'] = int(USE_LISTVIEW)
     new_config['General']['metadata_xbmc'] = METADATA_XBMC

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -28,6 +28,7 @@ from sickbeard.exceptions import ex
 from sickbeard import encodingKludge as ek
 from sickbeard import db
 
+import sys
 
 class ShowUpdater():
 
@@ -36,8 +37,9 @@ class ShowUpdater():
 
     def run(self, force=False):
 
-        # update at 3 AM
-        run_updater_time = datetime.time(hour=3)
+        # update at specified time.
+        run_updater_time = datetime.time(hour=sickbeard.UPDATE_TIME)
+        sys.exit(str(run_updater_time))
 
         update_datetime = datetime.datetime.today()
         update_date = update_datetime.date()


### PR DESCRIPTION
Addresses issue with hardcoded time for full updates.

Command line option added
- u <time>
  --updatetime=<time>

Accepts an integer between 0 and 23 to specify the hour to update at.
