### PR TITLE
Protect configfiles, but leave the shows readable

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -94,10 +94,6 @@ def daemonize():
 
     os.setsid()  # @UndefinedVariable - only available in UNIX
 
-    # Make sure I can read my own files and shut out others
-    prev = os.umask(0)
-    os.umask(prev and int('077', 8))
-
     # Make the child a session-leader by detaching from the terminal
     try:
         pid = os.fork()  # @UndefinedVariable - only available in UNIX

--- a/lib/configobj.py
+++ b/lib/configobj.py
@@ -2057,7 +2057,11 @@ class ConfigObj(Section):
         if self.BOM and ((self.encoding is None) or match_utf8(self.encoding)):
             # Add the UTF8 BOM
             output = BOM_UTF8 + output
-            
+
+        # Protect our configuration file so we can read the configuration file, and others can not.
+        prev = os.umask(0)
+        os.umask(prev and int('077', 8))
+        
         if not output.endswith(newline):
             output += newline
         if outfile is not None:
@@ -2066,6 +2070,8 @@ class ConfigObj(Section):
             h = open(self.filename, 'wb')
             h.write(output)
             h.close()
+        # Reset the umask to the original setting
+        os.umask(prev)
 
 
     def validate(self, validator, preserve_errors=False, copy=False,


### PR DESCRIPTION
Moved the umask setting from the global scope into the configfile object.

End result is that (new) configfiles have umask 077, but other files and directories created by SickBeard have the regular umask. By default that means shows are group and world readable, which is what you would normally want.
