### PR TITLE
Retain only X episodes (per show setting, optionally delete old episodes automatically)

### DIFF
--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -91,6 +91,13 @@ Results <b>without one</b> of these words in the title will be filtered out<br /
 Separate words with a comma, e.g. "word1,word2,word3"<br />
 <br />
 
+<span class="showLegend">Retain Episode Count (this show):</span><input type="text" name="retain_episode_count" id="retain_episode_count" value="$show.retain_episode_count" size="5" /><br />
+Note: A value of 0, will retain all episodes (default behavior).<br />
+The maximum number of episodes to retain on disk. When new episodes are downloaded,<br />
+old episodes are deleted, keeping the most recent episodes (determined by air date).<br />
+<br />
+
+
 <input class="btn" type="submit" value="Submit" />
 </form>
 

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -27,7 +27,7 @@ from sickbeard import encodingKludge as ek
 from sickbeard.name_parser.parser import NameParser, InvalidNameException
 
 MIN_DB_VERSION = 9  # oldest db version we support migrating from
-MAX_DB_VERSION = 18
+MAX_DB_VERSION = 19
 
 
 class MainSanityCheck(db.DBSanityCheck):
@@ -605,3 +605,21 @@ class AddHistorySource(AddSkipNotifications):
             self.connection.mass_action(set_torrent_source)
 
         self.incDBVersion()
+
+
+class AddRetainEpisodeCount(AddHistorySource):
+    """ Adding column retain_episode_count tv_shows """
+
+    def test(self):
+        return self.checkDBVersion() >= 19
+
+    def execute(self):
+        backupDatabase(19)
+
+        logger.log(u"Adding column retain_episode_count to tvshows")
+        if not self.hasColumn("tv_shows", "retain_episode_count"):
+            self.addColumn("tv_shows", "retain_episode_count", "INTEGER", default=0)
+
+        self.incDBVersion()
+
+

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -846,10 +846,6 @@ class PostProcessor(object):
         #clean episode retention as required by show
         ep_obj.show.cleanEpisodeRetention()
 
-        if ep_obj.show.retain_episode_count is not None and ep_obj.show.retain_episode_count > 0:
-          a=None
-          #ep_obj.show.episodes
-
         # send notifiers library update
         notifiers.update_library(ep_obj)
 

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -842,6 +842,13 @@ class PostProcessor(object):
         # generate nfo/tbn
         ep_obj.createMetaFiles()
         ep_obj.saveToDB()
+        
+        #clean episode retention as required by show
+        ep_obj.show.cleanEpisodeRetention()
+
+        if ep_obj.show.retain_episode_count is not None and ep_obj.show.retain_episode_count > 0:
+          a=None
+          #ep_obj.show.episodes
 
         # send notifiers library update
         notifiers.update_library(ep_obj)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -936,7 +936,7 @@ class TVShow(object):
             "SELECT * FROM tv_episodes WHERE showid = ? AND (status % 10)=? ORDER BY airdate DESC",
             [self.tvdbid, DOWNLOADED]
         )
-        if self.retain_episode_count is not None and self.retain_episode_count > 0:
+        if self.retain_episode_count is not None and int(self.retain_episode_count) > 0:
             logger.log(u"Checking retained episodes.. :"+self.name, logger.DEBUG)
             remove=len(sqlResults) - int(self.retain_episode_count)
             if remove > 0:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -73,6 +73,8 @@ class TVShow(object):
         self.rls_ignore_words = ""
         self.rls_require_words = ""
 
+        self.retain_episode_count = 0
+
         self.lock = threading.Lock()
         self._isDirGood = False
 
@@ -656,6 +658,8 @@ class TVShow(object):
 
             self.rls_ignore_words = sqlResults[0]["rls_ignore_words"]
             self.rls_require_words = sqlResults[0]["rls_require_words"]
+            
+            self.retain_episode_count = int(sqlResults[0]["retain_episode_count"])
 
     def loadFromTVDB(self, cache=True, tvapi=None, cachedSeason=None):
 
@@ -820,6 +824,7 @@ class TVShow(object):
                         "last_update_tvdb": self.last_update_tvdb,
                         "rls_ignore_words": self.rls_ignore_words,
                         "rls_require_words": self.rls_require_words,
+                        "retain_episode_count": self.retain_episode_count,
                         "skip_notices": self.skip_notices
                         }
 
@@ -925,6 +930,27 @@ class TVShow(object):
             # if it's >= maxBestQuality then it's good
             else:
                 return Overview.GOOD
