### PR TITLE
New Feature: PVR provider type along with support for NextPVR

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -102,6 +102,32 @@
                                 <span class="component-desc">Do not use if you use a post-process script like sabToSickbeard on the same <i>TV Download Dir</i>.</span>
                             </label>
                         </div>
+                        
+                        <div class="field-pair" #if $sickbeard.USE_PVRS == False then "style=\"display:none\"" else ""#>
+                            <label class="nocheck clearfix" for="pvr_post_download_actionr">
+                                <span class="component-title">PVR Cleanup</span>
+                                <select name="pvr_post_download_action" id="pvr_post_download_action" class="input-large" >
+                                    #set $pvr_post_download_action_text = {PVR_DO_NOTHING: "Do Nothing ", PVR_CANCEL_RECORDING: "Cancel Pending Recording ", PVR_DELETE_RECORDING: "Delete Existing Recording "}
+                                    #for $curAction in (PVR_DO_NOTHING, PVR_CANCEL_RECORDING, PVR_DELETE_RECORDING):
+                                      #if $sickbeard.PVR_POST_DOWNLOAD_ACTION == $curAction:
+                                        #set $pvr_post_download_action = "selected=\"selected\""
+                                      #else
+                                        #set $pvr_post_download_action = ""
+                                      #end if
+                                    <option value="$curAction" $pvr_post_download_action>$pvr_post_download_action_text[$curAction]</option>
+                                    #end for
+                                    </select>
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">What function should be performed on PVRs after a file is downloaded?</span>
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc"><b>NOTE:</b> This will allow you to unschedule and/or delete recordings from your pvr if the same episode has been downloaded via nzb/torrent.</span>
+                            </label>
+
+                        </div>
 
                         <div class="clearfix"></div>
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>

--- a/data/interfaces/default/config_providers.tmpl
+++ b/data/interfaces/default/config_providers.tmpl
@@ -38,7 +38,7 @@
                         <p>At least one provider is required but two are recommended.</p>
 
                         #if not $sickbeard.USE_NZBS or not $sickbeard.USE_TORRENTS:
-                        <blockquote style="margin: 20px 0;">NZB/Torrent providers can be toggled in <b><a href="$sbRoot/config/search">Search Settings</a></b></blockquote>
+                        <blockquote style="margin: 20px 0;">NZB/Torrent/PVR providers can be toggled in <b><a href="$sbRoot/config/search">Search Settings</a></b></blockquote>
                         #else:
                         <br/>
                         #end if
@@ -86,11 +86,13 @@
                                 <span class="component-title jumbo">Configure Provider:</span>
                                 <span class="component-desc">
                                     #set $provider_config_list = []
-                                    #for $cur_provider in ("btn", "hdbits", "omgwtfnzbs", "tvtorrents", "torrentleech"):
+                                    #for $cur_provider in ("btn", "hdbits", "omgwtfnzbs", "tvtorrents", "torrentleech", "nextpvr"):
                                         #set $cur_provider_obj = $sickbeard.providers.getProviderClass($cur_provider)
                                         #if $cur_provider_obj.providerType == $GenericProvider.NZB and not $sickbeard.USE_NZBS:
                                             #continue
                                         #elif $cur_provider_obj.providerType == $GenericProvider.TORRENT and not $sickbeard.USE_TORRENTS:
+                                            #continue
+                                        #elif $cur_provider_obj.providerType == $GenericProvider.PVR and not $sickbeard.USE_PVRS:
                                             #continue
                                         #end if
                                         $provider_config_list.append($cur_provider_obj)
@@ -189,6 +191,15 @@
                             </label>
                         </div>
                     </div><!-- /btnDiv //-->
+                    
+                    <div class="providerDiv" id="nextpvrDiv">
+                        <div class="field-pair">
+                            <label class="clearfix">
+                                <span class="component-title">NextPVR Url</span>
+                                <input class="component-desc" type="text" name="nextpvr_url" value="$sickbeard.NEXTPVR_URL" size="40" />
+                            </label>
+                        </div>
+                    </div><!-- /nextpvrDiv //-->
 
 <!-- end div for editing providers -->
 

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -1,4 +1,5 @@
 #import sickbeard
+#from sickbeard.common import PVR_HD_CHANNEL_GREATER_THAN, PVR_HD_CHANNEL_LESS_THAN, PVR_HD_CHANNEL_FIXED_LIST
 #set global $title="Config - Search Settings"
 #set global $header="Search Settings"
 
@@ -289,6 +290,86 @@
 
                     </fieldset>
                 </div><!-- /component-group3 //-->
