### PR TITLE
NotifyMyAndroid Endpoint Fix

### DIFF
--- a/data/interfaces/default/config_notifications.tmpl
+++ b/data/interfaces/default/config_notifications.tmpl
@@ -855,7 +855,7 @@
                 <div class="component-group clearfix">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="$sbRoot/images/notifiers/nma.png" alt="" title="NMA" />
-                        <h3><a href="http://nma.usk.bz" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notify My Android</a></h3>
+                        <h3><a href="www.notifymyandroid.com" rel="noreferrer" onclick="window.open('${sickbeard.ANON_REDIRECT}' + this.href, '_blank'); return false;">Notify My Android</a></h3>
                         <p>Notify My Android is a Prowl-like Android App and API that offers an easy way to send notifications from your application directly to your Android device.</p>
                     </div>
                     <fieldset class="component-group-list">

--- a/lib/pynma/pynma.py
+++ b/lib/pynma/pynma.py
@@ -6,7 +6,7 @@ from urllib import urlencode
 
 __version__ = "0.1"
 
-API_SERVER = 'nma.usk.bz'
+API_SERVER = 'www.notifymyandroid.com'
 ADD_PATH   = '/publicapi/notify'
 
 USER_AGENT="PyNMA/v%s"%__version__


### PR DESCRIPTION
See Notify My Android's [author comments in Google+](https://plus.google.com/110805020263741864090/posts/3mfTq6cYwTf) regarding the issue.

Summary:
`nma.usk.bz` is no longer supported as an endpoint for NotifyMyAndroid. Instead, `www.notifymyandroid.com` is recommended.
