### PR TITLE
Filename sanitization fix

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -159,7 +159,7 @@ def sanitizeFileName(name):
 
     # remove bad chars from the filename
     name = re.sub(r'[\\/\*]', '-', name)
-    name = re.sub(r'[:"<>|?]', '', name)
+    name = re.sub(r'[:"<>|?;,]', '', name)
 
     # remove leading/trailing periods and spaces
     name = name.strip(' .')


### PR DESCRIPTION
Fixed this issue:

`Season.23/How.Its.Made.S23E28.Wood.Garage.Doors;.Salt.Spreaders;.Animatronic.Dinosaurs.mp4`

which should be:

`Season.23/How.Its.Made.S23E28.Wood.Garage.Doors.Salt.Spreaders.Animatronic.Dinosaurs.mp4`
