### PR TITLE
update btn api url

### DIFF
--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -130,7 +130,7 @@ class BTNProvider(generic.TorrentProvider):
 
     def _api_call(self, apikey, params={}, results_per_page=1000, offset=0):
 
-        server = jsonrpclib.Server('http://api.btnapps.net')
+        server = jsonrpclib.Server('http://api.broadcasthe.net')
         parsedJSON = {}
 
         try:


### PR DESCRIPTION
Updates the api url for BTN. Does what https://github.com/midgetspy/Sick-Beard/pull/982 does, but without the line ending changes. 

The BTN forums have threads full of folks hacking this fix. I just did it myself with success. It'd be great to have it in officially. Thanks!