### PR TITLE
newznab - tweaks

### DIFF
--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -158,8 +158,6 @@ def makeSceneSearchString(episode):
     myDB = db.DBConnection()
     numseasonsSQlResult = myDB.select("SELECT COUNT(DISTINCT season) as numseasons FROM tv_episodes WHERE showid = ? and season != 0", [episode.show.tvdbid])
     numseasons = int(numseasonsSQlResult[0][0])
-    numepisodesSQlResult = myDB.select("SELECT COUNT(episode) as numepisodes FROM tv_episodes WHERE showid = ? and season != 0", [episode.show.tvdbid])
-    numepisodes = int(numepisodesSQlResult[0][0])
 
     # see if we should use dates instead of episodes
     if episode.show.air_by_date and episode.airdate != datetime.date.fromordinal(1):
@@ -168,9 +166,8 @@ def makeSceneSearchString(episode):
         epStrings = ["S%02iE%02i" % (int(episode.season), int(episode.episode)),
                     "%ix%02i" % (int(episode.season), int(episode.episode))]
 
-    # for single-season shows just search for the show name -- if total ep count (exclude s0) is less than 11
-    # due to the amount of qualities and releases, it is easy to go over the 50 result limit on rss feeds otherwise
-    if numseasons == 1 and numepisodes < 11:
+    # for single-season shows just search for the show name
+    if numseasons == 1:
         epStrings = ['']
 
     showNames = set(makeSceneShowSearchStrings(episode.show))


### PR DESCRIPTION
- If there are more than 100 results for a query, fetch up to an additional 300 results (4 hits total).
- Handle when newznab sites take their API offline more gracefully.
- Add logic to fall back to query by string if searching by tvrage id returns 0 results
  
  > Right now we search using tvr if matched, if we have 0 results then sb gives up. Which may be bad if they only have newznab/one provider. Since not all newznab sites may have the tvr associated correctly or even have tvr lookups enabled. This now makes it fall back to searching by string (as if we had no tvr) in that scenario, which can result in a few more hits but at least then we can get results.. so in the end it could mean less hits as were not trying forever with no chance of getting anything.
