### PR TITLE
adding sickbeard_start function to init.freebsd

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -48,23 +48,26 @@ load_rc_config ${name}
 
 WGET="/usr/local/bin/wget" # You need wget for this script to safely shutdown Sick Beard.
 
+start_cmd="${name}_start"
 status_cmd="${name}_status"
 stop_cmd="${name}_stop"
 
-command="/usr/sbin/daemon"
-command_args="-f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py --quiet --nolaunch"
+sickbeard_start() {
+    # Check for wget and refuse to start without it.
+    if [ ! -x "${WGET}" ]; then
+      warn "Sickbeard not started: You need wget to safely shut down Sick Beard."
+      exit 1
+    fi
 
-# Check for wget and refuse to start without it.
-if [ ! -x "${WGET}" ]; then
-  warn "Sickbeard not started: You need wget to safely shut down Sick Beard."
-  exit 1
-fi
+    # Ensure user is root when running this script.
+    if [ `id -u` != "0" ]; then
+      echo "Oops, you should be root before running this!"
+      exit 1
+    fi
 
-# Ensure user is root when running this script.
-if [ `id -u` != "0" ]; then
-  echo "Oops, you should be root before running this!"
-  exit 1
-fi
+    /usr/sbin/daemon -f -p ${sickbeard_pid} python ${sickbeard_dir}/SickBeard.py --quiet --nolaunch
+    echo "Starting ${name}."
+}
 
 verify_sickbeard_pid() {
     # Make sure the pid corresponds to the Sick Beard process.
@@ -77,7 +80,7 @@ verify_sickbeard_pid() {
 sickbeard_stop() {
     echo "Stopping $name"
     verify_sickbeard_pid
-    ${WGET} -O - -q --user=${sickbeard_web_user} --password=${sickbeard_web_password} "http://${sickbeard_host}:${sickbeard_port}/home/shutdown/" >/dev/null
+    ${WGET} -O - -q --user=${sickbeard_web_user} --password=${sickbeard_web_password} "http://${sickbeard_host}:${sickbeard_port}/home/shutdown/?pid=${pid}" >/dev/null
     if [ -n "${pid}" ]; then
       wait_for_pids ${pid}
       echo "Stopped"


### PR DESCRIPTION
the changes in this pull request allowed me to do the following, all in working order:

```
root@usenet:/usr/local/etc/rc.d # service sickbeard start
Starting sickbeard.

root@usenet:~ # service sickbeard status
sickbeard is running as 53554

root@usenet:~ # service sickbeard stop
Stopping sickbeard
Waiting for PIDS: 53554.
Stopped
```
1. there was no start function in the init script so I added one. Previously, starting sickbeard via the script did nothing at all.
2. the shutdown script did not work, so I changed the http request to reflect the actual shutdown url.

my testing environment for this script is FreeBSD 10.0-STABLE. I'd be happy to work more on this script if it is needed.

Let me know if you have any questions.
