### PR TITLE
update history to store provider type as source

### DIFF
--- a/data/css/style.css
+++ b/data/css/style.css
@@ -752,6 +752,26 @@ span.pause {
 }
 
 /* =======================================================================
+history.tmpl
+========================================================================== */
+th.col-src,
+td.col-src {
+  width: 45px;
+  text-align: center;
+}
+th.col-time,
+td.col-time {
+  width: 155px;
+  white-space: nowrap;
+  text-align: center;
+}
+th.col-action,
+td.col-action {
+  width: 110px;
+  text-align: center;
+}
+
+/* =======================================================================
 config.tmpl
 ========================================================================== */
 .infoTable td {

--- a/data/interfaces/default/history.tmpl
+++ b/data/interfaces/default/history.tmpl
@@ -15,47 +15,71 @@
 
 <script type="text/javascript">
 <!--
-\$(document).ready(function() 
-{ 
+\$(document).ready(function() {
     \$("#historyTable:has(tbody tr)").tablesorter({
         widgets: ['zebra', 'stickyHeaders', 'filter'],
-        sortList: [[0,1]],
+        sortList: [[1,1]],
+        sortLocaleCompare : true,
+        headers: {
+            1: { sorter: "text" }
+        },
         textExtraction: {
-            4: function(node) { return \$(node).find("span").text().toLowerCase(); }
-        }
+            0: function(node) { if (\$("img[title]", node).length > 0) {
+                                    return \$("img[title]", node).eq(0).attr("title");
+                                } else {
+                                    return \$(node).text();
+                                }
+                              },
+            4: function(node) { if (\$("img[alt]", node).length > 0) {
+                                    return \$("img[alt]", node).eq(0).attr("alt");
+                                } else {
+                                    return \$(node).text();
+                                }
+                              },
+            5: function(node) { return \$(node).find("span").text().toLowerCase(); }
+        },
+        widgetOptions : { filter_useParsedData : true }
     });
     \$('#limit').change(function(){
-        url = '$sbRoot/history/?limit='+\$(this).val()
+        url = '$sbRoot/history/?limit=' + \$(this).val()
         window.location.href = url
     });
 });
 //-->
 </script>
 
-<div class="h2footer align-right"><b>Limit:</b> 
+<div class="h2footer align-right"><b>Limit:</b>
     <select name="limit" id="limit">
         <option value="100" #if $limit == "100" then "selected=\"selected\"" else ""#>100</option>
         <option value="250" #if $limit == "250" then "selected=\"selected\"" else ""#>250</option>
         <option value="500" #if $limit == "500" then "selected=\"selected\"" else ""#>500</option>
+        <option value="1000" #if $limit == "1000" then "selected=\"selected\"" else ""#>1000</option>
         <option value="0" #if $limit == "0" then "selected=\"selected\"" else ""#>All</option>
     </select>
 </div><br/>
 
 <table id="historyTable" class="tablesorter" cellspacing="1" border="0" cellpadding="0">
-  <thead><tr><th class="nowrap">Time</th><th>Episode</th><th>Action</th><th>Provider</th><th>Quality</th></tr></thead>
+  <thead><tr><th class="col-src">Src</th><th class="col-time">Time</th><th>Episode</th><th class="col-action">Action</th><th>Provider</th><th>Quality</th></tr></thead>
   <tbody>
 #for $hItem in $historyResults:
 #set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($hItem["action"]))
   <tr>
-    <td class="nowrap">$datetime.datetime.strptime(str($hItem["date"]), $history.dateFormat)</td>
-    <td><a href="$sbRoot/home/displayShow?show=$hItem["showid"]#season-$hItem["season"]">$hItem["show_name"] - <%=str(hItem["season"]) +"x"+ "%02i" % int(hItem["episode"]) %></a></td>
-    <td align="center">$statusStrings[$curStatus]</td>
+    <td class="col-src">
+    #if $len($hItem["source"]) > 0:
+        <img src="$sbRoot/images/${hItem["source"]}.png" width="16" height="16" alt="$hItem["source"]" title="$hItem["source"]"/>
+    #else:
+        $hItem["source"]
+    #end if
+    </td>
+    <td class="col-time">$datetime.datetime.strptime(str($hItem["date"]), $history.dateFormat)</td>
+    <td><a href="$sbRoot/home/displayShow?show=$hItem["showid"]#season-$hItem["season"]">$hItem["show_name"] - <%=str(hItem["season"]) + "x" + "%02i" % int(hItem["episode"]) %></a></td>
+    <td class="col-action">$statusStrings[$curStatus]</td>
     <td align="center">
     #if $curStatus == DOWNLOADED and $str($hItem["provider"]) == '-1':
         #set $match = $re.search("\-(\w+)\.\w{3}\Z", $os.path.basename($hItem["resource"]))
         #if $match:
             #if $match.group(1).upper() in ("X264", "720P"):
-                #set $match = $re.search("(\w+)\-.*\-"+$match.group(1)+"\.\w{3}\Z", $os.path.basename($hItem["resource"]), re.IGNORECASE)
+                #set $match = $re.search("(\w+)\-.*\-" + $match.group(1) + "\.\w{3}\Z", $os.path.basename($hItem["resource"]), re.IGNORECASE)
                 #if $match:
                     $match.group(1).upper()
                 #end if
@@ -66,19 +90,19 @@
     #elif $curStatus == DOWNLOADED:
         $hItem["provider"]
     #else
-      #if $len($hItem["provider"]) > 0
+      #if $len($hItem["provider"]) > 0:
         #set provider_id = $generic.GenericProvider.makeID($hItem["provider"])
         #set $provider = $providers.getProviderClass($provider_id)
         #if $provider is not None:
             #set image_name = provider.imageName()
         #else:
-            #if $hItem["provider"] in ["Bin-Req", "TVBinz", "NZBs.org Old", "NZBMatrix", "NZBs'R'US", "Newzbin", "nzbX"]
+            #if $hItem["provider"] in ["Bin-Req", "TVBinz", "NZBs.org Old", "NZBMatrix", "NZBs'R'US", "Newzbin", "nzbX"]:
                 #set image_name = $provider_id + '.png'
             #else:
                 #set image_name = 'missing.png'
             #end if
         #end if
-        <img src="$sbRoot/images/providers/$image_name" width="16" height="16" alt="$hItem["provider"]" title="$hItem["provider"]"/> $hItem["provider"]
+        <img src="$sbRoot/images/providers/$image_name" width="16" height="16" alt="$hItem["provider"]" title="$hItem["provider"]"/>
       #end if
     #end if
     </td>

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -27,7 +27,7 @@ from sickbeard import encodingKludge as ek
 from sickbeard.name_parser.parser import NameParser, InvalidNameException
 
 MIN_DB_VERSION = 9  # oldest db version we support migrating from
-MAX_DB_VERSION = 17
+MAX_DB_VERSION = 18
 
 
 class MainSanityCheck(db.DBSanityCheck):
@@ -98,7 +98,7 @@ def backupDatabase(version):
 # Add new migrations at the bottom of the list; subclass the previous migration.
 
 
-# schema is based off v17 - build 50#
+# schema is based off v18 - build 507
 class InitialSchema (db.SchemaUpgrade):
     def test(self):
         return self.hasTable("tv_shows") and self.hasTable("db_version") and self.checkDBVersion() >= MIN_DB_VERSION and self.checkDBVersion() <= MAX_DB_VERSION
@@ -107,14 +107,14 @@ class InitialSchema (db.SchemaUpgrade):
         if not self.hasTable("tv_shows") and not self.hasTable("db_version"):
             queries = [
                 "CREATE TABLE db_version (db_version INTEGER);",
-                "CREATE TABLE history (action NUMERIC, date NUMERIC, showid NUMERIC, season NUMERIC, episode NUMERIC, quality NUMERIC, resource TEXT, provider TEXT);",
+                "CREATE TABLE history (action NUMERIC, date NUMERIC, showid NUMERIC, season NUMERIC, episode NUMERIC, quality NUMERIC, resource TEXT, provider TEXT, source TEXT);",
                 "CREATE TABLE info (last_backlog NUMERIC, last_tvdb NUMERIC);",
                 "CREATE TABLE tv_episodes (episode_id INTEGER PRIMARY KEY, showid NUMERIC, tvdbid NUMERIC, name TEXT, season NUMERIC, episode NUMERIC, description TEXT, airdate NUMERIC, hasnfo NUMERIC, hastbn NUMERIC, status NUMERIC, location TEXT, file_size NUMERIC, release_name TEXT);",
                 "CREATE TABLE tv_shows (show_id INTEGER PRIMARY KEY, location TEXT, show_name TEXT, tvdb_id NUMERIC, network TEXT, genre TEXT, runtime NUMERIC, quality NUMERIC, airs TEXT, status TEXT, flatten_folders NUMERIC, paused NUMERIC, startyear NUMERIC, tvr_id NUMERIC, tvr_name TEXT, air_by_date NUMERIC, lang TEXT, last_update_tvdb NUMERIC, rls_require_words TEXT, rls_ignore_words TEXT, skip_notices NUMERIC);",
                 "CREATE INDEX idx_tv_episodes_showid_airdate ON tv_episodes (showid,airdate);",
                 "CREATE INDEX idx_showid ON tv_episodes (showid);",
                 "CREATE UNIQUE INDEX idx_tvdb_id ON tv_shows (tvdb_id);",
-                "INSERT INTO db_version (db_version) VALUES (17);"
+                "INSERT INTO db_version (db_version) VALUES (18);"
             ]
 
             for query in queries:
@@ -446,7 +446,7 @@ class AddRequireAndIgnoreWords(AddLastUpdateTVDB):
         self.incDBVersion()
 
 
-# included in build 50# (2014-0#-##)
+# included in build 507 (2014-0#-##)
 class CleanupHistoryAndSpecials(AddRequireAndIgnoreWords):
     """ Cleanup older history entries and set specials from wanted to skipped """
 
@@ -560,7 +560,7 @@ class CleanupHistoryAndSpecials(AddRequireAndIgnoreWords):
         self.connection.action("VACUUM")
 
 
-# included in build 50# (2014-0#-##)
+# included in build 507 (2014-0#-##)
 class AddSkipNotifications(CleanupHistoryAndSpecials):
     """ Adding column skip_notices to tv_shows """
 
@@ -573,5 +573,35 @@ class AddSkipNotifications(CleanupHistoryAndSpecials):
         logger.log(u"Adding column skip_notices to tvshows")
         if not self.hasColumn("tv_shows", "skip_notices"):
             self.addColumn("tv_shows", "skip_notices")
+
+        self.incDBVersion()
+
+
+# included in build 507 (2014-0#-##)
+class AddHistorySource(AddSkipNotifications):
+    """ Adding column source to history """
+
+    def test(self):
+        return self.checkDBVersion() >= 18
+
+    def execute(self):
+        backupDatabase(18)
+
+        logger.log(u"Adding column source to history")
+        if not self.hasColumn("history", "source"):
+            self.addColumn("history", "source", "TEXT", "")
+
+        logger.log(u"Analyzing history and setting snatch source...")
+        # set source to nzb by default
+        self.connection.action("UPDATE history SET source = 'nzb' WHERE action % 100 = 2")
+        # set source to torrent where needed
+        set_torrent_source = []
+        history_results = self.connection.select("SELECT * FROM history WHERE action % 100 = 2 AND provider IN ('BTN', 'HDbits', 'TorrentLeech', 'TvTorrents')")
+        for cur_result in history_results:
+                set_torrent_source.append(["UPDATE history SET source = 'torrent' WHERE action = ? AND date = ? AND showid = ? AND provider = ? AND quality = ?", \
+                                          [cur_result["action"], cur_result["date"], cur_result["showid"], cur_result["provider"], cur_result["quality"]]
+                                           ])
+        if len(set_torrent_source) > 0:
+            self.connection.mass_action(set_torrent_source)
 
         self.incDBVersion()

--- a/sickbeard/history.py
+++ b/sickbeard/history.py
@@ -23,13 +23,14 @@ from sickbeard.common import SNATCHED, Quality
 
 dateFormat = "%Y%m%d%H%M%S"
 
-def _logHistoryItem(action, showid, season, episode, quality, resource, provider):
+
+def _logHistoryItem(action, showid, season, episode, quality, resource, provider, source):
 
     logDate = datetime.datetime.today().strftime(dateFormat)
 
     myDB = db.DBConnection()
-    myDB.action("INSERT INTO history (action, date, showid, season, episode, quality, resource, provider) VALUES (?,?,?,?,?,?,?,?)",
-                [action, logDate, showid, season, episode, quality, resource, provider])
+    myDB.action("INSERT INTO history (action, date, showid, season, episode, quality, resource, provider, source) VALUES (?,?,?,?,?,?,?,?,?)",
+                [action, logDate, showid, season, episode, quality, resource, provider, source])
 
 
 def logSnatch(searchResult):
@@ -39,28 +40,32 @@ def logSnatch(searchResult):
         showid = int(curEpObj.show.tvdbid)
         season = int(curEpObj.season)
         episode = int(curEpObj.episode)
+
         quality = searchResult.quality
 
         providerClass = searchResult.provider
-        if providerClass != None:
+        if providerClass is not None:
             provider = providerClass.name
+            source = searchResult.provider.providerType
         else:
             provider = "unknown"
+            source = "unknown"
 
         action = Quality.compositeStatus(SNATCHED, searchResult.quality)
 
         resource = searchResult.name
 
-        _logHistoryItem(action, showid, season, episode, quality, resource, provider)
+        _logHistoryItem(action, showid, season, episode, quality, resource, provider, source)
 
-def logDownload(episode, filename, new_ep_quality, release_group=None):
+
+def logDownload(episode, filename, new_ep_quality, release_group=None, source=""):
 
     showid = int(episode.show.tvdbid)
     season = int(episode.season)
     epNum = int(episode.episode)
 
     quality = new_ep_quality
-    
+
     # store the release group as the provider if possible
     if release_group:
         provider = release_group
@@ -69,5 +74,4 @@ def logDownload(episode, filename, new_ep_quality, release_group=None):
 
     action = episode.status
 
-    _logHistoryItem(action, showid, season, epNum, quality, filename, provider)
-
+    _logHistoryItem(action, showid, season, epNum, quality, filename, provider, source)


### PR DESCRIPTION
- Add `source` to history (nzb/torrent) to store the provider type.
- Improve filter on history to handle accented characters, use extracted provider image title rather than relying on the text (keep column width down), and specify some column widths.