+                
+                <div id="core-component-group4" class="component-group clearfix">
+
+                    <div class="component-group-desc">
+                        <h3>PVR Search</h3>
+                        <p>Settings that dictate how Sick Beard handles PVR search results.</p>
+                    </div>
+
+                    <fieldset class="component-group-list">
+
+                        <div class="field-pair">
+                            <input type="checkbox" name="use_pvrs" class="enabler" id="use_pvrs" #if $sickbeard.USE_PVRS == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="use_pvrs">
+                                <span class="component-title">Search PVRs</span>
+                                <span class="component-desc">Should Sick Beard search via PVR providers?</span>
+                            </label>
+                        </div>
+                        
+                        <div id="content_use_pvrs">
+                             <div class="field-pair">
+                                <label class="nocheck clearfix" for="pvr_hd_channel_method">
+                                    <span class="component-title">HD Channel Method</span>
+                                    <span class="component-desc">
+                                        <select name="pvr_hd_channel_method" id="pvr_hd_channel_method" class="input-medium" >
+                                        #set $pvr_hd_channel_method_text = {PVR_HD_CHANNEL_GREATER_THAN: "Greater Than", PVR_HD_CHANNEL_LESS_THAN: "Less Than", PVR_HD_CHANNEL_FIXED_LIST: "List"}
+                                        #for $curAction in (PVR_HD_CHANNEL_GREATER_THAN, PVR_HD_CHANNEL_LESS_THAN, PVR_HD_CHANNEL_FIXED_LIST):
+                                          #if $sickbeard.PVR_HD_CHANNEL_METHOD == $curAction:
+                                            #set $pvr_hd_channel_method = "selected=\"selected\""
+                                          #else
+                                            #set $pvr_hd_channel_method = ""
+                                          #end if
+                                        <option value="$curAction" $pvr_hd_channel_method>$pvr_hd_channel_method_text[$curAction]</option>
+                                        #end for
+                                        </select>
+                                    </span>
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">How should sickbeard determine HD channels?</span>
+                                </label>
+                            </label>
+                            </div>
+                            
+                            <div class="field-pair" name="channel_cutoff_settings" id="channel_cutoff_settings">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Channel</span>
+                                    <input type="text" name="pvr_hd_channel_cutoff" id="pvr_hd_channel_cutoff" value="$sickbeard.PVR_HD_CHANNEL_CUTOFF" size="6" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">The channel number where HD channels start/stop</span>
+                                </label>
+                            </div>
+                            
+                            <div class="field-pair" name="channel_list_settings" id="channel_list_settings">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">HD Channel List</span>
+                                    <input type="text" name="pvr_hd_channel_list" id="pvr_hd_channel_list" value="$sickbeard.PVR_HD_CHANNEL_LIST" size="35" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">A comma separated list of HD channels</span>
+                                </label>
+                            </div>
+                            
+                            <div class="field-pair" name="pvr_max_scheduling_days" id="pvr_max_scheduling_days">
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">Scheduling Limit</span>
+                                    <input type="text" name="pvr_max_scheduling_days" id="pvr_max_scheduling_days" value="$sickbeard.PVR_MAX_SCHEDULING_DAYS" size="6" />
+                                </label>
+                                <label class="nocheck clearfix">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Maximum days in advance that a recording should be scheduled</span>
+                                </label>
+                            </div>
+                            
+                        </div><!-- /content_use_pvrs //-->
+
+                    </fieldset>
+                </div><!-- /component-group4 //-->
 
                 <div class="component-group-save">
                     <input type="submit" class="btn config_submitter" value="Save Changes" />

--- a/data/js/configSearch.js
+++ b/data/js/configSearch.js
@@ -55,5 +55,23 @@ $(document).ready(function(){
     });
 
     toggle_torrent_title();
+    
+    
+        $.fn.pvr_hd_channel_method_handler = function() {
+
+        var selectedHdChannelMethod = $('#pvr_hd_channel_method :selected').val();
+
+        if (selectedHdChannelMethod == 2) {
+            $('#channel_list_settings').show();
+            $('#channel_cutoff_settings').hide();
+        } else {
+            $('#channel_list_settings').hide();
+            $('#channel_cutoff_settings').show();
+        }
+
+    };
+    
+    $('#pvr_hd_channel_method').change($(this).pvr_hd_channel_method_handler);
+    $(this).pvr_hd_channel_method_handler();
 
 });

--- a/readme.md
+++ b/readme.md
@@ -1,58 +1,23 @@
-Sick Beard
+Sick Beard PVR
 =====
 
-*Sick Beard is currently an alpha release. There may be severe bugs in it and at any given time it may not work at all.*
+This fork of the Sick Beard project adds in support for pvr recording software. Currently the only software supported is [NextPVR][nextPVR], although in theory others could be added.
 
