### PR TITLE
Updated naming convention

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -26,7 +26,7 @@
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/xbmc.png" alt="" title="XBMC" />
                         <h3><a href="http://xbmc.org/" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC</a></h3>
                         <p>A free and open source cross-platform media center and home entertainment system software with a 10-foot user interface designed for the living-room TV.</p>
-                        <p>For SickBeard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
+                        <p>For Sick Beard to communicate with XBMC you must turn on the <a href="http://wiki.xbmc.org/index.php?title=Webserver" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">XBMC Webserver</a>.</p>
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">


### PR DESCRIPTION
Edited text to say "Sick Beard" instead of "SickBeard" to be in-line with naming conventions.
