### PR TITLE
Changes to fix issue 1111 (colour downloads for shows that are up to date)

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -361,7 +361,18 @@ home.tmpl
   height: 20px;
   line-height: 18px;
 }
-.progressbarText {
+.progressbarTextComplete {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  text-align: center;
+  text-shadow: 0 0 0.1em #fff;
+  vertical-align: middle;
+  background-color: #64be64;
+}
+.progressbarTextIncomplete {
   position: absolute;
   top: 0;
   width: 100%;

--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -220,16 +220,31 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
         <td align="center"><span class="quality Custom">Custom</span></td>
     #end if
         <td align="center"><span style="display: none;">$download_stat</span><div id="progressbar$curShow.tvdbid" style="position:relative;"></div>
+          
+    #if $cur_total != $cur_downloaded
           <script type="text/javascript">
           <!--
                 \$(function() {
                  \$("\#progressbar$curShow.tvdbid").progressbar({
                      value: $progressbar_percent
                  });
-                 \$("\#progressbar$curShow.tvdbid").append("<div class='progressbarText' title='$download_stat_tip'>$download_stat</div>")
+                 \$("\#progressbar$curShow.tvdbid").append("<div class='progressbarTextIncomplete' title='$download_stat_tip'>$download_stat</div>")
                 });
           //-->
           </script>
+    #else
+        <script type="text/javascript">
+          <!--
+                \$(function() {
+                 \$("\#progressbar$curShow.tvdbid").progressbar({
+                     value: $progressbar_percent
+                 });
+                 \$("\#progressbar$curShow.tvdbid").append("<div class='progressbarTextComplete' title='$download_stat_tip'>$download_stat</div>")
+                });
+          //-->
+          </script>
+    #end if
+    
         </td>
         <td align="center"><img src="$sbRoot/images/#if int($curShow.paused) == 0 and $curShow.status != "Ended" then "yes16.png\" alt=\"Y\"" else "no16.png\" alt=\"N\""# width="16" height="16" /></td>
         <td align="center">$curShow.status</td>


### PR DESCRIPTION
First time ever modifying a css or tmpl file, and brand new to github, so please be gentle.

Love Sick Beard but have always wanted a faster way to tell if a show was up-to-date or not (as detailed in issue 1111). These changes modify the style.css file to add a progressbarTextComplete and progressbarTextIncomplete to allow different colours for the 'downloads' column depending on whether you have downloaded all the episodes or not. I also modified the home.tmpl file to use the different styles. Note that there may need to be an additional check for brand new shows - if the total downloaded and total available are both 0, I think it will show green which may be misleading?

I tried to use the same shade of green that was used in the tick icon in the Active column, and think that I kept the tabs/spacing the same. See attached image for what it will look like after this change.

![image](https://cloud.githubusercontent.com/assets/7887756/3278478/d84bf0fa-f3c1-11e3-80bd-f376dba3207e.png)