+    def cleanEpisodeRetention(self):
+        myDB = db.DBConnection()
+        sqlResults = myDB.select(
+            "SELECT * FROM tv_episodes WHERE showid = ? AND (status % 10)=? ORDER BY airdate DESC",
+            [self.tvdbid, DOWNLOADED]
+        )
+        if self.retain_episode_count is not None and self.retain_episode_count > 0:
+            logger.log(u"Checking retained episodes.. :"+self.name, logger.DEBUG)
+            remove=len(sqlResults) - int(self.retain_episode_count)
+            if remove > 0:
+                logger.log(u"Removing the last "+str(remove)+" episodes", logger.DEBUG)
+                for ep in sqlResults[-1 * remove:]:
+                    epObj=TVEpisode(self, ep['season'], ep['episode'])
+                    #delete files, and mark as SKIPPED
+                    epObj.deleteFiles()
+                    del epObj
+            else:
+                logger.log(u"Retaining all " +str(len(sqlResults)) + " Episodes", logger.DEBUG)
+
+
+
 
 
 def dirty_setter(attr_name):
@@ -1750,3 +1776,35 @@ class TVEpisode(object):
             self.saveToDB()
             for relEp in self.relatedEps:
                 relEp.saveToDB()
+
+    # delete the files associated with this episode, and mark it skipped
+    # log and ignore failed attempts
+    def deleteFiles(self):
+        related_files = helpers.list_associated_files(self.location, base_name_only=True)
+        logger.log(u"Delete episode files: " + self.location , logger.MESSAGE)
+        # overwrites composite field, as we're
+        #about to delete the file - quality is irrelevant
+        
+        try:
+            if len(self.location) > 0:
+              os.remove(self.location)
+            #if there are no exceptions, then mark it cleared
+            self.hasnfo=0
+            self.hastbn=0
+            self.location=u''
+            self.file_size=0
+            self.status=SKIPPED
+            self.saveToDB()
+            #if related files could not all be deleted, we don't have the episode at this point anyway
+            for cur_related_file in related_files:
+                try:
+                    os.remove(cur_related_file)
+                except (IOError, OSError), e:
+                    logger.log(u"Unable to remove related file " + self.location + ": " + ex(e), logger.ERROR)
+                    pass       
+        except (IOError, OSError), e:
+            logger.log(u"Unable to remove episode file " + self.location + ": " + ex(e), logger.ERROR)
+            pass
+
+     
+

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1800,7 +1800,7 @@ class TVEpisode(object):
                 try:
                     os.remove(cur_related_file)
                 except (IOError, OSError), e:
-                    logger.log(u"Unable to remove related file " + self.location + ": " + ex(e), logger.ERROR)
+                    logger.log(u"Unable to remove related file " + cur_related_file + ": " + ex(e), logger.ERROR)
                     pass       
         except (IOError, OSError), e:
             logger.log(u"Unable to remove episode file " + self.location + ": " + ex(e), logger.ERROR)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2284,7 +2284,7 @@ class Home:
         return result['description'] if result else 'Episode not found.'
 
     @cherrypy.expose
-    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, skip_notices=None, directCall=False, air_by_date=None, tvdbLang=None, rls_ignore_words=None, rls_require_words=None):
+    def editShow(self, show=None, location=None, anyQualities=[], bestQualities=[], flatten_folders=None, paused=None, skip_notices=None, directCall=False, air_by_date=None, tvdbLang=None, rls_ignore_words=None, rls_require_words=None,retain_episode_count=None):
 
         if show is None:
             errString = "Invalid show ID: " + str(show)
@@ -2356,6 +2356,7 @@ class Home:
                 showObj.lang = tvdb_lang
                 showObj.rls_ignore_words = rls_ignore_words.strip()
                 showObj.rls_require_words = rls_require_words.strip()
+                showObj.retain_episode_count = retain_episode_count
 
             # if we change location clear the db of episodes, change it, write to db, and rescan
             if os.path.normpath(showObj._location) != os.path.normpath(location):


### PR DESCRIPTION
Database Changes:
- creating new field on tv_shows : retain_episode_count (integer), default 0. Added to TVShow form. Default (0) ignores this setting entirely.

" Note: A value of 0, will retain all episodes (default behavior)."
" The maximum number of episodes to retain on disk. When new episodes are downloaded,"
" old episodes are deleted, keeping the most recent episodes (determined by air date)."

Implementation:
- At the end of the post processing, and renaming, a method call to TVShow will check retention limits.
- If the show has more than the specified number of episodes on disk (marked as downloaded), the older (by air date) episodes are deleted.
- As each episode is deleted, the episode status is reset to SKIPPED (related files deleted as well, nfo, srt, etc).

Use case:
- You want to have the most recent N episodes available for casual watching, but are uninterested in archiving or long term storage.
- In particular, news shows or time sensitive media. (ie, a daily show)

Error Cases:
- If permissions on the filesystem disallow deletion of the base episode file, it is left as is (still marked "downloaded"). It will be attempted again after the next episode download.
- If the base episode file is deleted, but the related files could NOT be removed, the episode is still considered deleted, and status is updated accordingly.
