### PR TITLE
Python ssl fix here

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -41,6 +41,9 @@ import threading
 import time
 import signal
 import traceback
+# We fix the https connection here by removing ssl verificaton
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 import getopt
 
 import sickbeard


### PR DESCRIPTION
The new version of Python broke https connections in SickBeard. A simple two line correction will fix this by removing the ssl verification.
