### PR TITLE
HTTPS Chain Certificate Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ sickbeard.db*
 autoProcessTV/autoProcessTV.cfg
 server.crt
 server.key
+chain.crt
 
 #  SB Test Related   #
 ######################

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -363,6 +363,7 @@ def main():
                       'enable_https': sickbeard.ENABLE_HTTPS,
                       'https_cert': sickbeard.HTTPS_CERT,
                       'https_key': sickbeard.HTTPS_KEY,
+                      'https_chaincert': sickbeard.HTTPS_CHAINCERT,
                       })
     except IOError:
         logger.log(u"Unable to start web server, is something else running on port: " + str(startPort), logger.ERROR)

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -152,6 +152,16 @@
                                     <span class="component-desc">File name or path to HTTPS Key.</span>
                                 </label>
                             </div>
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">HTTPS Chain Certificate</span>
+                                    <input type="text" name="https_chaincert" value="$sickbeard.HTTPS_CHAINCERT" size="35" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">File name or path to HTTPS Chain Certificate.</span>
+                                </label>
+                            </div>
                         </div>
 
                         <input type="submit" class="btn config_submitter" value="Save Changes" />

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -115,6 +115,7 @@ API_KEY = None
 ENABLE_HTTPS = False
 HTTPS_CERT = None
 HTTPS_KEY = None
+HTTPS_CHAINCERT = None
 
 LAUNCH_BROWSER = None
 CACHE_DIR = None
@@ -322,7 +323,7 @@ def initialize(consoleLogging=True):
 
     with INIT_LOCK:
 
-        global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
+        global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, HTTPS_CHAINCERT, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
@@ -398,6 +399,7 @@ def initialize(consoleLogging=True):
         ENABLE_HTTPS = bool(check_setting_int(CFG, 'General', 'enable_https', 0))
         HTTPS_CERT = check_setting_str(CFG, 'General', 'https_cert', 'server.crt')
         HTTPS_KEY = check_setting_str(CFG, 'General', 'https_key', 'server.key')
+        HTTPS_CHAINCERT = check_setting_str(CFG, 'General', 'https_chaincert', 'chain.crt')
 
         ACTUAL_CACHE_DIR = check_setting_str(CFG, 'General', 'cache_dir', 'cache')
         # fix bad configs due to buggy code
@@ -981,6 +983,7 @@ def save_config():
     new_config['General']['enable_https'] = int(ENABLE_HTTPS)
     new_config['General']['https_cert'] = HTTPS_CERT
     new_config['General']['https_key'] = HTTPS_KEY
+    new_config['General']['https_chaincert'] = HTTPS_CHAINCERT
 
     new_config['General']['use_nzbs'] = int(USE_NZBS)
     new_config['General']['use_torrents'] = int(USE_TORRENTS)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -679,7 +679,7 @@ class ConfigGeneral:
     @cherrypy.expose
     def saveGeneral(self, log_dir=None, web_port=None, web_log=None, web_ipv6=None,
                     launch_browser=None, web_username=None, use_api=None, api_key=None,
-                    web_password=None, version_notify=None, enable_https=None, https_cert=None, https_key=None):
+                    web_password=None, version_notify=None, enable_https=None, https_cert=None, https_key=None, https_chaincert=None):
 
         results = []
 

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -76,6 +76,7 @@ def initWebServer(options={}):
     enable_https = options['enable_https']
     https_cert = options['https_cert']
     https_key = options['https_key']
+    https_chaincert = options['https_chaincert']
 
     if enable_https:
         # If either the HTTPS certificate or key do not exist, make some self-signed ones.
@@ -117,6 +118,8 @@ def initWebServer(options={}):
     if enable_https:
         options_dict['server.ssl_certificate'] = https_cert
         options_dict['server.ssl_private_key'] = https_key
+        if https_chaincert and os.path.exists(https_chaincert):
+            options_dict['server.ssl_certificate_chain'] = https_chaincert
         protocol = "https"
     else:
         protocol = "http"


### PR DESCRIPTION
If one needed a chain certificate for their browser not to complain about their certificate.

As far as I know, sticking it into server.crt does not work?

Default is for a chain.crt in the sickbeard data directory.
