### PR TITLE
Add workaround for improperly cleaned scgi over unix domain socket URI

### DIFF
--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -30,6 +30,11 @@ from sickbeard import db
 
 import sickbeard
 
+# Address poor support for scgi over unix domain sockets
+# this is not nicely handled by python currently
+# http://bugs.python.org/issue23636
+urlparse.uses_netloc.append('scgi')
+
 naming_ep_type = ("%(seasonnumber)dx%(episodenumber)02d",
                   "s%(seasonnumber)02de%(episodenumber)02d",
                    "S%(seasonnumber)02dE%(episodenumber)02d",

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -14,6 +14,7 @@ class QualityTests(unittest.TestCase):
         self.assertEqual(config.clean_url("google.com/xml.rpc"), "http://google.com/xml.rpc")
         self.assertEqual(config.clean_url("google.com"), "http://google.com/")
         self.assertEqual(config.clean_url("http://www.example.com/folder/"), "http://www.example.com/folder/")
+        self.assertEqual(config.clean_url("scgi:///home/user/.config/path/socket"), "scgi:///home/user/.config/path/socket")
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(QualityTests)


### PR DESCRIPTION
The newly added test should demonstrate the currently broken behavior.
