### PR TITLE
Update pynma.py

### DIFF
--- a/lib/pynma/pynma.py
+++ b/lib/pynma/pynma.py
@@ -6,7 +6,7 @@ from urllib import urlencode
 
 __version__ = "0.1"
 
-API_SERVER = 'nma.usk.bz'
+API_SERVER = 'www.notifymyandroid.com'
 ADD_PATH   = '/publicapi/notify'
 
 USER_AGENT="PyNMA/v%s"%__version__


### PR DESCRIPTION
The current NMA domain has expired and is not responding. Updating the API_SERVER variable to a working domain fixes this issue.