-Sick Beard is a PVR for newsgroup users (with limited torrent support). It watches for new episodes of your favorite shows and when they are posted it downloads them, sorts and renames them, and optionally generates metadata for them. It currently supports several torrent and usenet sites and retrieves show information from theTVDB.com and TVRage.com.
+I find it useful for recording shows that might not be available via NZB or Torrent files or if you'd prefer not to use those methods but still want Sick Beard to manage all of your TV shows.
 
-Features include:
-
-* automatically retrieves new episode torrent or nzb files
-* can scan your existing library and then download any old seasons or episodes you're missing
-* can watch for better versions and upgrade your existing episodes (to from TV DVD/BluRay for example)
-* XBMC library updates, poster/fanart downloads, and NFO/TBN generation
-* configurable episode renaming
-* sends NZBs directly to SABnzbd, prioritizes and categorizes them properly
-* available for any platform, uses simple HTTP interface
-* can notify XBMC, Growl, or Twitter when new episodes are downloaded
-* specials and double episode support
+Please see the original [Sick Beard][sickbeard] documentation for initial setup.  If you already have a configured and running Sick Beard instance, you should be able to grab this source, copy your config.ini and sickbeard.db files into this project and start it up.
 
 
-Sick Beard makes use of the following projects:
+## Configuration
 
-* [cherrypy][cherrypy]
-* [Cheetah][cheetah]
-* [simplejson][simplejson]
-* [tvdb_api][tvdb_api]
-* [ConfigObj][configobj]
-* [SABnzbd+][sabnzbd]
-* [jQuery][jquery]
-* [Python GNTP][pythongntp]
-* [SocksiPy][socks]
-* [python-dateutil][dateutil]
-* [jsonrpclib][jsonrpclib]
+In order to configure the new functionality, you need to set options in 3 places in the Config menu -
 
-## Dependencies
+* **Search Settings** - Check the **Search PVRs** box and choose how HD channels will be determined along with how many days in advance recordings will be scheduled. Recommended setting is about 2 or 3 days.  Save your choices.
+* **Search Providers** - Ensure that the PVR you want to use is checked in the **Priorities** section. You also need to configure any options listed in **Configure Built-In Providers** for the selected pvr. For NextPVR it is just the url where it running.
+* **Post Processing** - Choose what you would like to happen if a show is both recorded and downloaded. Your options are to do nothing and leave the recording, unschedule the recording if it has not yet recorded, or delete the recording if it already has recorded.
 
-To run Sick Beard from source you will need Python 2.5+ and Cheetah 2.1.0+.
-The [binary releases][githubdownloads] are standalone. Build 503 and older can be found on the now defunct [legacy releases][googledownloads].
+Any post processing such as commercial removal, video compression, renaming etc is currently left up to the PVR software.  Although, once that is complete, you can use the autoProcessTV script to import into Sick Beard.
 
-## Bugs
 
-If you find a bug please report it or it'll never get fixed. Verify that it hasn't [already been submitted][googleissues] and then [log a new bug][googlenewissue]. Be sure to provide as much information as possible.
-
-[cherrypy]: http://www.cherrypy.org
-[cheetah]: http://www.cheetahtemplate.org/
-[simplejson]: http://code.google.com/p/simplejson/ 
-[tvdb_api]: http://github.com/dbr/tvdb_api
-[configobj]: http://www.voidspace.org.uk/python/configobj.html
-[sabnzbd]: http://www.sabnzbd.org/
-[jquery]: http://jquery.com
-[pythongntp]: http://github.com/kfdm/gntp
-[socks]: http://code.google.com/p/socksipy-branch/
-[dateutil]: http://labix.org/python-dateutil
-[googledownloads]: http://code.google.com/p/sickbeard/downloads/list
-[googleissues]: http://code.google.com/p/sickbeard/issues/list
-[googlenewissue]: http://code.google.com/p/sickbeard/issues/entry
-[jsonrpclib]: https://github.com/joshmarshall/jsonrpclib
-[githubdownloads]: https://github.com/midgetspy/Sick-Beard/releases
+[nextPVR]: http://nextpvr.com/
+[sickbeard]: http://sickbeard.com/

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,9 @@ Please see the original [Sick Beard][sickbeard] documentation for initial setup.
 In order to configure the new functionality, you need to set options in 3 places in the Config menu -
 
 * **Search Settings** - Check the **Search PVRs** box and choose how HD channels will be determined along with how many days in advance recordings will be scheduled. Recommended setting is about 2 or 3 days.  Save your choices.
