### PR TITLE
Fixed the sickbeard_stop() function and removed the dependency on wget

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -46,19 +46,11 @@ load_rc_config ${name}
 : ${sickbeard_web_user:=""}
 : ${sickbeard_web_password:=""}
 
-WGET="/usr/local/bin/wget" # You need wget for this script to safely shutdown Sick Beard.
-
 status_cmd="${name}_status"
 stop_cmd="${name}_stop"
 
 command="/usr/sbin/daemon"
 command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py --quiet --nolaunch"
-
-# Check for wget and refuse to start without it.
-if [ ! -x "${WGET}" ]; then
-  warn "Sickbeard not started: You need wget to safely shut down Sick Beard."
-  exit 1
-fi
 
 # Ensure user is root when running this script.
 if [ `id -u` != "0" ]; then
@@ -77,7 +69,7 @@ verify_sickbeard_pid() {
 sickbeard_stop() {
     echo "Stopping $name"
     verify_sickbeard_pid
-    ${WGET} -O - -q --user=${sickbeard_web_user} --password=${sickbeard_web_password} "http://${sickbeard_host}:${sickbeard_port}/home/shutdown/" >/dev/null
+    fetch -o - -q "http://${sickbeard_web_user}:${sickbeard_web_password}@${sickbeard_host}:${sickbeard_port}/home/shutdown/?pid=$pid" >/dev/null
     if [ -n "${pid}" ]; then
       wait_for_pids ${pid}
       echo "Stopped"


### PR DESCRIPTION
sickbeard_stop() didn't actually shutdown SickBeard because it didn't
specify the PID. While fixing that I also removed the dependency on
wget. Wget isn't needed because fetch is included in the FreeBSD base
system
