### PR TITLE
Update show by path if it's known

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -844,6 +844,7 @@ class PostProcessor(object):
         ep_obj.saveToDB()
 
         # send notifiers library update
+        ep_obj.showPath = dest_path
         notifiers.update_library(ep_obj)
 
         self._run_extra_scripts(ep_obj)


### PR DESCRIPTION
Since SB is the one placing the file in the path for XBMC to update, it already knows which path it's going to be in, so just give that path to XBMC instead of going through the process of querying XBMC where it will be and then asking XBMC to updating that.

Asking XBMC the path of a given show to update only works if the show exists already.  If it's a new show (or one where all previous episodes have been deleted) XBMC won't have a path for it in it's database and that forces SB to fall back to asking XBMC to do a full library update.  This is inefficient and wasteful since we can still achieve a single directory update by giving that known path to XBMC.
