### PR TITLE
Change Sick Beard version from 'master' to 'development'

### DIFF
--- a/sickbeard/version.py
+++ b/sickbeard/version.py
@@ -1,1 +1,1 @@
-SICKBEARD_VERSION = "master"
+SICKBEARD_VERSION = "development"


### PR DESCRIPTION
The new default branch name is 'development'. This change reflects that.
