### PR TITLE
API: prevent conversion of None type on file_size

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -854,7 +854,10 @@ class CMD_Episode(ApiCall):
         status, quality = Quality.splitCompositeStatus(int(episode["status"]))
         episode["status"] = _get_status_Strings(status)
         episode["quality"] = _get_quality_string(quality)
-        episode["file_size_human"] = _sizeof_fmt(episode["file_size"])
+        if episode["file_size"]:
+            episode["file_size_human"] = _sizeof_fmt(episode["file_size"])
+        else:
+            episode["file_size_human"] = ""
 
         myDB.connection.close()
         return _responds(RESULT_SUCCESS, episode)


### PR DESCRIPTION
Hi, I came across the following error when using the API

```
{
    "data": {
        "args": [], 
        "error_msg": "float argument required, not NoneType", 
        "kwargs": {
            "episode": "9", 
            "season": "4", 
            "tvdbid": "252861"
        }
    }, 
    "message": "SickBeard encountered an internal error! Please report to the Devs", 
    "result": "fatal"
}
```

It seems that when the file_size value is null that the program tries to convert it to a human readable format.
Perhaps a more elegant approach would be using a get setter, will leave it up to you.
Post change the result is:

```
{
    "data": {
        "airdate": "2015-02-08", 
        "description": "", 
        "file_size": null, 
        "file_size_human": "", 
        "location": "", 
        "name": "Season 4, Episode 9", 
        "quality": "N/A", 
        "release_name": null, 
        "status": "Unaired"
    }, 
    "message": "", 
    "result": "success"
}
```
