### PR TITLE
OMG update2

### DIFF
--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -93,7 +93,7 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
         return [x for x in show_name_helpers.makeSceneSearchString(ep_obj)]
 
     def _get_title_and_url(self, item):
-        return (item['release'], item['getnzb'])
+        return (item['release'].replace('_', '.'), item['getnzb'])
 
     def _doSearch(self, search, show=None, retention=0):
 
@@ -102,6 +102,7 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
         params = {'user': sickbeard.OMGWTFNZBS_USERNAME,
                   'api': sickbeard.OMGWTFNZBS_APIKEY,
                   'eng': 1,
+                  'nukes': 1,  # show nuke info
                   'catid': '19,20',  # SD,HD
                   'retention': sickbeard.USENET_RETENTION,
                   'search': search}
@@ -129,6 +130,9 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
             results = []
 
             for item in parsedJSON:
+                if 'nuked' in item and item['nuked'].startswith('1'):
+                    # logger.log(u"Skipping nuked release: " + item['release'], logger.DEBUG)
+                    continue
                 if 'release' in item and 'getnzb' in item:
                     results.append(item)
 
@@ -166,7 +170,7 @@ class OmgwtfnzbsCache(tvcache.TVCache):
         params = {'user': sickbeard.OMGWTFNZBS_USERNAME,
                   'api': sickbeard.OMGWTFNZBS_APIKEY,
                   'eng': 1,
-                  'delay': 25,
+                  'delay': 30,
                   'catid': '19,20'}  # SD,HD
 
         rss_url = 'https://rss.omgwtfnzbs.org/rss-download.php?' + urllib.urlencode(params)

--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -72,6 +72,9 @@ class WombleCache(tvcache.TVCache):
 
         return RSS_data
 
+    def _translateTitle(self, title):
+        return title.replace(' ', '.').replace('_', '.')
+
     def _checkAuth(self, data):
         return data != 'Invalid Link'
 

--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -52,7 +52,7 @@ class WombleCache(tvcache.TVCache):
         RSS_data = None
         xml_element_tree = None
 
-        for url in [self.provider.url + 'rss/?sec=tv-sd&fr=false', self.provider.url + 'rss/?sec=tv-hd&fr=false']:
+        for url in [self.provider.url + 'rss/?sec=tv-x264&fr=false', self.provider.url + 'rss/?sec=tv-dvd&fr=false']:
             logger.log(u"Womble's Index cache update URL: " + url, logger.DEBUG)
             data = self.provider.getURL(url)
 


### PR DESCRIPTION
- Convert `_` to `.` in release names for OMG and Womble, fix releases getting rejected by invalid show name.
- OMGWTFNZBs: Increase rss item delay from 25->30 min
- OMGWTFNZBs: Skip nuked releases on backlog search.
- WOMBLE: Adjust rss feeds used.
