### PR TITLE
Remove umask changing

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -94,10 +94,6 @@ def daemonize():
 
     os.setsid()  # @UndefinedVariable - only available in UNIX
 
-    # Make sure I can read my own files and shut out others
-    prev = os.umask(0)
-    os.umask(prev and int('077', 8))
-
     # Make the child a session-leader by detaching from the terminal
     try:
         pid = os.fork()  # @UndefinedVariable - only available in UNIX


### PR DESCRIPTION
The changed umask is very annoying, it causes all new show directories to be automatically created with a 077 umask. This means that other process wanting to read from that directory have to be run as the same user.

In this pull request I've removed the umask changing from SickBeard, should someone want to run with a more restricted umask, they can set it themselves in the init file (where it belongs IMHO).