-* **Search Providers** - Ensure that the PVR you want to use is checked in the **Priorities** section. You also need to configure any options listed in **Configure Built-In Providers** for the selected pvr. For NextPVR it is just the url where it running.
+
+* **Search Providers** - Ensure that the PVR you want to use is checked in the **Priorities** section. You also need to configure any options listed in **Configure Built-In Providers** for the selected pvr. For NextPVR it is just the url where it is running.
+
 * **Post Processing** - Choose what you would like to happen if a show is both recorded and downloaded. Your options are to do nothing and leave the recording, unschedule the recording if it has not yet recorded, or delete the recording if it already has recorded.
 
 Any post processing such as commercial removal, video compression, renaming etc is currently left up to the PVR software.  Although, once that is complete, you can use the autoProcessTV script to import into Sick Beard.

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -76,6 +76,11 @@ class TorrentSearchResult(SearchResult):
     """
     resultType = "torrent"
 
+class PVRSearchResult(SearchResult):
+    """
+    PVR result with pvr provider specific data stored in extraInfo
+    """
+    resultType = "pvr"
 
 class ShowListUI:
     """

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -69,6 +69,15 @@ multiEpStrings[NAMING_EXTEND] = "Extend"
 multiEpStrings[NAMING_LIMITED_EXTEND] = "Extend (Limited)"
 multiEpStrings[NAMING_LIMITED_EXTEND_E_PREFIXED] = "Extend (Limited, E-prefixed)"
 
+# pvr methods for determining hd
+PVR_HD_CHANNEL_GREATER_THAN = 0
+PVR_HD_CHANNEL_LESS_THAN = 1
+PVR_HD_CHANNEL_FIXED_LIST = 2
+
+# pvr post processing actions
+PVR_DO_NOTHING = 0
+PVR_CANCEL_RECORDING = 1
+PVR_DELETE_RECORDING = 2
 
 class Quality:
     NONE = 0               # 0

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -22,7 +22,8 @@ __all__ = ['ezrss',
            'torrentleech',
            'womble',
            'btn',
-           'omgwtfnzbs'
+           'omgwtfnzbs',
+           'nextpvr'
            ]
 
 import sickbeard

