### PR TITLE
handle new newznab XML namespace for NZBgeek

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -408,6 +408,8 @@ class NewznabProvider(generic.NZBProvider):
                 if parsedXML.tag == 'rss':
                     items = parsedXML.findall('.//item')
                     response = parsedXML.find('.//{http://www.newznab.com/DTD/2010/feeds/attributes/}response')
+                    if not response and "nzbgeek" in self.url:
+                        response = parsedXML.find('.//{http://nzbgeek.info/feeds/attributes/}response')
 
                 else:
                     logger.log(u"Resulting XML from " + self.name + " isn't RSS, not parsing it", logger.ERROR)


### PR DESCRIPTION
For some reason, sometimes (that's weird...) the newznab namespace in the XML is not the one defined in "sickbeard/providers/newznab.py". I made it work with this quick fix but I don't get why the issue happened (could it be related to my config?).
