### PR TITLE
Elandril quality

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -153,6 +153,8 @@ class Quality:
             return Quality.SDTV
         elif checkName(["(dvdrip|bdrip)(.ws)?.(xvid|divx|x264)"], any) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDDVD
+        elif checkName(["dvdrip.(wide|ws)?", "sdtv"], all) and not checkName(["(720|1080)[pi]"], all):
+            return Quality.SDDVD	
         elif checkName(["720p", "hdtv", "x264"], all) or checkName(["hr.ws.pdtv.x264"], any) and not checkName(["(1080)[pi]"], all):
             return Quality.HDTV
         elif checkName(["720p|1080i", "hdtv", "mpeg-?2"], all) or checkName(["1080[pi].hdtv", "h.?264"], all):

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -161,9 +161,9 @@ class Quality:
             return Quality.HDWEBDL
         elif checkName(["1080p", "web.dl|webrip|webhd"], all) or checkName(["1080p", "itunes", "h.?264"], all):
             return Quality.FULLHDWEBDL
-        elif checkName(["720p", "bluray|hddvd", "x264"], all):
+        elif checkName(["720p", "bluray|hddvd|bd", "x264"], all):
             return Quality.HDBLURAY
-        elif checkName(["1080p", "bluray|hddvd", "x264"], all):
+        elif checkName(["1080p", "bluray|hddvd|bd", "x264"], all):
             return Quality.FULLHDBLURAY
         else:
             return Quality.UNKNOWN

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -149,6 +149,8 @@ class Quality:
             return Quality.SDTV
         elif checkName(["web.dl|webrip", "xvid|x264|h.?264"], all) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDTV
+        elif checkName(["sdtv", "(pdtv|dsr|tvrip)"], all) and not checkName(["(720|1080)[pi]"], all):
+            return Quality.SDTV
         elif checkName(["(dvdrip|bdrip)(.ws)?.(xvid|divx|x264)"], any) and not checkName(["(720|1080)[pi]"], all):
             return Quality.SDDVD
         elif checkName(["720p", "hdtv", "x264"], all) or checkName(["hr.ws.pdtv.x264"], any) and not checkName(["(1080)[pi]"], all):

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -157,9 +157,9 @@ class Quality:
             return Quality.RAWHDTV
         elif checkName(["1080p", "hdtv", "x264"], all):
             return Quality.FULLHDTV
-        elif checkName(["720p", "web.dl|webrip"], all) or checkName(["720p", "itunes", "h.?264"], all):
+        elif checkName(["720p", "web.dl|webrip|webhd"], all) or checkName(["720p", "itunes", "h.?264"], all):
             return Quality.HDWEBDL
-        elif checkName(["1080p", "web.dl|webrip"], all) or checkName(["1080p", "itunes", "h.?264"], all):
+        elif checkName(["1080p", "web.dl|webrip|webhd"], all) or checkName(["1080p", "itunes", "h.?264"], all):
             return Quality.FULLHDWEBDL
         elif checkName(["720p", "bluray|hddvd", "x264"], all):
             return Quality.HDBLURAY


### PR DESCRIPTION
Additional/modified regex strings for Quality.nameQuality to recognize some additional commonly used release names:
1. ["sdtv", "(pdtv|dsr|tvrip)"] => SDTV
2. ["dvdrip.(wide|ws)?", "sdtv"] => SDDVD
3. webhd == web-dl
4. bd == bluray