--- a/sickbeard/providers/nextpvr.py
+++ b/sickbeard/providers/nextpvr.py
@@ -1,0 +1,264 @@
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime, time
+import generic
+import sickbeard
+
+from sickbeard import logger, common, ui
+from datetime import timedelta
+from time import gmtime
+
+try:
+    import json
+except ImportError:
+    from lib import simplejson as json
+
+class NextPVRProvider(generic.PVRProvider):
+
+    def __init__(self):
+
+        generic.PVRProvider.__init__(self, "NextPVR")
+        
+        # urls for nextpvr json apis
+        self.search_obj_url = '/public/SearchService/Get/SearchObj'
+        self.search_url = '/public/SearchService/Search'
+        self.schedule_obj_url = '/public/ScheduleService/Get/SchedSettingsObj'
+        self.schedule_url = '/public/ScheduleService/Record'
+        self.manage_obj_url = '/public/ManageService/Get/RecordingsSortFilterObj'
+        self.manage_url = '/public/ManageService/Get/SortedFilteredList'
+        self.cancel_recording_url = '/public/ScheduleService/CancelRec'
+        self.delete_recording_url = '/public/ScheduleService/CancelDelRec'
+
+        self.supportsBacklog = True
+               
+
+    def isEnabled(self):       
+        return sickbeard.USE_NEXTPVR
+           
+    def _get_title_and_url(self, item):
+        url = str(item['OID']) # unique identifier for this item
+        return (self._getName(item), url)
+    
+    def _get_season_search_strings(self, show, season, episode=None):
+        params = {}
+        params['show'] = show
+        params['show_name'] = show.name
+        params['season'] = season
+        
+        seasonStr = "s0" if season < 10 else "s"
+        seasonStr = seasonStr + str(season)   
+    
+        params['seasonStr'] = seasonStr    
+        params['episodeStr'] = ''
+               
+        return [params]
+    
+    def _get_episode_search_strings(self, ep_obj):
+        params = self._get_season_search_strings(ep_obj.show, ep_obj.season)
+
+        p = params[0]
+        p['episodeStr'] = self._get_episode_string(ep_obj.episode)
+        
+        return params
+    
+    def _get_episode_string(self, episode):
+            epStr = "e0" if episode < 10 else "e"
+            return epStr + str(episode) 
+         
+    def getQuality(self, item):       
+        return self.determineQualityByChannel(int(item['FormattedChannelNumber']))
+    
+    def _getName(self, item):
+        return item['Title'] + '.' + item['Subtitle']
+            
+    def _doSearch(self, params, show=None):
+        logger.log("NEXTPVR PROVIDER: _doSearch called", logger.DEBUG)
+        
+        results = []
+        
+        searchObj = self._getEmptyObj(self.search_obj_url)
+        
+        if not searchObj:
+            logger.log(u"No search object returned", logger.ERROR)
+            return results
+                
+        searchObj["searchPhrase"] = params['show_name']
+        season = params['season']
+        now = datetime.datetime.now()
+               
+        searchObjJson = json.dumps(searchObj)
+        
+        data = self.getURL(sickbeard.NEXTPVR_URL + self.search_url, searchObjJson, {'Content-Type': 'application/json'})
+        
+        allResults = json.loads(data)
+        
+        scheduledOrRecordedNames, scheduledOrRecordedOids, scheduledOrRecordedStatus, recordedOriginalAirdate = self._getScheduledOrRecordedEps(params['show_name']) # @UnusedVariable
+       
+        # get air dates since not all subtitles have season.ep
+        airDates = self.getAirDates(params['show'], season)
+       
+        # look through our guide data results
+        for result in allResults['SearchResults']['EPGEvents']:
+            epgEvent = result['epgEventJSONObject']['epgEvent']
+            name = self._getName(epgEvent)
+            subtitle = epgEvent['Subtitle']
+            originalAirDate = datetime.datetime.strptime(epgEvent['OriginalAirdate'], "%Y-%m-%dT%H:%M:%S").date()
+            startTime = self._adjustTimezone(datetime.datetime.strptime(epgEvent['StartTime'], "%Y-%m-%dT%H:%M:%SZ"))
+                            
+            # see if we want this ep 
+            ep = params['seasonStr'] + params['episodeStr']
+            if name not in scheduledOrRecordedNames and startTime > now:
+                if ep in subtitle:
+                    results.append(epgEvent) 
+                elif originalAirDate in airDates.values():
+                    # need to add season.ep into subtitle so parser can figure out later
+                    # there may be multiple episodes with the same date and so lets add them all
+                    for e, d in airDates.items():
+                        if d == originalAirDate:
+                            eStr = self._get_episode_string(e)
+                            epgEvent['Subtitle'] = params['seasonStr'] + eStr + "." + subtitle 
+                            results.append(epgEvent)
+                            break
+        
+        return results        
+    
+    def _getScheduledOrRecordedEps(self, title):
+        
+        # TODO: refactor into array of dicts since I keep adding items to it
+        recordedEpNames = []
+        recordedEpOids = []
+        recordedEpStatus = []
+        recordedOriginalAirdate = []
+        
+        manageObj = self._getEmptyObj(self.manage_obj_url)
+        manageObj['Completed'] = True
+        manageObj['Pending'] = True
+        manageObj['InProgress'] = True
+        manageObj['FilterByName'] = True
+        manageObj['NameFilter'] = title
+        
+        manageObjJson = json.dumps(manageObj)
+        
+        data = self.getURL(sickbeard.NEXTPVR_URL + self.manage_url, manageObjJson, {'Content-Type': 'application/json'})
+        allResults = json.loads(data)
+        
+        for result in allResults['ManageResults']['EPGEvents']:
+            epgEvent = result['epgEventJSONObject']['epgEvent']
+            schedule = result['epgEventJSONObject']['schd']
+            recordedEpNames.append(self._getName(epgEvent))
+            recordedEpOids.append(schedule['OID'])
+            recordedEpStatus.append(schedule['Status'])
+            recordedOriginalAirdate.append(datetime.datetime.strptime(epgEvent['OriginalAirdate'], "%Y-%m-%dT%H:%M:%S").date())
+                       
+        return recordedEpNames, recordedEpOids, recordedEpStatus, recordedOriginalAirdate
+    
+
+
+        
+    def snatchEpisode(self, item):
+        logger.log(u"NEXTPVR snatching " + item.name, logger.DEBUG)
+        
+        snatchStatus = False
+        
+        scheduleObj = self._getEmptyObj(self.schedule_obj_url)
+        
+        if not scheduleObj:
+            logger.log(u"No schedule object returned", logger.ERROR)
+            return snatchStatus
+        
+        
+        scheduleObj['epgeventOID'] = str(item.extraInfo['OID'])
+        scheduleObjJson = json.dumps(scheduleObj)
+        data = self.getURL(sickbeard.NEXTPVR_URL + self.schedule_url, scheduleObjJson, {'Content-Type': 'application/json'})   
+        
+        result = json.loads(data)
+        epgEvent = result['epgEventJSONObject']['epgEvent']
+        
+        hasSchedule = bool(epgEvent['HasSchedule'])
+        hasConflict = bool(epgEvent['ScheduleHasConflict'])
+                        
+        if(hasSchedule and not hasConflict):
+            schedule = result['epgEventJSONObject']['schd']
+            if(schedule['Status'] == 'Pending'):
+                msgTitle = u"NEXTPVR successfully scheduled "
+                msg = self._getName(epgEvent) + " on channel:" + epgEvent['FormattedChannelNumber']
+                ui.notifications.message(msgTitle,msg)
+                logger.log(msgTitle + msg, logger.MESSAGE)  
+                   
+        # TODO: maybe keep separate pvr/dl snatch status           
+        # For now always return false so we attempt to dl too           
+        return snatchStatus
+     
+    def postDownloadCleanup(self, ep_obj):
+        
+        resultMessage = None
+        
+        if sickbeard.PVR_POST_DOWNLOAD_ACTION == common.PVR_DO_NOTHING:
+            return None
+        
+        params = self._get_episode_search_strings(ep_obj)[0]
+        scheduledOrRecordedNames, scheduledOrRecordedOids, scheduledOrRecordedStatus, scheduledOrRecordedOriginalAirdate = self._getScheduledOrRecordedEps(params['show_name'])
+        wanted_name = params['show_name'] + '.' + params['seasonStr'] + params['episodeStr']
+        
+        for name, oid, status, origAirdate in zip(scheduledOrRecordedNames, scheduledOrRecordedOids, scheduledOrRecordedStatus, scheduledOrRecordedOriginalAirdate):
+            
+            if wanted_name in name or ep_obj.airdate == origAirdate:
+                if sickbeard.PVR_POST_DOWNLOAD_ACTION == common.PVR_DELETE_RECORDING and status == 'Completed':
+                    url = self.delete_recording_url
+                else:
+                    url = self.cancel_recording_url
+                
+                url = sickbeard.NEXTPVR_URL + url + "/" + str(oid)
+                
+                # nextpvr sets a 404 if it can't find file to delete, this may not be a real error if
+                # someone deleted file outside of nextpvr so catch and ignore
+                try:
+                    data = self.getURL(url)
+                except:   
+                    logger.log(u"NextPvr could not delete recording of " + name + " but this may not necessarily indicate an error.", logger.WARNING)
+                   
+                resultMessage = u"NextPvr finished cleanup of " + name   
+                
+                break
+            
+        return resultMessage
+            
+    
+    def getRecordingDateTime(self, epgEvent):
+        return self._adjustTimezone(datetime.datetime.strptime(epgEvent['StartTime'], "%Y-%m-%dT%H:%M:%SZ"))
+    
+    def _adjustTimezone(self, dt):
+        offset = time.localtime()[3] - gmtime()[3]
+        return dt + timedelta(hours=offset)
+        
+    def _getEmptyObj(self, typeUrl):
+        
+        # use nextpvr api to retrieve empty json object of specific type with default values
+        # to be updated and used in subsequent call
+        
+        emptyObj = None
+        
+        data = self.getURL(sickbeard.NEXTPVR_URL + typeUrl)
+        
+        if not data:
+            logger.log(u"No data returned from " + typeUrl, logger.ERROR)
+        else:    
+            emptyObj = json.loads(data) 
+            
+        return emptyObj
+            
+provider = NextPVRProvider()
+        

