### PR TITLE
Use getURL correctly when gzip encoding is a valid response

### DIFF
--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -127,8 +127,7 @@ class NMJNotifier:
         try:
             req = urllib2.Request(updateUrl)
             logger.log(u"NMJ: Sending NMJ scan update command via url: %s" % (updateUrl), logger.DEBUG)
-            handle = sickbeard.helpers.getURLFileLike(req)
-            response = handle.read()
+            response = sickbeard.helpers.getURL(req)
         except IOError, e:
             if hasattr(e, 'reason'):
                 logger.log(u"NMJ: Could not contact Popcorn Hour on host %s: %s" % (host, e.reason), logger.WARNING)

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -45,8 +45,7 @@ class NMJv2Notifier:
         try:
             url_loc = "http://" + host + ":8008/file_operation?arg0=list_user_storage_file&arg1=&arg2=" + instance + "&arg3=20&arg4=true&arg5=true&arg6=true&arg7=all&arg8=name_asc&arg9=false&arg10=false"
             req = urllib2.Request(url_loc)
-            handle1 = sickbeard.helpers.getURLFileLike(req)
-            response1 = handle1.read()
+            response1 = sickbeard.helpers.getURL(req)
             # TODO: convert to etree?
             xml = parseString(response1)
             time.sleep(0.5)
@@ -55,8 +54,7 @@ class NMJv2Notifier:
                 xmlData = xmlTag.replace('<path>', '').replace('</path>', '').replace('[=]', '')
                 url_db = "http://" + host + ":8008/metadata_database?arg0=check_database&arg1=" + xmlData
                 reqdb = urllib2.Request(url_db)
-                handledb = sickbeard.helpers.getURLFileLike(reqdb)
-                responsedb = handledb.read()
+                responsedb = sickbeard.helpers.getURL(reqdb)
                 xmldb = parseString(responsedb)
                 returnvalue = xmldb.getElementsByTagName('returnValue')[0].toxml().replace('<returnValue>', '').replace('</returnValue>', '')
                 if returnvalue == "0":
@@ -94,11 +92,9 @@ class NMJv2Notifier:
             logger.log(u"NMJv2: Try to mount network drive via url: %s" % (host), logger.DEBUG)
             prereq = urllib2.Request(url_scandir)
             req = urllib2.Request(url_updatedb)
-            handle1 = sickbeard.helpers.getURLFileLike(prereq)
-            response1 = handle1.read()
+            response1 = sickbeard.helpers.getURL(prereq)
             time.sleep(0.5)
-            handle2 = sickbeard.helpers.getURLFileLike(req)
-            response2 = handle2.read()
+            response2 = sickbeard.helpers.getURL(req)
         except IOError, e:
             logger.log(u"NMJv2: Could not contact Popcorn Hour on host %s: %s" % (host, e), logger.WARNING)
             return False

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -74,10 +74,7 @@ class PLEXNotifier:
             else:
                 pw_mgr = None
 
-            response = sickbeard.helpers.getURLFileLike(req, password_mgr=pw_mgr)
-
-            result = response.read().decode(sickbeard.SYS_ENCODING)
-            response.close()
+            result = sickbeard.helpers.getURL(req, password_mgr=pw_mgr)
 
             logger.log(u"PLEX: HTTP response: " + result.replace('\n', ''), logger.DEBUG)
             # could return result response = re.compile('<html><li>(.+\w)</html>').findall(result)
@@ -181,8 +178,8 @@ class PLEXNotifier:
                 req.add_header("X-Plex-Version", "1.0")
                 
                 try:
-                    response = sickbeard.helpers.getURLFileLike(req, throw_exc=True)
-                    auth_tree = etree.parse(response)
+                    response = sickbeard.helpers.getURL(req, throw_exc=True)
+                    auth_tree = etree.fromstring(response)
                     token = auth_tree.findall(".//authentication-token")[0].text
                     token_arg = "?X-Plex-Token=" + token
                 
@@ -194,7 +191,7 @@ class PLEXNotifier:
 
             url = "http://%s/library/sections%s" % (sickbeard.PLEX_SERVER_HOST, token_arg)
             try:
-                xml_tree = etree.parse(sickbeard.helpers.getURLFileLike(url))
+                xml_tree = etree.fromstring(sickbeard.helpers.getURL(url))
                 media_container = xml_tree.getroot()
             except IOError, e:
                 logger.log(u"PLEX: Error while trying to contact Plex Media Server: " + ex(e), logger.ERROR)

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -193,10 +193,7 @@ class XBMCNotifier:
             else:
                 pw_mgr = None
 
-            response = sickbeard.helpers.getURLFileLike(req, password_mgr=pw_mgr, throw_exc=True)
-            if response:
-                result = response.read().decode(sickbeard.SYS_ENCODING)
-                response.close()
+            result = sickbeard.helpers.getURL(req, password_mgr=pw_mgr, throw_exc=True)
 
             logger.log(u"XBMC: HTTP response: " + result.replace('\n', ''), logger.DEBUG)
             return result
@@ -333,10 +330,9 @@ class XBMCNotifier:
                 pw_mgr = None
 
             
-            response = sickbeard.helpers.getURLFileLike(req, password_mgr=pw_mgr, throw_exc=True)
+            response = sickbeard.helpers.getURL(req, password_mgr=pw_mgr, throw_exc=True)
             # parse the json result
-            result = json.load(response)
-            response.close()
+            result = json.loads(response)
             logger.log(u"XBMC: JSON response: " + str(result), logger.DEBUG)
             return result  # need to return response for parsing
 


### PR DESCRIPTION
Plex notifications were failing due to use of getURLFileLike returning
a file like object that had not been gzip decoded in line with addheader
request.
