### PR TITLE
ISSUE-2556: Centralised regex rename to remove _ from filenames.

### DIFF
--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -188,7 +188,9 @@ def isGoodResult(name, show, log=True):
     """
     Use an automatically-created regex to make sure the result actually is the show it claims to be
     """
-
+    #
+    # Change _ to . to fix releases being rejected whetre the naming convention is to use _ (e.g. FoV)
+    name = re.sub('_', '.', name)
     all_show_names = allPossibleShowNames(show)
     showNames = map(sanitizeSceneName, all_show_names) + all_show_names
 


### PR DESCRIPTION
Some releases (e.g. FoV) use _ in their release naming conventions. This is not
removed in Sick-Beard in a central location. This change fixes that.
