### PR TITLE
Add ability to specify HTTPS Chain file

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -363,6 +363,7 @@ def main():
                       'enable_https': sickbeard.ENABLE_HTTPS,
                       'https_cert': sickbeard.HTTPS_CERT,
                       'https_key': sickbeard.HTTPS_KEY,
+                      'https_chain': sickbeard.HTTPS_CHAIN,
                       })
     except IOError:
         logger.log(u"Unable to start web server, is something else running on port: " + str(startPort), logger.ERROR)

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -152,6 +152,17 @@
                                     <span class="component-desc">File name or path to HTTPS Key.</span>
                                 </label>
                             </div>
+
+                            <div class="field-pair">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">HTTPS Chain</span>
+                                    <input type="text" name="https_chain" value="$sickbeard.HTTPS_CHAIN" size="35" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">File name or path to HTTPS Chain.</span>
+                                </label>
+                            </div>
                         </div>
 
                         <input type="submit" class="btn config_submitter" value="Save Changes" />

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -116,6 +116,7 @@ API_KEY = None
 ENABLE_HTTPS = False
 HTTPS_CERT = None
 HTTPS_KEY = None
+HTTPS_CHAIN = None
 
 LAUNCH_BROWSER = None
 CACHE_DIR = None
@@ -334,7 +335,7 @@ def initialize(consoleLogging=True):
 
     with INIT_LOCK:
 
-        global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
+        global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, HTTPS_CHAIN, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
@@ -413,6 +414,7 @@ def initialize(consoleLogging=True):
         ENABLE_HTTPS = bool(check_setting_int(CFG, 'General', 'enable_https', 0))
         HTTPS_CERT = check_setting_str(CFG, 'General', 'https_cert', 'server.crt')
         HTTPS_KEY = check_setting_str(CFG, 'General', 'https_key', 'server.key')
+        HTTPS_CHAIN = check_setting_str(CFG, 'General', 'https_chain', 'chain.crt')
 
         ACTUAL_CACHE_DIR = check_setting_str(CFG, 'General', 'cache_dir', 'cache')
         # fix bad configs due to buggy code
@@ -1009,6 +1011,7 @@ def save_config():
     new_config['General']['enable_https'] = int(ENABLE_HTTPS)
     new_config['General']['https_cert'] = HTTPS_CERT
     new_config['General']['https_key'] = HTTPS_KEY
+    new_config['General']['https_chain'] = HTTPS_CHAIN
 
     new_config['General']['use_nzbs'] = int(USE_NZBS)
     new_config['General']['use_torrents'] = int(USE_TORRENTS)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -76,6 +76,20 @@ def change_HTTPS_KEY(https_key):
 
     return True
 
+def change_HTTPS_CHAIN(https_chain):
+
+    if https_chain == '':
+        sickbeard.HTTPS_CHAIN = ''
+        return True
+
+    if os.path.normpath(sickbeard.HTTPS_CHAIN) != os.path.normpath(https_chain):
+        if helpers.makeDir(os.path.dirname(os.path.abspath(https_chain))):
+            sickbeard.HTTPS_CHAIN = os.path.normpath(https_chain)
+            logger.log(u"Changed https chain path to " + https_chain)
+        else:
+            return False
+
+    return True
 
 def change_LOG_DIR(log_dir, web_log):
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -719,7 +719,7 @@ class ConfigGeneral:
     @cherrypy.expose
     def saveGeneral(self, log_dir=None, web_port=None, web_log=None, web_ipv6=None,
                     launch_browser=None, web_username=None, use_api=None, api_key=None,
-                    web_password=None, version_notify=None, enable_https=None, https_cert=None, https_key=None):
+                    web_password=None, version_notify=None, enable_https=None, https_cert=None, https_key=None, https_chain=None):
 
         results = []
 
@@ -747,6 +747,9 @@ class ConfigGeneral:
 
         if not config.change_HTTPS_KEY(https_key):
             results += ["Unable to create directory " + os.path.normpath(https_key) + ", https key directory not changed."]
+
+        if not config.change_HTTPS_CHAIN(https_chain):
+            results += ["Unable to create directory " + os.path.normpath(https_chain) + ", https chain directory not changed."]
 
         # API
         sickbeard.USE_API = config.checkbox_to_value(use_api)

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -76,6 +76,7 @@ def initWebServer(options={}):
     enable_https = options['enable_https']
     https_cert = options['https_cert']
     https_key = options['https_key']
+    https_chain = options['https_chain']
 
     if enable_https:
         # If either the HTTPS certificate or key do not exist, make some self-signed ones.
@@ -117,6 +118,7 @@ def initWebServer(options={}):
     if enable_https:
         options_dict['server.ssl_certificate'] = https_cert
         options_dict['server.ssl_private_key'] = https_key
+        options_dict['server.ssl_certificate_chain'] = https_chain
         protocol = "https"
     else:
         protocol = "http"


### PR DESCRIPTION
Fixes bug with certificates not including certificate chain.

Adds a configuration option for HTTPS Chain file, and provides the file to CherryPy in option "server.ssl_certificate_chain".

Link to associated bug report:
https://code.google.com/p/sickbeard/issues/detail?id=2546
