### PR TITLE
Simple filenames

### DIFF
--- a/data/interfaces/default/config_postProcessing.tmpl
+++ b/data/interfaces/default/config_postProcessing.tmpl
@@ -88,6 +88,14 @@
                         </div>
 
                         <div class="field-pair">
+                            <input type="checkbox" name="use_ascii_filenames" id="use_ascii_filenames" #if $sickbeard.USE_ASCII_FILENAMES == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="use_ascii_filenames">
+                                <span class="component-title">Use simple filenames</span>
+                                <span class="component-desc">Replace unicode characters with their ASCII equivalent from episodes filename.</span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <input type="checkbox" name="process_automatically" id="process_automatically" #if $sickbeard.PROCESS_AUTOMATICALLY == True then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="process_automatically">
                                 <span class="component-title">Scan and Process</span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Cheetah>=2.1.0
+Unidecode>=0.04.18

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -185,6 +185,7 @@ TORRENT_DIR = None
 ADD_SHOWS_WO_DIR = None
 CREATE_MISSING_SHOW_DIRS = None
 RENAME_EPISODES = False
+USE_ASCII_FILENAMES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
 MOVE_ASSOCIATED_FILES = False
@@ -372,7 +373,7 @@ def initialize(consoleLogging=True):
                 KEEP_PROCESSED_DIR, TV_DOWNLOAD_DIR, TVDB_BASE_URL, MIN_SEARCH_FREQUENCY, \
                 showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TVDB_API_PARMS, \
                 NAMING_PATTERN, NAMING_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, \
-                RENAME_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
+                RENAME_EPISODES, USE_ASCII_FILENAMES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
                 WOMBLE, OMGWTFNZBS, OMGWTFNZBS_USERNAME, OMGWTFNZBS_APIKEY, providerList, newznabProviderList, \
                 EXTRA_SCRIPTS, USE_TWITTER, TWITTER_USERNAME, TWITTER_PASSWORD, TWITTER_PREFIX, \
                 USE_BOXCAR2, BOXCAR2_ACCESS_TOKEN, BOXCAR2_NOTIFY_ONDOWNLOAD, BOXCAR2_NOTIFY_ONSNATCH, BOXCAR2_SOUND, \
@@ -490,6 +491,7 @@ def initialize(consoleLogging=True):
         TV_DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'tv_download_dir', '')
         PROCESS_AUTOMATICALLY = check_setting_int(CFG, 'General', 'process_automatically', 0)
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
+        USE_ASCII_FILENAMES = check_setting_int(CFG, 'General', 'use_ascii_filenames', 0)
         KEEP_PROCESSED_DIR = check_setting_int(CFG, 'General', 'keep_processed_dir', 1)
         MOVE_ASSOCIATED_FILES = check_setting_int(CFG, 'General', 'move_associated_files', 0)
         FILTER_ASSOCIATED_FILES = check_setting_str(CFG, 'General', 'filter_associated_files', '')
@@ -1072,6 +1074,7 @@ def save_config():
     new_config['General']['filter_associated_files'] = FILTER_ASSOCIATED_FILES
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
+    new_config['General']['use_ascii_filenames'] = int(USE_ASCII_FILENAMES)
     new_config['General']['create_missing_show_dirs'] = int(CREATE_MISSING_SHOW_DIRS)
     new_config['General']['add_shows_wo_dir'] = int(ADD_SHOWS_WO_DIR)
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -36,6 +36,7 @@ if sys.version_info >= (2, 7, 9):
 import zlib
 from lib import MultipartPostHandler
 from httplib import BadStatusLine
+from unidecode import unidecode
 
 try:
     import json
@@ -49,6 +50,7 @@ try:
 except ImportError:
     import elementtree.ElementTree as etree
 
+import sickbeard
 from sickbeard.exceptions import MultipleShowObjectsException, ex
 from sickbeard import logger
 from sickbeard.common import USER_AGENT, mediaExtensions
@@ -170,7 +172,7 @@ def sanitizeFileName(name):
     # remove leading/trailing periods and spaces
     name = name.strip(' .')
 
-    return name
+    return name if not sickbeard.USE_ASCII_FILENAMES else unidecode(name)
 
 def getURL(url, validate=False, cookies = cookielib.CookieJar(), password_mgr=None, throw_exc=False):
     """

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -809,7 +809,7 @@ class PostProcessor(object):
         # figure out the base name of the resulting episode file
         if sickbeard.RENAME_EPISODES:
             orig_extension = self.file_name.rpartition('.')[-1]
-            new_base_name = ek.ek(os.path.basename, proper_path)
+            new_base_name = helpers.sanitizeFileName(ek.ek(os.path.basename, proper_path))
             new_file_name = new_base_name + '.' + orig_extension
 
         else:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -838,7 +838,7 @@ class ConfigPostProcessing:
     @cherrypy.expose
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                     xbmc_data=None, xbmc_12plus_data=None, mediabrowser_data=None, sony_ps3_data=None, wdtv_data=None, tivo_data=None, mede8er_data=None,
-                    keep_processed_dir=None, process_automatically=None, rename_episodes=None,
+                    keep_processed_dir=None, process_automatically=None, rename_episodes=None, use_ascii_filenames=None,
                     move_associated_files=None, filter_associated_files=None, tv_download_dir=None, naming_custom_abd=None, naming_abd_pattern=None):
 
         results = []
@@ -851,6 +851,7 @@ class ConfigPostProcessing:
         sickbeard.MOVE_ASSOCIATED_FILES = config.checkbox_to_value(move_associated_files)
         sickbeard.FILTER_ASSOCIATED_FILES = filter_associated_files
         sickbeard.RENAME_EPISODES = config.checkbox_to_value(rename_episodes)
+        sickbeard.USE_ASCII_FILENAMES = config.checkbox_to_value(use_ascii_filenames)
 
         sickbeard.PROCESS_AUTOMATICALLY = config.checkbox_to_value(process_automatically)
 


### PR DESCRIPTION
Added option to use simple filenames and replace unicode characters with their ASCII equivalent.

WHY: when sharing a disk between a linux machine running SB and a windows machine, for example by using Docker with a shared volume, the difference codepages mess up the visualisation of the file names. Everything keeps working just fine but it will look ugly. Using "simple" file names make sure we have maximum readability and stay as close as possible to the original names.

DRAWBACKS: It introduces another dependency to an external library.
