### PR TITLE
Refining FreeBSD Init Script

### DIFF
--- a/init.freebsd
+++ b/init.freebsd
@@ -29,8 +29,8 @@ load_rc_config ${name}
 : ${sickbeard_dir=/usr/local/sickbeard}
 
 pidfile=${sickbeard_dir}/sickbeard.pid
-procname="*python"
 command=${sickbeard_dir}/SickBeard.py
+command_interpreter="/usr/local/bin/python2.7"
 sickbeard_flags="--datadir=${sickbeard_dir} --daemon --pidfile=${pidfile} ${sickbeard_flags}"
 faststop_cmd="${name}_stop"
 

--- a/init.freebsd
+++ b/init.freebsd
@@ -32,5 +32,6 @@ pidfile=${sickbeard_dir}/sickbeard.pid
 procname="*python"
 command=${sickbeard_dir}/SickBeard.py
 command_args="--datadir=${sickbeard_dir} --daemon --pidfile=${pidfile}"
+faststop_cmd="${name}_stop"
 
 run_rc_command "$1"

--- a/init.freebsd
+++ b/init.freebsd
@@ -32,6 +32,5 @@ pidfile=${sickbeard_dir}/sickbeard.pid
 command=${sickbeard_dir}/SickBeard.py
 command_interpreter="/usr/local/bin/python2.7"
 sickbeard_flags="--datadir=${sickbeard_dir} --daemon --pidfile=${pidfile} ${sickbeard_flags}"
-faststop_cmd="${name}_stop"
 
 run_rc_command "$1"

--- a/init.freebsd
+++ b/init.freebsd
@@ -31,7 +31,7 @@ load_rc_config ${name}
 pidfile=${sickbeard_dir}/sickbeard.pid
 procname="*python"
 command=${sickbeard_dir}/SickBeard.py
-command_args="--datadir=${sickbeard_dir} --daemon --pidfile=${pidfile}"
+sickbeard_flags="--datadir=${sickbeard_dir} --daemon --pidfile=${pidfile} ${sickbeard_flags}"
 faststop_cmd="${name}_stop"
 
 run_rc_command "$1"


### PR DESCRIPTION
Fixed bad behaviour when shutting down the system. Sickbeard would fail to start after a restart/shutdown. The reason is that rc.shutdown issues the faststop command which doesn't delete the pidfile. As a result sickbeard would not start up complaining of pidfile existing on start. You can reproduce on a FreeBSD system by shutting down and starting up. Sickbeard will not be running. If you try to start it manually it will complain about the pidfile. You can also reproduce by running `service sickbeard faststop` then `service sickbeard start`. The same behaviour will be noticed. To resolve you must manually delete the pidfile and start sickbeard again. My change overrides the faststop function replacing it with the normal stop function.

I also cleaned up some miscellaneous things that weren't ideal like command_args and procname being used which are discouraged in [FreeBSD documentation](https://www.freebsd.org/doc/en/articles/rc-scripting/).
