### PR TITLE
Remove unnecessary type attribute from script and style tags.

### DIFF
--- a/data/interfaces/default/apiBuilder.tmpl
+++ b/data/interfaces/default/apiBuilder.tmpl
@@ -7,15 +7,15 @@
         <meta name="viewport" content="width=device-width">
         <meta name="robots" content="noindex">
 
-        <script type="text/javascript" charset="utf-8">
+        <script>
         <!--
             sbRoot = "$sbRoot";
         //-->
         </script>
-        <script type="text/javascript" src="$sbRoot/js/lib/jquery-1.7.2.min.js?$sbPID"></script>
-        <script type="text/javascript" src="$sbRoot/js/apibuilder.js?$sbPID"></script>
+        <script src="$sbRoot/js/lib/jquery-1.7.2.min.js?$sbPID"></script>
+        <script src="$sbRoot/js/apibuilder.js?$sbPID"></script>
 
-        <style type="text/css">
+        <style>
         <!--
             #apibuilder select { padding: 2px 2px 2px 6px; display: block; float: left; margin: auto 8px 4px auto; }
             #apibuilder select option { padding: 1px 6px; line-height: 1.2em; }
@@ -24,8 +24,8 @@
         -->
         </style>
 
-<script type="text/javascript">
-var hide_empty_list=true; 
+<script>
+var hide_empty_list=true;
 var disable_empty_list=true;
 
 addListGroup("api", "Command");

--- a/data/interfaces/default/comingEpisodes.tmpl
+++ b/data/interfaces/default/comingEpisodes.tmpl
@@ -9,10 +9,10 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 #set $sort = $sickbeard.COMING_EPS_SORT
-<script type="text/javascript" src="$sbRoot/js/ajaxEpSearch.js?$sbPID"></script>
+<script src="$sbRoot/js/ajaxEpSearch.js?$sbPID"></script>
 
 <div class="h2footer align-right">
-    <b>Key:</b> 
+    <b>Key:</b>
     <span class="listing-overdue">Past</span>
     <span class="listing-current">Current</span>
     <span class="listing-default">Future</span>
@@ -22,8 +22,8 @@
 
 #if $layout == 'list':
 <!-- start list view //-->
