### PR TITLE
Page does not load with saved Pushover priority

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -694,10 +694,10 @@
                                 <label class="nocheck clearfix">
                                     <span class="component-title">Pushover Priority:</span>
                                    <select id="pushover_priority" name="pushover_priority">
-                                        <option value="-2" #if $sickbeard.PUSHOVER_PRIORITY == -2 then 'selected="selected"' else ""#>Lowest</option>
-                                        <option value="-1" #if $sickbeard.PUSHOVER_PRIORITY == -1 then 'selected="selected"' else ""#>Low</option>
-                                        <option value="0" #if $sickbeard.PUSHOVER_PRIORITY == 0 then 'selected="selected"' else ""#>Normal</option>
-                                        <option value="1" #if $sickbeard.PUSHOVER_PRIORITY == 1 then 'selected="selected"' else ""#>High</option>
+                                        <option value="-2" #if $sickbeard.PUSHOVER_PRIORITY == '-2' then 'selected' else ''#>Lowest</option>
+                                        <option value="-1" #if $sickbeard.PUSHOVER_PRIORITY == '-1' then 'selected' else ''#>Low</option>
+                                        <option value="0"  #if $sickbeard.PUSHOVER_PRIORITY ==  '0' then 'selected' else ''#>Normal</option>
+                                        <option value="1"  #if $sickbeard.PUSHOVER_PRIORITY ==  '1' then 'selected' else ''#>High</option>
                                     </select>
                                 </label>
                                 <label class="nocheck clearfix">


### PR DESCRIPTION
This fixes an issue where the notifications configuration page does not
show the saved pushover priority in the select form control. The template
was comparing the html string value to integers which was always false,
hence never returning the selected attribute.
