### PR TITLE
Fixed episode file_size_human exception if the file_size is None.

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -854,7 +854,11 @@ class CMD_Episode(ApiCall):
         status, quality = Quality.splitCompositeStatus(int(episode["status"]))
         episode["status"] = _get_status_Strings(status)
         episode["quality"] = _get_quality_string(quality)
-        episode["file_size_human"] = _sizeof_fmt(episode["file_size"])
+        # ensure that we don't try to convert a None
+        if episode["file_size"]:
+            episode["file_size_human"] = _sizeof_fmt(episode["file_size"])
+        else:
+            episode["file_size_human"] = ""
 
         myDB.connection.close()
         return _responds(RESULT_SUCCESS, episode)


### PR DESCRIPTION
Ran into an exception on an API episode call. Logged out the traceback to see what happened and this came up:

2015-01-15 05:01:00 ERROR    CP Server Thread-4 :: API :: float argument required, not NoneType
    TypeError: float argument required, not NoneType
        return "%3.2f %s" % (num, x)
      File "sickbeard/webapi.py", line 522, in _sizeof_fmt
        episode["file_size_human"] = _sizeof_fmt(episode["file_size"])
      File "sickbeard/webapi.py", line 858, in run
        curOutDict = _functionMaper.get(cmd)(curArgs, curKwargs).run()
      File "sickbeard/webapi.py", line 252, in call_dispatcher
        outDict = _call_dispatcher(args, kwargs)
      File "sickbeard/webapi.py", line 112, in default
2015-01-15 05:01:00 ERROR    CP Server Thread-4 :: API :: Traceback (most recent call last):

For some reason the file_size in the DB was None. Later on when it converts it to a readable format, it bombs out. Simple fix.
