### PR TITLE
Modify config UI to clairfy some Plex options are for use with clients

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -143,15 +143,15 @@
                             <div class="field-pair">
                                 <input type="checkbox" name="plex_notify_onsnatch" id="plex_notify_onsnatch" #if $sickbeard.PLEX_NOTIFY_ONSNATCH then "checked=\"checked\"" else ""# />
                                 <label class="clearfix" for="plex_notify_onsnatch">
-                                    <span class="component-title">Notify on Snatch</span>
-                                    <span class="component-desc">Send notification when we start a download?</span>
+                                    <span class="component-title">Notify Client on Snatch</span>
+                                    <span class="component-desc">Send notification (Plex clients only) when we start a download?</span>
                                 </label>
                             </div>
                             <div class="field-pair">
                                 <input type="checkbox" name="plex_notify_ondownload" id="plex_notify_ondownload" #if $sickbeard.PLEX_NOTIFY_ONDOWNLOAD then "checked=\"checked\"" else ""# />
                                 <label class="clearfix" for="plex_notify_ondownload">
-                                    <span class="component-title">Notify on Download</span>
-                                    <span class="component-desc">Send notification when we finish a download?</span>
+                                    <span class="component-title">Notify Client on Download</span>
+                                    <span class="component-desc">Send notification (Plex clients only) when we finish a download?</span>
                                 </label>
                             </div>
                             <div class="field-pair">


### PR DESCRIPTION
Modified the UI buttons as well as hover help to clarify that "Notify on Snatch" and "Notify on Download" are only used with/sent to Plex clients as opposed to servers.  This is to assist with user issues such as http://sickbeard.com/forums/viewtopic.php?f=4&t=6704
