### PR TITLE
Sabnzbd ignore duplicates

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -184,6 +184,13 @@
                                 </label>
                             </div>
                         </div>
+                        <div class="field-pair">
+                            <input type="checkbox" name="sab_duplicates" class="enabler" id="sab_duplicates" #if $sickbeard.SAB_DUPLICATES then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="sab_duplicates">
+                                <span class="component-title">Ignore Duplicate NZBs</span>
+                                <span class="component-desc">Don't download search results already in SABnzbd History</span>
+                            </label>
+                        </div>                        
 
                         <div id="nzbget_settings">
                             <div class="field-pair">

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -183,15 +183,15 @@
                                     <span class="component-desc">Category for downloads to go into (eg. TV)</span>
                                 </label>
                             </div>
+                        
+                            <div class="field-pair">
+                                <input type="checkbox" name="sab_duplicates" class="enabler" id="sab_duplicates" #if $sickbeard.SAB_DUPLICATES then "checked=\"checked\"" else ""# />
+                                <label class="clearfix" for="sab_duplicates">
+                                    <span class="component-title">Ignore Duplicate NZBs</span>
+                                    <span class="component-desc">Don't download search results already in SABnzbd   History</span>
+                                </label>
+                            </div>                        
                         </div>
-                        <div class="field-pair">
-                            <input type="checkbox" name="sab_duplicates" class="enabler" id="sab_duplicates" #if $sickbeard.SAB_DUPLICATES then "checked=\"checked\"" else ""# />
-                            <label class="clearfix" for="sab_duplicates">
-                                <span class="component-title">Ignore Duplicate NZBs</span>
-                                <span class="component-desc">Don't download search results already in SABnzbd History</span>
-                            </label>
-                        </div>                        
-
                         <div id="nzbget_settings">
                             <div class="field-pair">
                                 <label class="nocheck clearfix">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -202,6 +202,7 @@ SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
 SAB_HOST = ''
+SAB_DUPLICATES = None
 
 NZBGET_USERNAME = None
 NZBGET_PASSWORD = None
@@ -336,7 +337,7 @@ def initialize(consoleLogging=True):
 
         global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
                 USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
-                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
+                SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, SAB_DUPLICATES, \
                 NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_ALWAYS_ON, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, XBMC_UPDATE_ONLYFIRST, \
                 XBMC_UPDATE_LIBRARY, XBMC_HOST, XBMC_USERNAME, XBMC_PASSWORD, \
@@ -546,6 +547,7 @@ def initialize(consoleLogging=True):
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '')
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
+        SAB_DUPLICATES = bool(check_setting_int(CFG, 'SABnzbd', 'sab_duplicates', 0))
 
         CheckSection(CFG, 'NZBget')
         NZBGET_USERNAME = check_setting_str(CFG, 'NZBget', 'nzbget_username', 'nzbget')
@@ -1095,6 +1097,7 @@ def save_config():
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
     new_config['SABnzbd']['sab_host'] = SAB_HOST
+    new_config['SABnzbd']['sab_duplicates'] = int(SAB_DUPLICATES)
 
     new_config['NZBget'] = {}
     new_config['NZBget']['nzbget_username'] = NZBGET_USERNAME

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -201,3 +201,47 @@ def testAuthentication(host=None, username=None, password=None, apikey=None):
         return False, sabText
 
     return True, "Success"
+
+def checkSabHistory(sbUrl=None):
+    """
+    Sends an API request to SAB to get the history, checks for matches to sbUrl
+    
+    sbUrl - the URL to scan the SAB history for
+
+    Returns: True if url match is found
+    """
+    if sickbeard.SAB_APIKEY is not None:
+        apikey = sickbeard.SAB_APIKEY
+        
+    if sickbeard.SAB_HOST is not None:
+        host = sickbeard.SAB_HOST
+    
+    if sickbeard.SAB_USERNAME is not None:
+        username = sickbeard.SAB_USERNAME
+        
+    if sickbeard.SAB_PASSWORD is not None:
+        password = sickbeard.SAB_PASSWORD
+
+    # build up the URL parameters
+    params = {}
+    params['mode'] = 'history'
+    params['output'] = 'json'
+    params['limit'] = '100'
+    params['ma_username'] = username
+    params['ma_password'] = password
+    params['apikey'] = apikey
+    url = host + "api?" + urllib.urlencode(params)
+
+    # send the request
+    logger.log(u"SABnzbd history request URL: " + url, logger.DEBUG)
+    result, f = _sabURLOpenSimple(url)
+    if not result:
+        return False
+
+    # check the sab history json result for a match to our url
+    sabText = f.getvalue()
+    sabHistory = json.loads(sabText)
+    for slot in sabHistory['history']['slots']:
+        if slot['url'] == sbUrl:
+            return True            
+    return False

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -231,6 +231,12 @@ def pickBestResult(results, show, quality_list=None):
     for cur_result in results:
         logger.log(u"Quality of " + cur_result.name + " is " + Quality.qualityStrings[cur_result.quality])
 
+        #if using sabnzbd, check to see if we've already got the same url in our history. If we do, then ignore this result. 
+        if sickbeard.SAB_DUPLICATES:
+            if sab.checkSabHistory(cur_result.url):
+        	   logger.log(u"Ignoring " + cur_result.name + " as it has already been downloaded by sabnzbd", logger.MESSAGE)
+        	   continue
+                
         if quality_list and cur_result.quality not in quality_list:
             logger.log(cur_result.name + " is a quality we know we don't want, rejecting it", logger.DEBUG)
             continue

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -776,7 +776,7 @@ class ConfigSearch:
 
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
-                       sab_apikey=None, sab_category=None, sab_host=None, nzbget_username=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
+                       sab_apikey=None, sab_category=None, sab_host=None, sab_duplicates=None, nzbget_username=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
                        torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, ignore_words=None):
 
         results = []
@@ -798,6 +798,7 @@ class ConfigSearch:
         sickbeard.SAB_PASSWORD = sab_password
         sickbeard.SAB_APIKEY = sab_apikey.strip()
         sickbeard.SAB_CATEGORY = sab_category
+        sickbeard.SAB_DUPLICATES = config.checkbox_to_value(sab_duplicates)
 
         if not config.change_NZB_DIR(nzb_dir):
             results += ["Unable to create directory " + os.path.normpath(nzb_dir) + ", directory not changed."]


### PR DESCRIPTION
This adds an option to the sabnzbd configuration to ignore duplicate NZBs found in sabnzbd's history. 

This is useful for failed downloads where you want sickbeard to grab another release - simply set the episode to wanted again and sickbeard will find the next viable release instead of downloading one already in sabnzbd's history. 
