### PR TITLE
Added support for the new append method from NZBGet 13+

### DIFF
--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -129,12 +129,17 @@ def sendNZB(nzb):
                         nzbcontent64 = standard_b64encode(data)
                         nzbget_result = nzbGetRPC.append(nzb_filename, sickbeard.NZBGET_CATEGORY, add_to_top, nzbcontent64)
 
-        # v12+ pass dupekey + dupescore
-        elif nzbget_version >= 12:
+        # v12 pass dupekey + dupescore
+        elif nzbget_version == 12:
             if nzbcontent64:
                 nzbget_result = nzbGetRPC.append(nzb_filename, sickbeard.NZBGET_CATEGORY, nzbgetprio, False, nzbcontent64, False, dupekey, dupescore, "score")
             else:
                 nzbget_result = nzbGetRPC.appendurl(nzb_filename, sickbeard.NZBGET_CATEGORY, nzbgetprio, False, nzb.url, False, dupekey, dupescore, "score")
+
+        # v13+ has a new combined append method that accepts both (url and content)
+        # also the return value has changed from boolean to integer (Positive number representing NZBID of the queue item. 0 and negative numbers represent error codes.)
+        elif nzbget_version >= 13:
+            nzbget_result = True if nzbGetRPC.append(nzb_filename, nzbcontent64 if nzbcontent64 is not None else nzb.url, sickbeard.NZBGET_CATEGORY, nzbgetprio, False, False, dupekey, dupescore, "score") > 0 else False
 
         # v9+ pass priority, no dupe info
         else:


### PR DESCRIPTION
NZBGet 13 will probably be released in the next few days. This version has a new combined append method that supports both nzb urls and content. Also the return value was changed form boolean to integer (NZBID or error number).

The old methods append and appendurl are now Deprecated, so it's more future proof to add the new method now.
