### PR TITLE
Fixed Unicode coercion errors in logging.

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -209,7 +209,7 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
         # Before python 2.7.9, there was no built-in way to validate SSL certificates
         # Since our default is not to validate, it is of low priority to make it available here
         if validate and sys.version_info < (2, 7, 9):
-            logger.log(u"The SSL certificate will not be validated for " + url + "(python 2.7.9+ required)", logger.MESSAGE)
+            logger.log(u"The SSL certificate will not be validated for " + str(url) + "(python 2.7.9+ required)", logger.MESSAGE)
 
         opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies),
                                       MultipartPostHandler.MultipartPostHandler,
@@ -224,42 +224,42 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
         return opener.open(url)
 
     except urllib2.HTTPError, e:
-        logger.log(u"HTTP error " + str(e.code) + " while loading URL " + url, logger.WARNING)
+        logger.log(u"HTTP error " + str(e.code) + " while loading URL " + str(url), logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except urllib2.URLError, e:
-        logger.log(u"URL error " + str(e.reason) + " while loading URL " + url, logger.WARNING)
+        logger.log(u"URL error " + str(e.reason) + " while loading URL " + str(url), logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except BadStatusLine:
-        logger.log(u"BadStatusLine error while loading URL " + url, logger.WARNING)
+        logger.log(u"BadStatusLine error while loading URL " + str(url), logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except socket.timeout:
-        logger.log(u"Timed out while loading URL " + url, logger.WARNING)
+        logger.log(u"Timed out while loading URL " + str(url), logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except ValueError:
-        logger.log(u"Unknown error while loading URL " + url, logger.WARNING)
+        logger.log(u"Unknown error while loading URL " + str(url), logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except Exception:
-        logger.log(u"Unknown exception while loading URL " + url + ": " + traceback.format_exc(), logger.WARNING)
+        logger.log(u"Unknown exception while loading URL " + str(url) + ": " + traceback.format_exc(), logger.WARNING)
         if throw_exc:
             raise 
         else:


### PR DESCRIPTION
Some error messages in helpers.py were not correctly wrapping variables
in str() calls before attempting to append them to unicode output. This
caused unicode coercion errors which masked the actual errors triggering
the logging.

This change simply fixes the logging so it is more accurate.

There may be other instances of similar handling.  But I wanted to keep
this contained to the specific instances I was encountering in my
install.
