### PR TITLE
Episode Status Management tweaks

### DIFF
--- a/data/interfaces/default/manage_episodeStatuses.tmpl
+++ b/data/interfaces/default/manage_episodeStatuses.tmpl
@@ -11,39 +11,50 @@
 
 <form action="$sbRoot/manage/episodeStatuses" method="get">
 Manage episodes with status <select name="whichStatus">
-#for $curStatus in [$common.SKIPPED, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]:
+#for $curStatus in [$common.SKIPPED, $common.UNKNOWN, $common.SNATCHED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]:
 <option value="$curStatus"#if $curStatus == $whichStatus then " selected=\"selected\"" else ""#>$common.statusStrings[$curStatus]</option>
 #end for
 </select>
-<input class="btn" type="submit" value="Manage" /> 
+<input class="btn" type="submit" value="Manage" /><br>
+
+<label class="checkbox">
+    <input type="checkbox" value="True" id="includeSpecials" name="includeSpecials" #if $includeSpecials then "checked=\"checked\"" else ""# />
+    Include episodes in Season 0 (Specials)?
+</label>
+
+<label class="checkbox">
+    <input type="checkbox" value="True" id="excludeNoAirdate" name="excludeNoAirdate" #if $excludeNoAirdate then "checked=\"checked\"" else ""# />
+    Exclude episodes with airdate of 'never' (No Airdate)?
+</label>
+
 </form>
 
 #if $whichStatus and not $ep_counts:
-<br />
+<hr>
+<h3>None of your episodes have status $common.statusStrings[$int($whichStatus)] <small>(#if $includeSpecials then "+Specials" else "-Specials"# #if $excludeNoAirdate then "-NoAirdate" else "+NoAirdate"#)</small></h3>
 
-<h3>None of your episodes have status $common.statusStrings[$int($whichStatus)]</h3>
 #elif $whichStatus and $ep_counts:
-<br />
-
-<h3>Shows containing $common.statusStrings[$int($whichStatus)] episodes</h3>
+<hr>
+<h3>${len($sorted_show_ids)} Shows containing $common.statusStrings[$int($whichStatus)] episodes <small>(#if $includeSpecials then "+Specials" else "-Specials"# #if $excludeNoAirdate then "-NoAirdate" else "+NoAirdate"#)</small></h3>
 
 <script type="text/javascript" src="$sbRoot/js/manageEpisodeStatuses.js?$sbPID"></script>
 
-<br />
-
 <form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
-
+<input type="button" class="btn btn-mini btn-primary toggleAll" value="Toggle All Episodes" />
+<input type="button" class="btn btn-mini btn-danger expandAll" value="Expand All Shows" />
 <table class="sickbeardTable" cellspacing="1" border="0" cellpadding="0">
     #for $cur_tvdb_id in $sorted_show_ids:
 <tr id="$cur_tvdb_id">
 <th><input type="checkbox" class="allCheck" id="allCheck-$cur_tvdb_id" name="$cur_tvdb_id-all" checked="checked" /></th>
-<th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="btn get_more_eps" id="$cur_tvdb_id" value="Expand" /></th>
+<th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="$sbRoot/home/displayShow?show=$cur_tvdb_id">$show_names[$cur_tvdb_id]</a> ($ep_counts[$cur_tvdb_id]) <input type="button" class="btn btn-mini get_more_eps" id="$cur_tvdb_id" value="Expand" /></th>
 </tr>
     #end for
 </table>
 
 <input type="hidden" id="oldStatus" name="oldStatus" value="$whichStatus" />
-#if $whichStatus in ($common.ARCHIVED, $common.IGNORED, $common.SNATCHED):
+<input type="hidden" id="opt_includeSpecials" name="opt_includeSpecials" value="$includeSpecials" />
+<input type="hidden" id="opt_excludeNoAirdate" name="opt_excludeNoAirdate" value="$excludeNoAirdate" />
+#if $whichStatus in ($common.SNATCHED, $common.ARCHIVED, $common.IGNORED):
 #set $row_class = "good"
 #else
 #set $row_class = $common.Overview.overviewStrings[$whichStatus]
@@ -51,7 +62,7 @@ Manage episodes with status <select name="whichStatus">
 <input type="hidden" id="row_class" value="$row_class" />
 <br />
 Set checked shows/episodes to <select name="newStatus">
-#set $statusList = [$common.SKIPPED, $common.WANTED, $common.ARCHIVED, $common.IGNORED]
+#set $statusList = [$common.WANTED, $common.SKIPPED, $common.ARCHIVED, $common.IGNORED]
 #if $int($whichStatus) in $statusList
 $statusList.remove($int($whichStatus))
 #end if

--- a/data/js/manageEpisodeStatuses.js
+++ b/data/js/manageEpisodeStatuses.js
@@ -27,13 +27,16 @@ $(document).ready(function() {
         var ischecked = $('#allCheck-' + cur_tvdb_id).prop('checked');
         var last_row = $('tr#' + cur_tvdb_id);
 
+        $(this).prop("disabled", true);
         $.getJSON(sbRoot + '/manage/showEpisodeStatuses',
                   {
                    tvdb_id: cur_tvdb_id,
-                   whichStatus: $('#oldStatus').val()
+                   whichStatus: $('#oldStatus').val(),
+                   includeSpecials: $('#opt_includeSpecials').val(),
+                   excludeNoAirdate: $('#opt_excludeNoAirdate').val()
                   },
                   function (data) {
-                      $.each(data, function(season,eps){
+                      $.each(data, function(season, eps) {
                           $.each(eps, function(episode, name) {
                               //alert(season+'x'+episode+': '+name);
                               last_row.after(make_row(cur_tvdb_id, season, episode, name, ischecked));
@@ -41,6 +44,39 @@ $(document).ready(function() {
                       });
                   });
         $(this).hide();
+    });
+
+    $('.expandAll').click(function() {
+        $(this).prop("disabled", true);
+        $('.get_more_eps').each(function() {
+            var cur_tvdb_id = $(this).attr('id');
+            var ischecked = $('#allCheck-' + cur_tvdb_id).prop('checked');
+            var last_row = $('tr#' + cur_tvdb_id);
+
+            $(this).prop("disabled", true);
+            $.getJSON(sbRoot + '/manage/showEpisodeStatuses',
+                      {
+                       tvdb_id: cur_tvdb_id,
+                       whichStatus: $('#oldStatus').val(),
+                       includeSpecials: $('#opt_includeSpecials').val(),
+                       excludeNoAirdate: $('#opt_excludeNoAirdate').val()
+                      },
+                      function (data) {
+                          $.each(data, function(season, eps) {
+                              $.each(eps, function(episode, name) {
+                                  last_row.after(make_row(cur_tvdb_id, season, episode, name, ischecked));
+                              });
+                          });
+                      });
+            $(this).hide();
+        });
+        $(this).hide();
+    });
+
+    $('.toggleAll').click(function() {
+        $('.sickbeardTable input').each(function() {
+            this.checked = !this.checked;
+        });
     });
 
 });


### PR DESCRIPTION
- Add 'expand all shows' button
- Add 'toggle all' button
- Add **Unknown** status to be queried (useful to find episodes that belong to a show with invalid location)
- Add options to filter out inital data set (by default the same data is returned as before, just now users have the option to fine tune)
  - Include specials (season0) - before we always excluded
  - Exclude episodes without airdate 'never' - before we always included