--- a/sickbeard/searchPvr.py
+++ b/sickbeard/searchPvr.py
@@ -1,0 +1,152 @@
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of Sick Beard.
+#
+# Sick Beard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Sick Beard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import with_statement
+
+import datetime
+import threading
+
+import sickbeard
+
+from sickbeard import db
+from sickbeard import search_queue
+from sickbeard import logger
+from sickbeard import ui
+
+
+class PVRSearcher:
+
+    def __init__(self):
+
+        self.lock = threading.Lock()
+        self.amActive = False
+        self.amPaused = False
+        self.amWaiting = False
+
+        self._resetPI()
+
+    def _resetPI(self):
+        self.percentDone = 0
+        self.currentSearchInfo = {'title': 'Initializing'}
+
+    def getProgressIndicator(self):
+        if self.amActive:
+            return ui.ProgressIndicator(self.percentDone, self.currentSearchInfo)
+        else:
+            return None
+
+    def am_running(self):
+        logger.log(u"amWaiting: " + str(self.amWaiting) + ", amActive: " + str(self.amActive), logger.DEBUG)
+        return (not self.amWaiting) and self.amActive
+
+    def searchPVR(self, which_shows=None):
+
+        if which_shows:
+            show_list = which_shows
+        else:
+            show_list = sickbeard.showList
+
+        def titler(x):
+            if not x:
+                return x
+            if not x.lower().startswith('a to ') and x.lower().startswith('a '):
+                    x = x[2:]
+            elif x.lower().startswith('an '):
+                    x = x[3:]
+            elif x.lower().startswith('the '):
+                    x = x[4:]
+            return x
+        # sort shows the same way we show them, makes it easier to follow along
+        show_list = sorted(show_list, lambda x, y: cmp(titler(x.name), titler(y.name)))
+
+        if self.amActive is True:
+            logger.log(u"Pvr search is still running, not starting it again", logger.DEBUG)
+            return
+
+        fromDate = datetime.date.fromordinal(1)
+
+        self.amActive = True
+        self.amPaused = False
+
+        # get separate lists of the season/date shows
+        #season_shows = [x for x in show_list if not x.air_by_date]
+        air_by_date_shows = [x for x in show_list if x.air_by_date]
+
+        # figure out how many segments of air by date shows we're going to do
+        air_by_date_segments = []
+        for cur_id in [x.tvdbid for x in air_by_date_shows]:
+            air_by_date_segments += self._get_air_by_date_segments(cur_id, fromDate)
+
+        logger.log(u"Air-by-date segments: " + str(air_by_date_segments), logger.DEBUG)
+
+        # go through non air-by-date shows and see if they need any episodes
+        for curShow in show_list:
+
+            if curShow.paused:
+                continue
+
+            if curShow.air_by_date:
+                segments = [x[1] for x in self._get_air_by_date_segments(curShow.tvdbid, fromDate)]
+            else:
+                segments = self._get_season_segments(curShow.tvdbid, fromDate)
+
+            for cur_segment in segments:
+
+                self.currentSearchInfo = {'title': curShow.name + " Season " + str(cur_segment)}
+
+                pvr_queue_item = search_queue.PVRQueueItem(curShow, cur_segment)
+
+                if not pvr_queue_item.wantSeason:
+                    logger.log(u"Nothing in season " + str(cur_segment) + " needs to be downloaded, skipping this season", logger.DEBUG)
+                else:
+                    sickbeard.searchQueueScheduler.action.add_item(pvr_queue_item)  # @UndefinedVariable
+
+        self.amActive = False
+        self._resetPI()
+
+
+    def _get_season_segments(self, tvdb_id, fromDate):
+        myDB = db.DBConnection()
+        sqlResults = myDB.select("SELECT DISTINCT(season) as season FROM tv_episodes WHERE showid = ? AND season > 0 and airdate > ?", [tvdb_id, fromDate.toordinal()])
+        return [int(x["season"]) for x in sqlResults]
+
+    def _get_air_by_date_segments(self, tvdb_id, fromDate):
+        # query the DB for all dates for this show
+        myDB = db.DBConnection()
+        num_air_by_date_results = myDB.select("SELECT airdate, showid FROM tv_episodes ep, tv_shows show WHERE season != 0 AND ep.showid = show.tvdb_id AND show.paused = 0 ANd ep.airdate > ? AND ep.showid = ?",
+                                 [fromDate.toordinal(), tvdb_id])
+
+        # break them apart into month/year strings
+        air_by_date_segments = []
+        for cur_result in num_air_by_date_results:
+            cur_date = datetime.date.fromordinal(int(cur_result["airdate"]))
+            cur_date_str = str(cur_date)[:7]
+            cur_tvdb_id = int(cur_result["showid"])
+
+            cur_result_tuple = (cur_tvdb_id, cur_date_str)
+            if cur_result_tuple not in air_by_date_segments:
+                air_by_date_segments.append(cur_result_tuple)
+
+        return air_by_date_segments
+
+    def run(self):
+        try:
+            self.searchPVR()
+        except:
+            self.amActive = False
+            raise

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -59,6 +59,7 @@ class TVShow(object):
         self.genre = ""
         self.runtime = 0
         self.quality = int(sickbeard.QUALITY_DEFAULT)