-<script type="text/javascript" src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
-<script type="text/javascript" charset="utf-8">
+<script src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
+<script charset="utf-8">
 <!--
 \$.tablesorter.addParser({
     id: 'loadingNames',
@@ -157,9 +157,9 @@
 <!-- end list view //-->
 #else:
 <!-- start non list view //-->
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 <!--
-\$(document).ready(function(){ 
+\$(document).ready(function(){
   \$('#sbRoot').ajaxEpSearch({'size': 16, 'loadingImage': 'loading16_333333.gif'});
   \$(".epSummary").hide();
   \$(".epSummaryTrigger").click(function() {
@@ -178,13 +178,13 @@
     #set $missed_header = False
     #set $show_div = "epListing listing-default"
 
-    #if $sort == "show": 
+    #if $sort == "show":
         <br/><br/>
     #end if
-    
+
     #for $cur_result in $sql_results:
     <!-- start $cur_result["show_name"] //-->
-        
+
         #if int($cur_result["paused"]) and not $sickbeard.COMING_EPS_DISPLAY_PAUSED:
             #continue
         #end if
@@ -238,7 +238,7 @@
             <span class="tvshowTitle"><a href="$sbRoot/home/displayShow?show=${cur_result["showid"]}">$cur_result["show_name"]
             #if int($cur_result["paused"]):
             <span class="pause">[paused]</span>
-            #end if            
+            #end if
             </a></span>
             <span class="tvshowTitleIcons">
                 <a href="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;" title="http://thetvdb.com/?tab=series&amp;id=${cur_result["showid"]}"><img alt="[tvdb]" height="16" width="16" src="$sbRoot/images/thetvdb16.png" /></a>
@@ -253,7 +253,7 @@
 #if $layout == 'banner':
         </tr>
         <tr>
-#end if          
+#end if
           <td class="nextEp">
             <span class="title">Next Episode:</span> <span><%=str(cur_result["season"])+"x"+"%02i" % int(cur_result["episode"]) %> - $cur_result["name"] ($datetime.date.fromordinal(int($cur_result["airdate"])))</span>
           </td>
@@ -277,7 +277,7 @@
       </table>
       </div>
     </div>
-    
+
     <!-- end $cur_result["show_name"] //-->
     #end for
 
@@ -286,7 +286,7 @@
 <!-- end non list view //-->
 #end if
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 window.setInterval( "location.reload(true)", 600000); // Refresh every 10 minutes
 //-->

--- a/data/interfaces/default/config_general.tmpl
+++ b/data/interfaces/default/config_general.tmpl
@@ -12,7 +12,7 @@
 #set global $topmenu="config"#
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
+<script src="$sbRoot/js/config.js?$sbPID"></script>
 
 <div id="config">
 <div id="config-content">
@@ -38,7 +38,7 @@
                                 <span class="component-desc">Should Sick Beard open its home page when started?</span>
                             </label>
                         </div>
-                        
+
                         <div class="field-pair">
                             <input type="checkbox" name="version_notify" id="version_notify" #if $sickbeard.VERSION_NOTIFY then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="version_notify">
@@ -72,7 +72,7 @@
                     </div>
 
                     <fieldset class="component-group-list">
-                        
+
                         <div class="field-pair">
                             <input type="checkbox" name="web_ipv6" id="web_ipv6" #if $sickbeard.WEB_IPV6 then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="web_ipv6">
@@ -80,7 +80,7 @@
                                 <span class="component-desc">Allow Sick Beard to bind to any available IPv6 address?</span>
                             </label>
                         </div>
-                        
+
                         <div class="field-pair">
                             <input type="checkbox" name="web_log" id="web_log" #if $sickbeard.WEB_LOG then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="web_log">
@@ -88,7 +88,7 @@
                                 <span class="component-desc">Have Sick Beard's web server (cherrypy) generate logs?</span>
                             </label>
                         </div>
-                        
+
                         <div class="field-pair">
                             <label class="nocheck clearfix">
                                 <span class="component-title">HTTP Port</span>
@@ -129,7 +129,7 @@
                                 <span class="component-desc">Enable accessing the interface from a HTTPS address.</span>
                             </label>
                         </div>
-                        
+
                         <div id="content_enable_https">
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
@@ -141,7 +141,7 @@
                                     <span class="component-desc">File name or path to HTTPS Certificate.</span>
                                 </label>
                             </div>
-    
+
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
                                     <span class="component-title">HTTPS Key</span>
@@ -201,7 +201,7 @@
 </form>
 </div></div>
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
     jQuery('#log_dir').fileBrowser({ title: 'Select Log Directory' });
 //-->

--- a/data/interfaces/default/config_hidden.tmpl
+++ b/data/interfaces/default/config_hidden.tmpl
@@ -8,7 +8,7 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
+<script src="$sbRoot/js/config.js?$sbPID"></script>
 
 <div id="config">
 <div id="config-content">
@@ -102,15 +102,15 @@
 </form>
 </div></div>
 
-<script type="text/javascript">
+<script>
 \$(document).ready(function () {
     var loading = '<img src="' + sbRoot + '/images/loading16.gif" height="16" width="16" />';
 
     \$('#sbEnded').click(function () {
         \$('#sbEnded-result').html(loading);
         \$.get(sbRoot + "/config/hidden/sbEnded",
-            function (data) { 
-                \$('#sbEnded-result').html(data); 
+            function (data) {
+                \$('#sbEnded-result').html(data);
                 \$("table").tablesorter({ theme : 'blue', widgets: ['zebra'], sortList: [[0,0]] });
                 var resort = true;
                 \$("table").trigger("update", [resort]);

--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -7,8 +7,8 @@
 #set global $topmenu="config"#
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/configNotifications.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
+<script src="$sbRoot/js/configNotifications.js?$sbPID"></script>
+<script src="$sbRoot/js/config.js?$sbPID"></script>
 
 <div id="config">
     <div id="config-content">

--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -14,8 +14,8 @@
 #set global $topmenu="config"#
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/configPostProcessing.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
+<script src="$sbRoot/js/configPostProcessing.js?$sbPID"></script>
+<script src="$sbRoot/js/config.js?$sbPID"></script>
 
 <div id="config">
 <div id="config-content">
@@ -526,7 +526,7 @@
 </form>
 </div></div>
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
     jQuery('#tv_download_dir').fileBrowser({ title: 'Select TV Download Directory' });
 //-->

--- a/data/interfaces/default/config_providers.tmpl
+++ b/data/interfaces/default/config_providers.tmpl
@@ -9,10 +9,10 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/configProviders.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
+<script src="$sbRoot/js/configProviders.js?$sbPID"></script>
+<script src="$sbRoot/js/config.js?$sbPID"></script>
 #if $sickbeard.USE_NZBS
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 \$(document).ready(function(){
 #for $curNewznabProvider in $sickbeard.newznabProviderList:

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -8,8 +8,8 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/configSearch.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/config.js?$sbPID"></script>
+<script src="$sbRoot/js/configSearch.js?$sbPID"></script>
+<script src="$sbRoot/js/config.js?$sbPID"></script>
 
 <div id="config">
 <div id="config-content">
@@ -18,7 +18,7 @@
 <form id="configForm" action="saveSearch" method="post">
 
             <div id="config-components">
-                
+
                 <div id="core-component-group1" class="component-group clearfix">
 
                     <div class="component-group-desc">
@@ -34,7 +34,7 @@
                                 <span class="component-desc">Replace original download with "Proper/Repack" if nuked?</span>
                             </label>
                         </div>
-                        
+
                         <div class="field-pair">
                             <label class="nocheck clearfix">
                                 <span class="component-title">Search Frequency</span>
@@ -70,7 +70,7 @@
 
                         <div class="clearfix"></div>
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
-                        
+
                     </fieldset>
                 </div><!-- /component-group1 //-->
 
@@ -139,7 +139,7 @@
                                     <span class="component-desc">(eg. http://localhost:8000/)</span>
                                 </label>
                             </div>
-                            
+
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
                                     <span class="component-title">SABnzbd Username</span>
@@ -172,7 +172,7 @@
                                     <span class="component-desc">SABnzbd+ Config -> General -> API Key.</span>
                                 </label>
                             </div>
-                            
+
                             <div class="field-pair">
                                 <label class="nocheck clearfix">
                                     <span class="component-title">SABnzbd Category</span>
@@ -238,15 +238,15 @@
                                 </label>
                             </div>
                         </div>
-                        
+
                         <div class="clearfix"></div>
-                        
+
                         <div class="testNotification" id="testSABnzbd-result">Click below to test.</div>
                         <input type="button" value="Test SABnzbd" id="testSABnzbd" class="btn test-button"/>
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
-                        
+
                         </div><!-- /content_use_nzbs //-->
-                        
+
                     </fieldset>
                 </div><!-- /component-group2 //-->
 
@@ -282,11 +282,11 @@
                                 <span class="component-desc">The directory where Sick Beard should store your <i>Torrent</i> files.</span>
                             </label>
                         </div>
-                        
+
                         <div class="clearfix"></div>
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
                         </div><!-- /content_use_torrents //-->
-                        
+
                     </fieldset>
                 </div><!-- /component-group3 //-->
 
@@ -299,7 +299,7 @@
 </form>
 </div></div>
 
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 <!--
     jQuery('#nzb_dir').fileBrowser({ title: 'Select NZB Black Hole/Watch Directory' });
     jQuery('#torrent_dir').fileBrowser({ title: 'Select Torrent Black Hole/Watch Directory' });

--- a/data/interfaces/default/displayShow.tmpl
+++ b/data/interfaces/default/displayShow.tmpl
@@ -89,7 +89,7 @@ replace with: <b><%=", ".join([Quality.qualityStrings[x] for x in sorted(bestQua
 </div>
 
 <div class="float-left">
-Change selected episodes to 
+Change selected episodes to
 <select id="statusSelect">
 #for $curStatus in [$WANTED, $SKIPPED, $ARCHIVED, $IGNORED] + sorted($Quality.DOWNLOADED):
 #if $curStatus == $DOWNLOADED:
@@ -196,7 +196,7 @@ Change selected episodes to
 
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_bottom.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/lib/jquery.bookmarkscroll.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/displayShow.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/ajaxEpSearch.js?$sbPID"></script>
+<script src="$sbRoot/js/lib/jquery.bookmarkscroll.js?$sbPID"></script>
+<script src="$sbRoot/js/displayShow.js?$sbPID"></script>
+<script src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
+<script src="$sbRoot/js/ajaxEpSearch.js?$sbPID"></script>

--- a/data/interfaces/default/editShow.tmpl
+++ b/data/interfaces/default/editShow.tmpl
@@ -10,8 +10,8 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
-<script type="text/javascript" charset="utf-8">
+<script src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
+<script charset="utf-8">
 <!--
 \$(document).ready(function(){
 
@@ -94,7 +94,7 @@ Separate words with a comma, e.g. "word1,word2,word3"<br />
 <input class="btn" type="submit" value="Submit" />
 </form>
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
     jQuery('#location').fileBrowser({ title: 'Select Show Location' });
 //-->

--- a/data/interfaces/default/errorlogs.tmpl
+++ b/data/interfaces/default/errorlogs.tmpl
@@ -18,7 +18,7 @@ $curError.time $curError.message
 </pre>
 </div>
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 window.setInterval( "location.reload(true)", 600000); // Refresh every 10 minutes
 //-->

--- a/data/interfaces/default/history.tmpl
+++ b/data/interfaces/default/history.tmpl
@@ -13,7 +13,7 @@
 #set global $topmenu="history"#
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript">
+<script>
 <!--
 \$(document).ready(function() {
     \$("#historyTable:has(tbody tr)").tablesorter({

--- a/data/interfaces/default/home.tmpl
+++ b/data/interfaces/default/home.tmpl
@@ -43,7 +43,7 @@
 
 #set $max_download_count = $max_download_count * 100
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 
 \$.tablesorter.addParser({
@@ -70,10 +70,10 @@
     type: 'numeric'
 });
 
-\$.tablesorter.addParser({ 
+\$.tablesorter.addParser({
     id: 'eps',
     is: function(s) {
-        return false; 
+        return false;
     },
     format: function(s) {
         match = s.match(/^(.*)/);
@@ -102,7 +102,7 @@
     type: 'numeric'
 });
 
-\$(document).ready(function(){ 
+\$(document).ready(function(){
 
     \$("#showListTable:has(tbody tr)").tablesorter({
         sortList: [[5,1],[1,0]],
@@ -219,7 +219,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
         <td align="center"><span class="quality Custom">Custom</span></td>
     #end if
         <td align="center"><span style="display: none;">$download_stat</span><div id="progressbar$curShow.tvdbid" style="position:relative;"></div>
-          <script type="text/javascript">
+          <script>
           <!--
                 \$(function() {
                  \$("\#progressbar$curShow.tvdbid").progressbar({

--- a/data/interfaces/default/home_addExistingShow.tmpl
+++ b/data/interfaces/default/home_addExistingShow.tmpl
@@ -12,14 +12,14 @@
 
 <form id="addShowForm" method="post" action="$sbRoot/home/addShows/addNewShow" accept-charset="utf-8">
 
-<script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/addExistingShow.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/rootDirs.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/addShowOptions.js?$sbPID"></script> 
+<script src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
+<script src="$sbRoot/js/addExistingShow.js?$sbPID"></script>
+<script src="$sbRoot/js/rootDirs.js?$sbPID"></script>
+<script src="$sbRoot/js/addShowOptions.js?$sbPID"></script>
 
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 <!--
-\$(document).ready(function(){ 
+\$(document).ready(function(){
     \$( "#tabs" ).tabs({
         collapsible: true,
         selected: #if $sickbeard.ROOT_DIRS then '-1' else '0'#

--- a/data/interfaces/default/home_newShow.tmpl
+++ b/data/interfaces/default/home_newShow.tmpl
@@ -10,10 +10,10 @@
 
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/lib/formwizard.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/newShow.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/addShowOptions.js?$sbPID"></script>
+<script src="$sbRoot/js/lib/formwizard.js?$sbPID"></script>
+<script src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
+<script src="$sbRoot/js/newShow.js?$sbPID"></script>
+<script src="$sbRoot/js/addShowOptions.js?$sbPID"></script>
 
 <div id="displayText">aoeu</div>
 <br />
@@ -80,6 +80,6 @@
 #end if
 </div>
 
-<script type="text/javascript" src="$sbRoot/js/rootDirs.js?$sbPID"></script>
+<script src="$sbRoot/js/rootDirs.js?$sbPID"></script>
 
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_bottom.tmpl")

--- a/data/interfaces/default/home_postprocess.tmpl
+++ b/data/interfaces/default/home_postprocess.tmpl
@@ -17,7 +17,7 @@ Force replace existing episodes:&nbsp;<input type="checkbox" name="force_replace
 </form>
 <br />
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
     jQuery('#episodeDir').fileBrowser({ title: 'Select Unprocessed Episode Folder', key: 'postprocessPath' });
 //-->

--- a/data/interfaces/default/inc_top.tmpl
+++ b/data/interfaces/default/inc_top.tmpl
@@ -16,13 +16,13 @@
         <link rel="apple-touch-icon-precomposed" sizes="72x72" href="$sbRoot/images/ico/apple-touch-icon-72x72-precomposed.png">
         <link rel="apple-touch-icon-precomposed" href="$sbRoot/images/ico/apple-touch-icon-57x57-precomposed.png">
 
-        <link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/bootstrap.css?$sbPID"/>
-        <link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery.pnotify.default.css?$sbPID" />
-        <link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery-ui-1.11.2.custom.css?$sbPID" />
-        <link rel="stylesheet" type="text/css" href="$sbRoot/css/lib/jquery.qtip.css?$sbPID"/>
-        <link rel="stylesheet" type="text/css" href="$sbRoot/css/style.css?$sbPID"/>
+        <link rel="stylesheet" href="$sbRoot/css/lib/bootstrap.css?$sbPID"/>
+        <link rel="stylesheet" href="$sbRoot/css/lib/jquery.pnotify.default.css?$sbPID" />
+        <link rel="stylesheet" href="$sbRoot/css/lib/jquery-ui-1.11.2.custom.css?$sbPID" />
+        <link rel="stylesheet" href="$sbRoot/css/lib/jquery.qtip.css?$sbPID"/>
+        <link rel="stylesheet" href="$sbRoot/css/style.css?$sbPID"/>
 
-<style type="text/css">
+<style>
 <!--
 #contentWrapper { background: url("$sbRoot/images/bg.png") repeat 0 0 transparent; }
 
@@ -60,31 +60,30 @@
 #if $sickbeard.NEWEST_VERSION_STRING:
 .ui-pnotify { top: 30px !important; }
 #end if
-//--> 
+//-->
 </style>
 
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery-1.7.2.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/bootstrap.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery-ui-1.11.2.custom.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.cookie.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.selectboxes.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.tablesorter-2.17.8.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.tablesorter.widgets-2.17.8.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.qtip-2012-04-26.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.pnotify-1.2.2.min.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.form-3.50.js?$sbPID"></script>
-
-    <script type="text/javascript" charset="utf-8">
+    <script src="$sbRoot/js/lib/jquery-1.7.2.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/bootstrap.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery-ui-1.11.2.custom.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.cookie.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.selectboxes.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.tablesorter-2.17.8.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.tablesorter.widgets-2.17.8.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.qtip-2012-04-26.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.pnotify-1.2.2.min.js?$sbPID"></script>
+    <script src="$sbRoot/js/lib/jquery.form-3.50.js?$sbPID"></script>
+    <script>
     <!--
         sbRoot = "$sbRoot"; // needed for browser.js & ajaxNotifications.js
         //HTML for scrolltopcontrol, which is auto wrapped in DIV w/ ID="topcontrol"
-        top_image_html = '<img src="$sbRoot/images/top.gif" width="31" height="11" alt="Jump to top" />'; 
+        top_image_html = '<img src="$sbRoot/images/top.gif" width="31" height="11" alt="Jump to top" />';
     //-->
     </script>
-    <script type="text/javascript" src="$sbRoot/js/lib/jquery.scrolltopcontrol-1.1.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/browser.js?$sbPID"></script>
-    <script type="text/javascript" src="$sbRoot/js/ajaxNotifications.js?$sbPID"></script>
-    <script type="text/javascript">
+    <script src="$sbRoot/js/lib/jquery.scrolltopcontrol-1.1.js?$sbPID"></script>
+    <script src="$sbRoot/js/browser.js?$sbPID"></script>
+    <script src="$sbRoot/js/ajaxNotifications.js?$sbPID"></script>
+    <script>
     <!--
         \$(document).ready(function() {
             \$("#NAV$topmenu").addClass("active");

--- a/data/interfaces/default/manage.tmpl
+++ b/data/interfaces/default/manage.tmpl
@@ -8,7 +8,7 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 \$.tablesorter.addParser({
     id: 'showNames',
@@ -31,8 +31,8 @@
     type: 'numeric'
 });
 
-\$(document).ready(function() 
-{ 
+\$(document).ready(function()
+{
     \$("#massUpdateTable:has(tbody tr)").tablesorter({
         sortList: [[3,0]],
         textExtraction: {
@@ -51,11 +51,11 @@
             9: { sorter: false},
             10: { sorter: false}
         }
-    }); 
+    });
 });
 //-->
 </script>
-<script type="text/javascript" src="$sbRoot/js/massUpdate.js?$sbPID"></script>
+<script src="$sbRoot/js/massUpdate.js?$sbPID"></script>
 
 <form name="massUpdateForm" method="post" action="massUpdate">
 
@@ -127,7 +127,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
     <td align="center"><span class="quality $qualityPresetStrings[$curShow.quality]">$qualityPresetStrings[$curShow.quality]</span></td>
 #else:
     <td align="center"><span class="quality Custom">Custom</span></td>
-#end if 
+#end if
     <td align="center"><img src="$sbRoot/images/#if int($curShow.flatten_folders) == 1 then "yes16.png\" alt=\"Y\"" else "no16.png\" alt=\"N\""# width="16" height="16" /></td>
     <td align="center">$curShow.status</td>
     <td align="center">$curUpdate</td>

--- a/data/interfaces/default/manage_episodeStatuses.tmpl
+++ b/data/interfaces/default/manage_episodeStatuses.tmpl
@@ -37,7 +37,7 @@ Manage episodes with status <select name="whichStatus">
 <hr>
 <h3>${len($sorted_show_ids)} Shows containing $common.statusStrings[$int($whichStatus)] episodes <small>(#if $includeSpecials then "+Specials" else "-Specials"# #if $excludeNoAirdate then "-NoAirdate" else "+NoAirdate"#)</small></h3>
 
-<script type="text/javascript" src="$sbRoot/js/manageEpisodeStatuses.js?$sbPID"></script>
+<script src="$sbRoot/js/manageEpisodeStatuses.js?$sbPID"></script>
 
 <form action="$sbRoot/manage/changeEpisodeStatuses" method="post">
 <input type="button" class="btn btn-mini btn-primary toggleAll" value="Toggle All Episodes" />

--- a/data/interfaces/default/manage_manageSearches.tmpl
+++ b/data/interfaces/default/manage_manageSearches.tmpl
@@ -9,11 +9,11 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
+<script src="$sbRoot/js/plotTooltip.js?$sbPID"></script>
 
 
 <h3>Backlog Search:</h3>
-<a class="btn" href="$sbRoot/manage/manageSearches/pauseBacklog?paused=#if $backlogPaused then "0" else "1"#"><i class="#if $backlogPaused then "icon-play" else "icon-pause"#"></i> #if $backlogPaused then "Unpause" else "Pause"#</a> 
+<a class="btn" href="$sbRoot/manage/manageSearches/pauseBacklog?paused=#if $backlogPaused then "0" else "1"#"><i class="#if $backlogPaused then "icon-play" else "icon-pause"#"></i> #if $backlogPaused then "Unpause" else "Pause"#</a>
 #if not $backlogRunning:
 Not in progress<br />
 #else:
@@ -23,7 +23,7 @@ Currently running<br />
 
 <br />
 <h3>Daily Episode Search:</h3>
-<a class="btn" href="$sbRoot/manage/manageSearches/forceSearch"><i class="icon-exclamation-sign"></i> Force</a> 
+<a class="btn" href="$sbRoot/manage/manageSearches/forceSearch"><i class="icon-exclamation-sign"></i> Force</a>
 #if not $searchStatus:
 Not in progress<br />
 #else:

--- a/data/interfaces/default/manage_massEdit.tmpl
+++ b/data/interfaces/default/manage_massEdit.tmpl
@@ -15,8 +15,8 @@
 #set $initial_quality = $common.SD
 #end if
 #set $anyQualities, $bestQualities = $common.Quality.splitQuality($initial_quality)
-<script type="text/javascript" src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/massEdit.js?$sbPID"></script>
+<script src="$sbRoot/js/qualityChooser.js?$sbPID"></script>
+<script src="$sbRoot/js/massEdit.js?$sbPID"></script>
 
 <form action="massEditSubmit" method="post">
 <input type="hidden" name="toEdit" value="$showList" />

--- a/data/interfaces/default/restart_bare.tmpl
+++ b/data/interfaces/default/restart_bare.tmpl
@@ -1,4 +1,4 @@
-<script type="text/javascript" charset="utf-8">
+<script charset="utf-8">
 <!--
 #try:
     #set curSBHost = $sbHost
@@ -16,8 +16,8 @@ sbHost = "$curSBHost";
 //-->
 </script>
 
-<script type="text/javascript" src="$sbRoot/js/lib/jquery-1.7.2.min.js?$sbPID"></script>
-<script type="text/javascript" src="$sbRoot/js/restart.js?$sbPID"></script>
+<script src="$sbRoot/js/lib/jquery-1.7.2.min.js?$sbPID"></script>
+<script src="$sbRoot/js/restart.js?$sbPID"></script>
 
 <h3>Performing Restart</h3>
 <br />

--- a/data/interfaces/default/testRename.tmpl
+++ b/data/interfaces/default/testRename.tmpl
@@ -11,7 +11,7 @@
 
 <input type="hidden" id="showID" value="$show.tvdbid" />
 
-<script type="text/javascript" src="$sbRoot/js/testRename.js"></script>
+<script src="$sbRoot/js/testRename.js"></script>
 
 <h3>Preview of the proposed name changes</h3>
 <blockquote style="margin-bottom: 0; color: #3A87AD;">
@@ -55,7 +55,7 @@
 #if len($epList) > 1:
     #set $epList = [$min($epList), $max($epList)]
 #end if
-        <tr class="season-$curSeason 
+        <tr class="season-$curSeason
             #if $curLoc == $newLoc:
                 #if $odd then "odd" else "even"#
             #else

--- a/data/interfaces/default/viewlogs.tmpl
+++ b/data/interfaces/default/viewlogs.tmpl
@@ -10,7 +10,7 @@
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 \$(document).ready(function(){
     \$('#minLevel').change(function(){
@@ -35,7 +35,7 @@ $logLines
 </pre>
 </div>
 <br />
-<script type="text/javascript" charset="utf-8">
+<script>
 <!--
 window.setInterval( "location.reload(true)", 600000); // Refresh every 10 minutes
 //-->

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -60,7 +60,7 @@ def initWebServer(options={}):
 <html>
     <head>
         <title>404</title>
-        <script type="text/javascript" charset="utf-8">
+        <script>
           <!--
           location.href = "%s/home/"
           //-->


### PR DESCRIPTION
The `type="text/javascript"` and `type="text/css"` attributes are unnecessary with the HTML5 doctype.

This commit removes them from all SickBeard-originated templates.
