### PR TITLE
Best Fit Quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,3 @@ ehthumbs.db
 Thumbs.db
 .directory
 *~
-*.nzb

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ ehthumbs.db
 Thumbs.db
 .directory
 *~
+*.nzb

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -34,6 +34,13 @@
                                 <span class="component-desc">Replace original download with "Proper/Repack" if nuked?</span>
                             </label>
                         </div>
+                        <div class="field-pair">
+                            <input type="checkbox" name="best_fit_quality" id="best_fit_quality" #if $sickbeard.BEST_FIT_QUALITY == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="best_fit_quality">
+                                <span class="component-title">Best Fit Quality</span>
+                                <span class="component-desc">Attempt to guess the quality in the case a perfect match cannot be found</span>
+                            </label>
+                        </div>
 
                         <div class="field-pair">
                             <label class="nocheck clearfix">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -153,6 +153,7 @@ NZB_METHOD = None
 NZB_DIR = None
 USENET_RETENTION = None
 DOWNLOAD_PROPERS = None
+BEST_FIT_QUALITY = None
 
 SEARCH_FREQUENCY = None
 BACKLOG_SEARCH_FREQUENCY = 21
@@ -347,7 +348,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, \
+                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, BEST_FIT_QUALITY, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
                 USE_XBMC, XBMC_ALWAYS_ON, XBMC_NOTIFY_ONSNATCH, XBMC_NOTIFY_ONDOWNLOAD, XBMC_UPDATE_FULL, XBMC_UPDATE_ONLYFIRST, \
@@ -478,15 +479,16 @@ def initialize(consoleLogging=True):
             NZB_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        BEST_FIT_QUALITY = bool(check_setting_int(CFG, 'General', 'best_fit_quality', 0))
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
         SEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'search_frequency', DEFAULT_SEARCH_FREQUENCY)
         if SEARCH_FREQUENCY < MIN_SEARCH_FREQUENCY:
             SEARCH_FREQUENCY = MIN_SEARCH_FREQUENCY
-        
+
         POSTPROCESS_FREQUENCY = check_setting_int(CFG, 'General', 'postprocess_frequency', DEFAULT_POSTPROCESS_FREQUENCY)
         if POSTPROCESS_FREQUENCY < MIN_POSTPROCESS_FREQUENCY:
             POSTPROCESS_FREQUENCY = MIN_POSTPROCESS_FREQUENCY
-        
+
         TV_DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'tv_download_dir', '')
         PROCESS_AUTOMATICALLY = check_setting_int(CFG, 'General', 'process_automatically', 0)
         RENAME_EPISODES = check_setting_int(CFG, 'General', 'rename_episodes', 1)
@@ -1044,6 +1046,7 @@ def save_config():
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['postprocess_frequency'] = int(POSTPROCESS_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['best_fit_quality'] = int(BEST_FIT_QUALITY)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)
     new_config['General']['flatten_folders_default'] = int(FLATTEN_FOLDERS_DEFAULT)

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -161,7 +161,7 @@ class Quality:
         elif checkName(["720p", "web.dl|webrip"], all) or checkName(["720p", "itunes", "h.?264"], all):
             return Quality.HDWEBDL
         elif checkName(["1080p", "web.dl|webrip"], all) or checkName(["1080p", "itunes", "h.?264"], all):
-            return Quality.FULLHDWEBDL  
+            return Quality.FULLHDWEBDL
         elif checkName(["720p", "bluray|hddvd", "x264"], all):
             return Quality.HDBLURAY
         elif checkName(["1080p", "bluray|hddvd", "x264"], all):
@@ -170,14 +170,13 @@ class Quality:
             return Quality.attemptFitQuality(name)
         else:
             return Quality.UNKNOWN
-        
     @staticmethod
     def attemptFitQuality(name):
         # perform a hierarchical search
         # -> Resolution
         #   -> Source
         #     -> Encoding
-        
+
         bestQuality = Quality.UNKNOWN
         if re.search("1080", name, re.I) :
             bestQuality = Quality.FULLHDTV
@@ -197,7 +196,7 @@ class Quality:
             bestQuality = Quality.SDTV
             if re.search("(dvdrip|bdrip)", name, re.I) :
                 bestQuality = Quality.SDDVD
-        
+
         return bestQuality
 
     @staticmethod

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -777,12 +777,13 @@ class ConfigSearch:
     @cherrypy.expose
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
                        sab_apikey=None, sab_category=None, sab_host=None, nzbget_username=None, nzbget_password=None, nzbget_category=None, nzbget_host=None,
-                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, ignore_words=None):
+                       torrent_dir=None, nzb_method=None, usenet_retention=None, search_frequency=None, download_propers=None, best_fit_quality=None, ignore_words=None):
 
         results = []
 
         # Episode Search
         sickbeard.DOWNLOAD_PROPERS = config.checkbox_to_value(download_propers)
+        sickbeard.BEST_FIT_QUALITY = config.checkbox_to_value(best_fit_quality)
 
         config.change_SEARCH_FREQUENCY(search_frequency)
         sickbeard.USENET_RETENTION = config.to_int(usenet_retention, default=500)


### PR DESCRIPTION
After finding several episodes in the logs that appeared to be valid search results (to me) but did not match any of the quality filters I added my own "Best Fit Quality" setting to the general search settings.  It is a fallback if a perfect quality match cannot be found.  The setting defaults to Off, but in practice has improved my search results and I'd prefer finding a "most likely correct" quality to an Unknown and therefore usually discarded quality.

I believe this is an improvement compared to choosing the "Any" quality setting for the show.  I would rather categorize filenames that are pretty close to ideal and download those rather than settle for SDTV or lower quality.

Also: Relatively new to Git and not sure how to undo or ignore the random whitespace changes that appeared.  Git doesn't allow committing whitespace-only changes.  Thanks Git.