### PR TITLE
Update pynma.py Notify my Android is no longer working, outdated Api Server

### DIFF
--- a/lib/pynma/pynma.py
+++ b/lib/pynma/pynma.py
@@ -6,7 +6,7 @@ from urllib import urlencode
 
 __version__ = "0.1"
 
-API_SERVER = 'nma.usk.bz'
+API_SERVER = 'www.notifymyandroid.com'
 ADD_PATH   = '/publicapi/notify'
 
 USER_AGENT="PyNMA/v%s"%__version__


### PR DESCRIPTION
Api server for NMA is outdated, nma.uak.bz is no longer in use and have to be replaced by www.notifymyandroid.com or www.notifymyandroid.appspot.com
