### PR TITLE
Fix for post-processing when download dir has broken symlinks

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -122,7 +122,8 @@ def processDir(dirName, nzbName=None, method=None, recurse=False, pp_options={})
     folders = filter(lambda x: ek.ek(os.path.isdir, ek.ek(os.path.join, dirName, x)), fileList)
 
     # videoFiles, sorted by size, process biggest file first. Leaves smaller same named file behind
-    videoFiles = sorted(filter(helpers.isMediaFile, fileList), key=lambda x: ek.ek(os.path.getsize, ek.ek(os.path.join, dirName, x)), reverse=True)
+    mediaFiles =  filter(lambda x: ek.ek(os.path.exists, ek.ek(os.path.join, dirName, x)), filter(helpers.isMediaFile, fileList))
+    videoFiles = sorted(mediaFiles, key=lambda x: ek.ek(os.path.getsize, ek.ek(os.path.join, dirName, x)), reverse=True)
     remaining_video_files = list(videoFiles)
 
     num_videoFiles = len(videoFiles)


### PR DESCRIPTION
This happens when running SB on a freenas jail, with a downloads folder shared between SB and other jails. For instance, couchpotato creates symlinks that are valid for the CP jail but are broken when used from the SB jail.

This was originally mentioned in the forums: http://sickbeard.com/forums/viewtopic.php?f=4&t=9598

This change fixes broken symlinks altogether, including the cause explained before.