+        self.pvr_quality = int(sickbeard.PVR_QUALITY_DEFAULT) # TODO: might eventually store separate pvr wanted show quality, but for now just get one global value
         self.flatten_folders = int(sickbeard.FLATTEN_FOLDERS_DEFAULT)
 
         self.status = ""
@@ -842,12 +843,16 @@ class TVShow(object):
         toReturn += "quality: " + str(self.quality) + "\n"
         return toReturn
 
-    def wantEpisode(self, season, episode, quality, manualSearch=False):
+    def wantEpisode(self, season, episode, quality, manualSearch=False, pvrSearch=False):
 
         logger.log(u"Checking if found episode " + str(season) + "x" + str(episode) + " is wanted at quality " + Quality.qualityStrings[quality], logger.DEBUG)
 
         # if the quality isn't one we want under any circumstances then just say no
-        anyQualities, bestQualities = Quality.splitQuality(self.quality)
+        if pvrSearch:
+            anyQualities, bestQualities = Quality.splitQuality(self.pvr_quality)
+        else:
+            anyQualities, bestQualities = Quality.splitQuality(self.quality)
+            
         logger.log(u"any,best = " + str(anyQualities) + " " + str(bestQualities) + " and found " + str(quality), logger.DEBUG)
 
         if quality not in anyQualities + bestQualities:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -777,7 +777,8 @@ class ConfigSearch:
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None, nzbget_username=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
-                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, ignore_words=None):
+                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, ignore_words=None,
+                       use_pvrs=None, pvr_hd_channel_method=None, pvr_hd_channel_cutoff=None, pvr_hd_channel_list=None, pvr_max_scheduling_days=None):
 
         results = []
 
