### PR TITLE
Return exit code 0 when stopping a non-running process in ubuntu init script

### DIFF
--- a/init.ubuntu
+++ b/init.ubuntu
@@ -99,12 +99,12 @@ case "$1" in
 
     stop)
         echo "Stopping $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+        start-stop-daemon --stop --pidfile $PID_FILE --retry 15 --oknodo
         ;;
 
     restart|force-reload)
         echo "Restarting $DESC"
-        start-stop-daemon --stop --pidfile $PID_FILE --retry 15
+        start-stop-daemon --stop --pidfile $PID_FILE --retry 15 --oknodo
         start-stop-daemon -d $APP_PATH -c $RUN_AS $EXTRA_SSD_OPTS --start --pidfile $PID_FILE --exec $DAEMON -- $DAEMON_OPTS
         ;;
 


### PR DESCRIPTION
If any other error occurs in the stop script it will just raise an error as expected and not start sickbeard.

This also allows the restart command to start sickbeard when it's not running yet.
