### PR TITLE
minor fixes

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -50,7 +50,6 @@ import sickbeard
 from sickbeard.exceptions import MultipleShowObjectsException, ex
 from sickbeard import logger, classes
 from sickbeard.common import USER_AGENT, mediaExtensions, XML_NSMAP
-from sickbeard.common import mediaExtensions
 
 from sickbeard import db
 from sickbeard import encodingKludge as ek

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -29,8 +29,8 @@ import datetime
 
 from name_parser.parser import NameParser, InvalidNameException
 
-resultFilters = ["sub(bed|ed|pack|s)", "(dk|fin|heb|kor|nl|nor|nordic|pl|swe)sub(bed|ed|s)?",
-                 "(dir|sample|sub|nfo)fix", "sample", "(dvd)?extras",
+resultFilters = ["sub(bed|ed|pack|s)", "(dk|fin|heb|kor|nor|nordic|pl|swe)-?sub(bed|ed|s)?",
+                 "(dir|sample|sub|nfo|proof)fix(es)?", "sample", "(dvd)?extras",
                  "dub(bed)?"]
 
 


### PR DESCRIPTION
Filter out releases like `Louie.S02E11.PROOFFiX.720p.BluRay.x264-DEiMOS` and `Rome.S02.DiRFiXES.720p.BluRay.x264-SiNNERS` as they are useless for our purposes.

Remove `nl` from sub filtering as these releases are safe for english users and sometimes can only be found with them (1080p web-dl), thus the user can just disable the sub as the audio is in english.