@@ -813,6 +814,13 @@ class ConfigSearch:
         if not config.change_TORRENT_DIR(torrent_dir):
             results += ["Unable to create directory " + os.path.normpath(torrent_dir) + ", directory not changed."]
 
+        # PVR Search
+        sickbeard.USE_PVRS = config.checkbox_to_value(use_pvrs)
+        sickbeard.PVR_HD_CHANNEL_METHOD = pvr_hd_channel_method
+        sickbeard.PVR_HD_CHANNEL_CUTOFF = pvr_hd_channel_cutoff
+        sickbeard.PVR_HD_CHANNEL_LIST = pvr_hd_channel_list.replace(" ", "")
+        sickbeard.PVR_MAX_SCHEDULING_DAYS = pvr_max_scheduling_days
+        
         sickbeard.save_config()
 
         if len(results) > 0:
@@ -839,7 +847,7 @@ class ConfigPostProcessing:
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                     xbmc_data=None, xbmc_12plus_data=None, mediabrowser_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None, mede8er_data=None,
                     keep_processed_dir=None, process_automatically=None, rename_episodes=None,
-                    move_associated_files=None, filter_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
+                    move_associated_files=None, filter_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None, pvr_post_download_action=None):
 
         results = []
 
@@ -890,6 +898,10 @@ class ConfigPostProcessing:
         sickbeard.metadata_provider_dict['WDTV'].set_config(sickbeard.METADATA_WDTV)
         sickbeard.metadata_provider_dict['TIVO'].set_config(sickbeard.METADATA_TIVO)
         sickbeard.metadata_provider_dict['Mede8er'].set_config(sickbeard.METADATA_MEDE8ER)
+
+
+        # PVR post processing
+        sickbeard.PVR_POST_DOWNLOAD_ACTION = config.to_int(pvr_post_download_action, default=0)
 
         # Save changes
         sickbeard.save_config()
@@ -1015,7 +1027,7 @@ class ConfigProviders:
                       tvtorrents_digest=None, tvtorrents_hash=None,
                       torrentleech_key=None,
                       btn_api_key=None, hdbits_username=None, hdbits_passkey=None,
-                      provider_order=None):
+                      provider_order=None, nextpvr_url=None):
 
         results = []
 
@@ -1082,6 +1094,8 @@ class ConfigProviders:
                 sickbeard.TORRENTLEECH = curEnabled
             elif curProvider == 'btn':
                 sickbeard.BTN = curEnabled
+            elif curProvider == 'nextpvr':
+                sickbeard.USE_NEXTPVR = curEnabled
             elif curProvider in newznabProviderDict:
                 newznabProviderDict[curProvider].enabled = bool(curEnabled)
             else:
@@ -1099,6 +1113,8 @@ class ConfigProviders:
 
         sickbeard.OMGWTFNZBS_USERNAME = omgwtfnzbs_username.strip()
         sickbeard.OMGWTFNZBS_APIKEY = omgwtfnzbs_apikey.strip()
+        
+        sickbeard.NEXTPVR_URL = nextpvr_url.strip().rstrip('/')
 
         sickbeard.NEWZNAB_DATA = '!!!'.join([x.configStr() for x in sickbeard.newznabProviderList])
         sickbeard.PROVIDER_ORDER = provider_list


### PR DESCRIPTION
I decided to add in support for pvr software as a new provider type.  I find it useful for less popular shows that aren't typically available via nzb or torrents - kids shows, cooking, news etc. Sick Beard now manages those recordings too.  I put in the framework generically for a pvr provider type, although currently [NextPVR](http://www.nextpvr.com) is the only app supported.  

In a nutshell - once per day this will check the EPG data from NextPVR via its REST interface and schedule any missing shows. Shows are not marked as snatched at this point. The code will attempt to pick a later recording date than the first air date (if multiples exist) to allow a download to occur since that is preferred.  If the same show is downloaded, you have the option to have the scheduled recording cancelled if it hasn't recorded or deleted if it has.  You also have a couple of options based upon channel number for determining if the recording will be SD/HD.

This is basically my first python code as well as my first github project, so hopefully I did all of this right. I've had the code running for about 2 months now and it's been very stable.

There's a little bit of additional info on configuration listed in the readme of the fork - https://github.com/kelliott72/Sick-Beard
